### PR TITLE
NET/PERF: Added IPV6 handling

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_server.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_server.sh
@@ -240,6 +240,15 @@ echo "test signal file			= ${TEST_SIGNAL_FILE}"
 echo "test run log folder		= ${TEST_RUN_LOG_FOLDER}"
 
 #
+# Check for internet protocol version
+#
+if [[ $IPERF3_SERVER_IP == *"::"* ]]; then
+    ipVersion="-6"
+else
+    ipVersion="-4"
+fi
+
+#
 # Extract the files from the IPerf tar package
 #
 tar -xzf ./${IPERF_PACKAGE}
@@ -275,7 +284,7 @@ case "$DISTRO" in
 debian*|ubuntu*)
     LogMsg "Updating apt repositories"
     apt-get update
-    
+
     LogMsg "Installing sar on Ubuntu"
     apt-get install sysstat -y
     if [ $? -ne 0 ]; then
@@ -507,7 +516,7 @@ while true; do
 
         for ((i=8001; i<=$number_of_iperf_instances; i++))
         do
-            /root/${rootDir}/src/iperf3 -s -D -4 -p $i
+            /root/${rootDir}/src/iperf3 -s -D $ipVersion -p $i
         done
         x=$(ps -aux | grep iperf | wc -l)
         echo "ps -aux | grep iperf | wc -l: $x"


### PR DESCRIPTION
- NET: if static IP is ipv6, the interface file will be created accordingly to support it
- PERF: Iperf Panorama can now be run with ipv4 or ipv6 address

Tested on RHEL 6, RHEL 7 and Ubuntu 15.10

Will be added:
- support for SLES
- ipv6 validation function