### PR TITLE
Improved NMI & KVP tests

### DIFF
--- a/WS2012R2/lisa/setupscripts/KVP_ModifyNonExistKeyValue.ps1
+++ b/WS2012R2/lisa/setupscripts/KVP_ModifyNonExistKeyValue.ps1
@@ -191,7 +191,7 @@ if ($job.ErrorCode -ne 0)
 
     if ($job.ErrorCode -eq 32773)
     {  
-        Write-Output "Error: Key = '${key} ,Non-existing key cannot be modified Error Code-' $($Job.ErrorCode) " | Out-File -Append $summaryLog
+        "Error (as expected): Key = '${key} ,Non-existing key cannot be modified Error Code-' $($Job.ErrorCode) "
         return $True
     }
     else

--- a/WS2012R2/lisa/setupscripts/NMI_SendAs_Unprivileged.ps1
+++ b/WS2012R2/lisa/setupscripts/NMI_SendAs_Unprivileged.ps1
@@ -223,6 +223,7 @@ $creds = New-Object -Typename System.Management.Automation.PSCredential -Argumen
 if(!$?)
 {
     Write-Output "Error: Could not created the credential object" | Tee-Object -Append -file $summaryLog
+    DeleteLocalUser
     return $false
 }
 
@@ -238,6 +239,7 @@ While ($job.State -ne "Completed")
     if($job.State -eq "Failed")
     {
         Write-Output "Error: Task job to send the NMI interrupt has failed!" | Tee-Object -Append -file $summaryLog
+        DeleteLocalUser
         return $false
     }
     start-sleep 2


### PR DESCRIPTION
Fixes: NMI_SendAs_Unprivileged didn't remove the user created if the test failed. KVP_ModifyNonExistKeyValue showed an error even with a succes test.