### PR TITLE
DM_Tests small fixes

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -276,7 +276,7 @@ $vm2Name = $null
 [int]$tries = 0
 
 # default number of tries
-Set-Variable defaultTries -option Constant -value 3
+Set-Variable defaultTries -option Constant -value 10
 
 # change working directory to root dir
 $testParams -match "RootDir=([^;]+)"

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -311,7 +311,7 @@
 			</testParams>
 			<testScript>setupScripts\DM_SaveRestore.ps1</testScript>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
-			<timeout>800</timeout>
+			<timeout>1800</timeout>
 		</test>
 
 		<test>
@@ -329,8 +329,8 @@
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=512MB</param>
-				<param>maxMem=75%</param>
-				<param>startupMem=75%</param>
+				<param>maxMem=80%</param>
+				<param>startupMem=80%</param>
 				<param>memWeight=100</param>
 				<param>staticMem=512MB</param>
 			</testParams>


### PR DESCRIPTION
1. Change timeout value on SaveRestore
2. Change startup memory on CleanShutdown from 75% to 80%
3. Increase number of tries for starting VM3 from 3 to 10 in
StartupHighCompete