### PR TITLE
IPERF: Jenkins automation

### DIFF
--- a/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
+++ b/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
@@ -132,14 +132,12 @@ $ethName = "eth1"
 If (Test-Path $resultFile)
 {
     write-host "Result File Exists! It will be overwritten after 1 second." -foregroundcolor red
-    sleep 1
     Remove-Item $resultFile
 }
 
 If (Test-Path $avgFile)
 {
     write-host "AVERAGE Result File Exists! It will be overwritten after 1 second." -foregroundcolor red
-    sleep 1
     Remove-Item $avgFile
 }
 
@@ -164,7 +162,7 @@ foreach ($conn in $connections)
     #$sarfile =  $logPath + "\" + $conn + "-" + "sar.log"
     $lines = (Get-Content $sarfile)
 
-    $count = $testDuration
+    $count = [int] $testDuration
     $lastGoodOne = 0
     for ($i = 0; $i -lt $lines.Length - 1; $i++)
     {
@@ -174,12 +172,7 @@ foreach ($conn in $connections)
         }
         $line = $lines[$i]
 
-        if ($line -eq $null)
-        {
-            continue
-        }
-        if ($line.trim() -eq "")
-        {
+        IF([string]::IsNullOrWhiteSpace($line)) {
             continue
         }
 

--- a/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
+++ b/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
@@ -1,0 +1,232 @@
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#
+# Check input arguments
+#
+if ($vmName -eq $null)
+{
+    "Error: VM name is null"
+    return $False
+}
+
+if ($hvServer -eq $null)
+{
+    "Error: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "Error: testParams is null"
+    return $False
+}
+
+# Write out test Params
+$testParams
+
+# change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+$params = $testParams.Split(";")
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+
+    switch ($fields[0].Trim())
+    {
+    "IPERF3_TEST_CONNECTION_POOL" { $testConnections = $fields[1].Trim() }
+    "INDIVIDUAL_TEST_DURATION"    { $testDuration  = $fields[1].Trim() }
+    "TEST_RUN_LOG_FOLDER"         { $logFolder    = $fields[1].Trim() }
+    "VM2NAME"                     { $vm2Name    = $fields[1].Trim() }
+    "VM2SERVER"                   { $vm2Server    = $fields[1].Trim() }
+    "TestLogDir"                  { $testDirectory = $fields[1].Trim() }
+    default   {}  # unknown param - just ignore it
+    }
+}
+
+if (-not $testConnections)
+{
+    "Error: test parameter IPERF3_TEST_CONNECTION_POOL was not specified"
+    return $False
+}
+
+if (-not $testDuration)
+{
+    "Error: test parameter INDIVIDUAL_TEST_DURATION was not specified"
+    return $False
+}
+
+if (-not $logFolder)
+{
+    "Error: test parameter TEST_RUN_LOG_FOLDER was not specified"
+    return $False
+}
+
+if (-not $testDirectory)
+{
+    "Error: Could not find Test Results folder"
+    return $False
+}
+
+if (-not $vm2Name)
+{
+    "Warning: vm2Name is missing!"
+}
+
+if (-not $vm2Server)
+{
+    "Warning: The second VMs server is not specified!"
+}
+
+$archive = "${testDirectory}\${vmName}_iPerf3_Panorama_iPerf3_Server_Logs.zip"
+
+$destination = "${testDirectory}\"
+
+
+Add-Type -assembly "system.io.compression.filesystem"
+[io.compression.zipfile]::ExtractToDirectory($archive, $destination)
+
+if (-not $?) {
+    write-host "Error: Could not extract the archive, try to extract it manually. If it doesn't exist, check on $vm2Name VM."
+    return $False
+}
+
+$logPath = "${testDirectory}\root\${logFolder}"
+$resultFile = Join-Path $logPath "sar.log"
+$avgFile = Join-Path $logPath "sar-avg.log"
+$ethName = "eth1"
+
+If (Test-Path $resultFile)
+{
+    write-host "Result File Exists! It will be overwritten after 1 second." -foregroundcolor red
+    sleep 1
+    Remove-Item $resultFile
+}
+
+If (Test-Path $avgFile)
+{
+    write-host "AVERAGE Result File Exists! It will be overwritten after 1 second." -foregroundcolor red
+    sleep 1
+    Remove-Item $avgFile
+}
+
+write-host "Parse logs from $logPath ..."
+
+$connections = $testConnections.Substring(1,$testConnections.Length-2)
+
+$connections = $connections.Split(" ")
+
+write-host " "
+write-host "------------------------------------"
+write-host "| Connections     Bandwidth (Gb/s) |"
+write-host "------------------------------------"
+
+foreach ($conn in $connections)
+{
+    #$gtotal is used to calculate average throughput
+    $gtotal=0
+    $gAvg=0
+
+    $sarfile =  $logPath + "\" + $conn + "\" + "sar.log"
+    #$sarfile =  $logPath + "\" + $conn + "-" + "sar.log"
+    $lines = (Get-Content $sarfile)
+
+    $count = $testDuration
+    $lastGoodOne = 0
+    for ($i = 0; $i -lt $lines.Length - 1; $i++)
+    {
+        if ($count -eq 0)
+        {
+            break
+        }
+        $line = $lines[$i]
+
+        if ($line -eq $null)
+        {
+            continue
+        }
+        if ($line.trim() -eq "")
+        {
+            continue
+        }
+
+        if ($line.Contains($ethName) -eq $false)
+        {
+            continue
+        }
+        else
+        {
+            $line = $line -Replace '\s+', ' '
+            #write-host $line.Split(" ")
+            $netThrEth0 = $line.Split(" ")[4]
+            if (($netThrEth0 -as [double]) -gt 100000)
+            {
+                echo $netThrEth0 >> $resultFile
+                $lastGoodOne = $netThrEth0
+                $gtotal = $gtotal + [double]$netThrEth0
+                $count = $count -1
+            }
+        }
+    }
+
+    if ($testDuration-$count -gt 0) {
+       $gAvg = $gtotal * 8 / 1000 / 1000 / ($testDuration - $count)
+    }
+
+    if ($count -gt 0)
+    {
+        for ($x =$count; $x -ne 0; $x--)
+        {
+                echo $lastGoodOne >> $resultFile
+        }
+    }
+    #echo $conn + " "+ $gAvg >> $avgFile
+    $conn + " "+ $gAvg | out-file $avgFile -append
+    write-host " $conn           $gAvg"
+}
+
+
+write-host "Average bandwith speeds were parsed succesfully and can be found in $testDirectory"
+
+"Stopping $vm2Name"
+Stop-VM -Name $vm2Name -ComputerName $vm2Server -force
+
+if (-not $?)
+{
+    "Warning: Unable to shut down $vm2Name"
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/NET_SendIPtoVM.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_SendIPtoVM.ps1
@@ -165,6 +165,7 @@ foreach ($p in $params)
     "sshKey"  { $sshKey  = $fields[1].Trim() }
     "ipv4"    { $ipv4    = $fields[1].Trim() }
     "MAC"     { $vm2MacAddress = $fields[1].Trim() }
+    "VM2SERVER"    { $vm2Server    = $fields[1].Trim() }
     default   {}  # unknown param - just ignore it
     }
 }
