### PR TITLE
FCOPY path fix

### DIFF
--- a/WS2012R2/lisa/setupscripts/FCOPY_basic.ps1
+++ b/WS2012R2/lisa/setupscripts/FCOPY_basic.ps1
@@ -198,6 +198,12 @@ if (-not $gsi.Enabled) {
 
 # Get VHD path of tested server; file will be copied there
 $vhd_path = Get-VMHost -ComputerName $hvServer | Select -ExpandProperty VirtualHardDiskPath
+
+# Fix path format if it's broken
+if ($vhd_path.Substring($vhd_path.Length - 1, 1) -ne "\"){
+    $vhd_path = $vhd_path + "\"
+}
+
 $vhd_path_formatted = $vhd_path.Replace(':','$')
 
 # Define the file-name to use with the current time-stamp

--- a/WS2012R2/lisa/setupscripts/FCOPY_file_exists.ps1
+++ b/WS2012R2/lisa/setupscripts/FCOPY_file_exists.ps1
@@ -200,6 +200,12 @@ if (-not $gsi.Enabled) {
 
 # Get VHD path of tested server; file will be copied there
 $vhd_path = Get-VMHost -ComputerName $hvServer | Select -ExpandProperty VirtualHardDiskPath
+
+# Fix path format if it's broken
+if ($vhd_path.Substring($vhd_path.Length - 1, 1) -ne "\"){
+    $vhd_path = $vhd_path + "\"
+}
+
 $vhd_path_formatted = $vhd_path.Replace(':','$')
 
 # Define the file-name to use with the current time-stamp

--- a/WS2012R2/lisa/setupscripts/FCOPY_large_file.ps1
+++ b/WS2012R2/lisa/setupscripts/FCOPY_large_file.ps1
@@ -243,6 +243,12 @@ if (-not $gsi.Enabled) {
 
 # Get VHD path of tested server; file will be copied there
 $vhd_path = Get-VMHost -ComputerName $hvServer | Select -ExpandProperty VirtualHardDiskPath
+
+# Fix path format if it's broken
+if ($vhd_path.Substring($vhd_path.Length - 1, 1) -ne "\"){
+    $vhd_path = $vhd_path + "\"
+}
+
 $vhd_path_formatted = $vhd_path.Replace(':','$')
 
 # Define the file-name to use with the current time-stamp

--- a/WS2012R2/lisa/setupscripts/FCOPY_non_ascii.ps1
+++ b/WS2012R2/lisa/setupscripts/FCOPY_non_ascii.ps1
@@ -418,13 +418,20 @@ else {
         Write-Output "MD5 checksum on Hyper-V: $localChksum"
     }
 
-    # Copy file to vhd folder
+    # Get vhd folder
     $vhd_path = Get-VMHost -ComputerName $hvServer | Select -ExpandProperty VirtualHardDiskPath
+
+    # Fix path format if it's broken
+    if ($vhd_path.Substring($vhd_path.Length - 1, 1) -ne "\"){
+        $vhd_path = $vhd_path + "\"
+    }
+
     $vhd_path_formatted = $vhd_path.Replace(':','$')
     
     $filePath = $vhd_path + $testfile
     $file_path_formatted = $vhd_path_formatted + $testfile
 
+    # Copy file to vhd folder
     Copy-Item -Path .\$testfile -Destination \\$hvServer\$vhd_path_formatted
 }
 

--- a/WS2012R2/lisa/setupscripts/FCOPY_overwrite.ps1
+++ b/WS2012R2/lisa/setupscripts/FCOPY_overwrite.ps1
@@ -319,6 +319,12 @@ $testfile = "testfile-$(get-date -uformat '%H-%M-%S-%Y-%m-%d').file"
 # Initial file copy, which must be successful. Create a text file with 20 characters, and then copy it.
 #
 $vhd_path = Get-VMHost -ComputerName $hvServer | Select -ExpandProperty VirtualHardDiskPath
+
+# Fix path format if it's broken
+if ($vhd_path.Substring($vhd_path.Length - 1, 1) -ne "\"){
+    $vhd_path = $vhd_path + "\"
+}
+
 $vhd_path_formatted = $vhd_path.Replace(':','$')
 
 $filePath = $vhd_path + $testfile

--- a/WS2012R2/lisa/setupscripts/fcopy_repeated_delete.ps1
+++ b/WS2012R2/lisa/setupscripts/fcopy_repeated_delete.ps1
@@ -293,6 +293,12 @@ if (-not $gsi.Enabled) {
 
 # Get VHD path of tested server; file will be copied there
 $vhd_path = Get-VMHost -ComputerName $hvServer | Select -ExpandProperty VirtualHardDiskPath
+
+# Fix path format if it's broken
+if ($vhd_path.Substring($vhd_path.Length - 1, 1) -ne "\"){
+    $vhd_path = $vhd_path + "\"
+}
+
 $vhd_path_formatted = $vhd_path.Replace(':','$')
 
 # Define the file-name to use with the current time-stamp


### PR DESCRIPTION
On some WS the retrieved VHD path was missing "\" in the end.  Added a
check for that and a fix if necessary