### PR TITLE
Jumbo Frame test set to use Private

### DIFF
--- a/WS2012R2/lisa/xml/NET_Tests.xml
+++ b/WS2012R2/lisa/xml/NET_Tests.xml
@@ -271,8 +271,11 @@
             </setupScript>
             <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testparams>
-                <param>NIC=NetworkAdapter,External,External,001600112200</param>
+                <param>NIC=NetworkAdapter,Private,Private,001600112200</param>
                 <param>TC_COVERED=NET-14</param>
+                <param>STATIC_IP=10.10.10.10</param>
+                <param>STATIC_IP2=10.10.10.20</param>
+                <param>NETMASK=255.255.255.0</param>
                 <param>MAC=001600112233</param>
                 <param>REMOTE_USER=root</param>
             </testparams>


### PR DESCRIPTION
As on some external NICs packets with a size larger than 1500 were not being sent, Jumbo Frames test is reverted to use Private NICs by default.