### PR TITLE
Add the branch of RedHat version

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/provisionLinuxForLisa.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/provisionLinuxForLisa.sh
@@ -121,7 +121,7 @@ LinuxRelease()
             echo "CENTOS";; 
         *SUSE*) 
             echo "SLES";; 
-        Red*Hat*) 
+        *Red*Hat*) 
             echo "RHEL";; 
         Debian*) 
             echo "DEBIAN";; 

--- a/WS2012R2/lisa/setupscripts/ProvisionSshKeys.ps1
+++ b/WS2012R2/lisa/setupscripts/ProvisionSshKeys.ps1
@@ -119,7 +119,7 @@ function GetLinuxDistro([String] $ipv4, [String] $password)
         return $null
     }
 
-    $distro = bin\plink -pw "${password}" root@${ipv4} "grep -hs 'Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux\|Oracle' /etc/{issue,*release,*version}"
+    $distro = bin\plink -pw "${password}" root@${ipv4} "grep -hs 'Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux Server [0-9]\.[0-9]\|Oracle' /etc/{issue,*release,*version}"
     if (-not $distro)
     {
         return $null
@@ -173,8 +173,7 @@ function InstallPackagesRequiredByLisa([String] $ipv4, [String] $password)
     switch -regex ($distro)
     {
         CentOS   { $cmd = "yum -y install dos2unix at"                        }
-        RedHat6   { $cmd = "yum -y install dos2unix at"                        }
-        RedHat7   { $cmd = "yum -y install dos2unix at"                        }
+        RedHat   { $cmd = "yum -y install dos2unix at"                        }
         Oracle   { $cmd = "yum -y install dos2unix at"                        }
         SUSE     { $cmd = "zypper --non-interactive install dos2unix at"      }
         Ubuntu   { $cmd = "apt-get -y install dos2unix at"                    }

--- a/WS2012R2/lisa/setupscripts/ProvisionSshKeys.ps1
+++ b/WS2012R2/lisa/setupscripts/ProvisionSshKeys.ps1
@@ -119,7 +119,7 @@ function GetLinuxDistro([String] $ipv4, [String] $password)
         return $null
     }
 
-    $distro = bin\plink -pw "${password}" root@${ipv4} "grep -ihs 'Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux\|Oracle' /etc/{issue,*release,*version}"
+    $distro = bin\plink -pw "${password}" root@${ipv4} "grep -hs 'Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux\|Oracle' /etc/{issue,*release,*version}"
     if (-not $distro)
     {
         return $null

--- a/WS2012R2/lisa/setupscripts/ProvisionSshKeys.ps1
+++ b/WS2012R2/lisa/setupscripts/ProvisionSshKeys.ps1
@@ -144,7 +144,10 @@ function GetLinuxDistro([String] $ipv4, [String] $password)
         "*Debian*"  {  $LinuxDistro = "Debian"
                        break
                     }
-        "*Red Hat*" {  $linuxDistro = "RedHat"
+        "*Red Hat Enterprise Linux Server 7.*" {  $linuxDistro = "RedHat7"
+                       break
+                    }
+        "*Red Hat Enterprise Linux Server 6.*" {  $linuxDistro = "RedHat6"
                        break
                     }
         "*Oracle*" {  $linuxDistro = "Oracle"
@@ -170,7 +173,8 @@ function InstallPackagesRequiredByLisa([String] $ipv4, [String] $password)
     switch -regex ($distro)
     {
         CentOS   { $cmd = "yum -y install dos2unix at"                        }
-        RedHat   { $cmd = "yum -y install dos2unix at"                        }
+        RedHat6   { $cmd = "yum -y install dos2unix at"                        }
+        RedHat7   { $cmd = "yum -y install dos2unix at"                        }
         Oracle   { $cmd = "yum -y install dos2unix at"                        }
         SUSE     { $cmd = "zypper --non-interactive install dos2unix at"      }
         Ubuntu   { $cmd = "apt-get -y install dos2unix at"                    }
@@ -187,6 +191,7 @@ function InstallPackagesRequiredByLisa([String] $ipv4, [String] $password)
     {
         Ubuntu { $cmd = "update-rc.d atd enable && update-rc.d atd enable" }
         Oracle { $cmd = "chkconfig atd on" }
+        RedHat6 { $cmd = "chkconfig atd on" }
         default { $cmd = "systemctl enable atd.service" }
     }
 


### PR DESCRIPTION
1. There are different versions in Redhat  for example: RHEL6 and RHEL7. however, different commands are suitable for different versions.  so split them in file. 
2. the "Red*Hat*" can't match the result. 
