### PR TITLE
Added remote run capability to FCOPY Tests

### DIFF
--- a/WS2012R2/lisa/xml/FCOPY_Tests.xml
+++ b/WS2012R2/lisa/xml/FCOPY_Tests.xml
@@ -99,7 +99,7 @@
 			<testParams>
 				<param>TC_COVERED=FCopy-05</param>
 			</testParams>
-			<noReboot>True</noReboot>
+			<noReboot>False</noReboot>
 		</test>
 
 		<test>


### PR DESCRIPTION
1. All FCOPY are now working on remote servers. This is done by
creating/copying the testfile on the server specified in lisa.
2. Small fix in XML file. NoReboot flag on FCOPY_non_ascii changed
because it prevented the next test to run properly