### PR TITLE
IPERF: fix sar results parser

### DIFF
--- a/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
+++ b/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
@@ -124,10 +124,25 @@ if (-not $?) {
     return $False
 }
 
+#Get Test Interface and Distribution
+$testInterface = Get-Content *ServerSideScript.log | where { $_ -match "TestInterface" }
+$testInterface = $testInterface.Substring(15)
+
+$distro = Get-Content *_summary.log | where { $_ -match "Distribution" }
+$distro = $testInterface.Substring(14)
+
+#set number of columns in sar log file according to distribution
+if ($distro -like "suse_12") {
+    [int] $columns = 4
+}
+else {
+    [int] $columns = 5
+}
+
 $logPath = "${testDirectory}\root\${logFolder}"
 $resultFile = Join-Path $logPath "sar.log"
 $avgFile = Join-Path $logPath "sar-avg.log"
-$ethName = "eth1"
+$ethName = "$testInterface"
 
 If (Test-Path $resultFile)
 {
@@ -184,7 +199,7 @@ foreach ($conn in $connections)
         {
             $line = $line -Replace '\s+', ' '
             #write-host $line.Split(" ")
-            $netThrEth0 = $line.Split(" ")[4]
+            $netThrEth0 = $line.Split(" ")[$columns]
             if (($netThrEth0 -as [double]) -gt 100000)
             {
                 echo $netThrEth0 >> $resultFile

--- a/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
+++ b/WS2012R2/lisa/Infrastructure/Analyze-IperfResultsThroughputFromLinuxSar.ps1
@@ -125,10 +125,10 @@ if (-not $?) {
 }
 
 #Get Test Interface and Distribution
-$testInterface = Get-Content *ServerSideScript.log | where { $_ -match "TestInterface" }
+$testInterface = Get-Content ${testDirectory}\*ServerSideScript.log | where { $_ -match "TestInterface" }
 $testInterface = $testInterface.Substring(15)
 
-$distro = Get-Content *_summary.log | where { $_ -match "Distribution" }
+$distro = Get-Content ${testDirectory}\*_summary.log | where { $_ -match "Distribution" }
 $distro = $testInterface.Substring(14)
 
 #set number of columns in sar log file according to distribution

--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_client.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_client.sh
@@ -431,6 +431,16 @@ redhat_7)
         # Install gcc which is required to build iperf3
         zypper --non-interactive install gcc
 
+        #Check if sysstat package is installed
+        command -v sar
+        if [ $? -ne 0 ]; then
+            msg="Error: Sysstat (sar) is not installed. Please install it before running the performance tests!"
+            LogMsg "${msg}"
+            echo "${msg}" >> ~/summary.log
+            UpdateTestState $ICA_TESTFAILED
+            exit 82
+        fi
+
         LogMsg "Check iptables status on SLES"
         service SuSEfirewall2 status
         if [ $? -ne 3 ]; then


### PR DESCRIPTION
- fixed distribution specific option in sar log parser
- in sar log parser we get the test interface on which Iperf was run
- on SLES we check the existence of sysstat before running the tests