### PR TITLE
Improved CORE_TymeSync_NTP

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/CORE_TimeSync_NTP.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/CORE_TimeSync_NTP.sh
@@ -344,9 +344,6 @@ else # other distro
     exit 10
 fi
 
-# We wait 10 seconds for the ntp server to sync
-sleep 10
-
 # Now let's see if the VM is in sync with ntp server
 ntpq -p
 if [[ $? -ne 0 ]]; then
@@ -355,26 +352,43 @@ if [[ $? -ne 0 ]]; then
     exit 10
 fi
 
-# loopinfo returns the offset between the ntp server and internal clock
-delay=$(ntpdc -c loopinfo | awk 'NR==1 {print $2}')
+# Variables for while loop. stopTest is the time until the test will run
+isOver=false
+secondsToRun=1800
+stopTest=$(( $(date +%s) + secondsToRun )) 
 
-# Using awk for float comparison
-check=$(echo "$delay $maxdelay" | awk '{if ($1 < $2) print 0; else print 1}')
+while [ $isOver == false ]; do
+    # loopinfo returns the offset between the ntp server and internal clock
+    delay=$(ntpdc -c loopinfo | awk 'NR==1 {print $2}')
 
-# Also check if delay is 0.0
-checkzero=$(echo "$delay $zerodelay" | awk '{if ($1 == $2) print 0; else print 1}')
+    # Using awk for float comparison
+    check=$(echo "$delay $maxdelay" | awk '{if ($1 < $2) print 0; else print 1}')
 
-if [[ $checkzero -eq 0 ]]; then
-    # If delay is 0, something is wrong, so we abort.
-    LogMsg "ERROR: Delay cannot be 0.000; Please check NTP sync manually."
-    UpdateTestState $ICA_TESTABORTED
-    exit 10
-elif [[ 0 -ne $check ]] ; then    
-    LogMsg "ERROR: NTP Time out of sync. Test Failed"
-    LogMsg "NTP offset is $delay seconds."
-    UpdateTestState $ICA_TESTFAILED
-    exit 10
-fi
+    # Also check if delay is 0.0
+    checkzero=$(echo "$delay $zerodelay" | awk '{if ($1 == $2) print 0; else print 1}')
+
+    # Check delay for changes; if it matches the requirements, the loop will end
+    if [[ $checkzero -ne 0 ]] && \
+       [[ $check -eq 0 ]]; then
+        isOver=true
+    fi
+
+    # The loop will run for half an hour if delay doesn't match the requirements
+    if  [[ $(date +%s) -gt $stopTest ]]; then
+        isOver=true
+        if [[ $checkzero -eq 0 ]]; then
+            # If delay is 0, something is wrong, so we abort.
+            LogMsg "ERROR: Delay cannot be 0.000; Please check NTP sync manually."
+            UpdateTestState $ICA_TESTABORTED
+            exit 10
+        elif [[ 0 -ne $check ]] ; then    
+            LogMsg "ERROR: NTP Time out of sync. Test Failed"
+            LogMsg "NTP offset is $delay seconds."
+            UpdateTestState $ICA_TESTFAILED
+            exit 10
+        fi
+    fi
+done
 
 # If we reached this point, time is synced.
 LogMsg "NTP offset is $delay seconds."

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -71,7 +71,7 @@
         <testName>TimeSync_NTP</testName>
         <testScript>CORE_TimeSync_NTP.sh</testScript>
         <files>remote-scripts/ica/CORE_TimeSync_NTP.sh</files>
-        <timeout>600</timeout>
+        <timeout>2000</timeout>
         <onError>Continue</onError>
         <testParams>
             <param>TC_COVERED=CORE-04</param>


### PR DESCRIPTION
NTP test is now waiting up to half an hour before giving a result