### PR TITLE
The value  $ICA_TESTFAILED is used, but not defined.  Added definition for ICA_TESTFAILE...

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/STOR_Big_Disk.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_Big_Disk.sh
@@ -25,6 +25,7 @@
 ICA_TESTRUNNING="TestRunning"
 ICA_TESTCOMPLETED="TestCompleted"
 ICA_TESTABORTED="TestAborted"
+ICA_TESTFAILED="TestFailed"
 CONSTANTS_FILE="constants.sh"
 
 LogMsg()


### PR DESCRIPTION
...D