@@ -194,6 +195,14 @@ if (-not $vm2MacAddress)
     return $False
 }
 
+Write-Host "$vm2Server is the iPerf server's host"
+
+if (-not $vm2Server)
+{
+    $vm2Server = "localhost"
+    "vm2Server was set as localhost"
+}
+
 $ipv4 = GetIPv4 $vmName $hvServer
 
 if (-not $ipv4) {
@@ -201,7 +210,7 @@ if (-not $ipv4) {
     return $False
 }
 
-$tempipv4VM2 = Get-VMNetworkAdapter -VMName $vm2Name | Where-object {$_.MacAddress -like "$vm2MacAddress"} | Select -Expand IPAddresses
+$tempipv4VM2 = Get-VMNetworkAdapter -VMName $vm2Name -ComputerName $vm2Server | Where-object {$_.MacAddress -like "$vm2MacAddress"} | Select -Expand IPAddresses
 $testipv4VM2 = $tempipv4VM2[0]
 
 if (-not $testipv4VM2) {

--- a/WS2012R2/lisa/xml/Perf_IPerf_IPv4_Panorama.xml
+++ b/WS2012R2/lisa/xml/Perf_IPerf_IPv4_Panorama.xml
@@ -21,8 +21,11 @@
 
 <config>
     <global>
-        <logfileRootDir>TestResults</logfileRootDir>
+        <logfileRootDir>\\redmond\wsscfs\OSTC\LIS\TestLog\Linux-Next_iPerf</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <LisaInitScript>
+            <file>.\setupScripts\CreateVMs.ps1</file>
+        </LisaInitScript>
         <email>
             <recipients>
                 <to>myself@mycompany.com</to>
@@ -31,11 +34,8 @@
             <subject>LIS Performance Test Results</subject>
             <smtpServer>mysmtphost.mycompany.com</smtpServer>
         </email>
+        <imageStoreDir>\\redmond\wsscfs\OSTC\LIS\VHDStore\test</imageStoreDir>
        <!-- Optional testParams go here -->
-        <testParams>
-            <param>vmCpuNumber=12</param>
-            <param>vmMemory=8GB</param>
-        </testParams>
     </global>
 
     <testSuites>
@@ -50,27 +50,35 @@
     <testCases>
          <test>
             <testName>iPerf3_Panorama</testName>
+            <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testScript>perf_iperf_panorama_client.sh</testScript>
             <files>remote-scripts/ica/perf_iperf_panorama_client.sh,remote-scripts/ica/perf_iperf_panorama_server.sh,remote-scripts/ica/perf_run_parallelcommands.sh,remote-scripts/ica/perf_capturer.sh,remote-scripts/ica/utils.sh</files>
             <files>Tools/iperf-3.0.5.tar.gz</files>
+            <postTest>Infrastructure\Analyze-IperfResultsThroughputFromLinuxSar.ps1</postTest>
             <testParams>
+                <param>TC_COVERED=iperf_upstream</param>
                 <param>IPERF_PACKAGE=iperf-3.0.5.tar.gz</param>
+                <param>STATIC_IP=10.10.10.20</param>
+                <param>NETMASK=255.255.255.0</param>
                 <param>SERVER_OS_USERNAME=root</param>
-                <param>IPERF3_SERVER_IP=192.168.1.100</param>
+                <param>MAC=001600112233</param>
+                <param>VM2NAME=IPERF-Server</param>
+                <param>VM2SERVER=LIS-PERF05</param>
+                <param>IPERF3_SERVER_IP=10.10.10.10</param>
                 <param>INDIVIDUAL_TEST_DURATION=60</param>
                 <param>CONNECTIONS_PER_IPERF3=4</param>
                 <param>TEST_SIGNAL_FILE=iperf3.test.signal</param>
                 <param>TEST_RUN_LOG_FOLDER=iperf3-test-logs</param>
-                <param>SSH_PRIVATE_KEY=sshKey</param>
+                <param>SSH_PRIVATE_KEY=rhel5_id_rsa</param>
                 <param>IPERF3_TEST_CONNECTION_POOL=(1 2 4 8 16 32 64 128 256 512 1024 2000 3000 6000)</param>
             </testParams>
             <uploadFiles>
                 <file>iPerf3_Client_Logs.zip</file>
                 <file>iPerf3_Server_Logs.zip</file>
                 <file>iPerf3_Panorama_ServerSideScript.log</file>
-		<file>iPerf3_Panorama.log</file>
+                <file>iPerf3_Panorama.log</file>
             </uploadFiles>
-            <timeout>1200</timeout>
+            <timeout>7200</timeout>
             <OnError>Continue</OnError>
          </test>
     </testCases>
@@ -78,22 +86,36 @@
     <VMs>
         <vm>
             <role>SUT1</role>
-            <hvServer>LIS-PERF02</hvServer>
-            <vmName>LIS-SLES12-Client</vmName>
+            <hvServer>LIS-PERF06</hvServer>
+            <vmName>IPERF-Client</vmName>
             <os>Linux</os>
             <ipv4></ipv4>
-            <sshKey>id_rsa.ppk</sshKey>
+            <sshKey>rhel5_id_rsa.ppk</sshKey>
             <suite>iPerf3</suite>
-            <preStartConfig>setupScripts/Config-VM.ps1</preStartConfig>
+            <hardware>
+               <create>true</create>
+               <numCPUs>12</numCPUs>
+               <memSize>8192</memSize>
+               <disableDiff>True</disableDiff>
+               <nic>VMBus,Vm.Enterprise#1</nic>
+               <nic>VMBus,Vm.Private40G#1,001600112200</nic>
+            </hardware>
         </vm>
         <vm>
             <role>NonSUT1</role>
-            <hvServer>LIS-PERF01</hvServer>
-            <vmName>LIS-SLES12-Server</vmName>
+            <hvServer>LIS-PERF05</hvServer>
+            <vmName>IPERF-Server</vmName>
             <os>Linux</os>
             <ipv4></ipv4>
-            <sshKey>id_rsa.ppk</sshKey>
-            <preStartConfig>setupScripts/Config-VM.ps1</preStartConfig>
+            <sshKey>rhel5_id_rsa.ppk</sshKey>
+            <hardware>
+               <create>true</create>
+               <numCPUs>12</numCPUs>
+               <memSize>8192</memSize>
+               <disableDiff>True</disableDiff>
+               <nic>VMBus,Vm.Enterprise#1,001600112233</nic>
+               <nic>VMBus,Vm.Private40G#1,001600112201</nic>
+            </hardware>
         </vm>
     </VMs>
 </config>


### PR DESCRIPTION
Created a Jenkins job which fully automates the IPERF panorama test case.
This job does the following:

    - Copies the latest vhdx from a specified network path to all the test servers.
    - Creates the VMs automatically with the given vhdx.
    - Now the test NICs are added and configured automatically.
    - Runs the Iperf tests.
    - Gathers the logs and creates a log with the average bandwidth speeds in the results folder.

For this:
    - changed the NET_SendIPtoVM.ps1 script to be able to retrieve IP addresses from any given remote server
    - changes to perf_iperf_panorama_client.sh
    - added Analyze-IperfResultsThroughputFromLinuxSar.ps1 to repository to parse sar results at the end of the tests.