### PR TITLE
NET: Added IPV6 support

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_client.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_client.sh
@@ -292,8 +292,11 @@ echo "iperf3 test connection pool   = ${IPERF3_TEST_CONNECTION_POOL}"
 #
 # Check for internet protocol version
 #
-if [[ $STATIC_IP == *"::"* ]]; then
-    if [[ $IPERF3_SERVER_IP == *"::"* ]]; then
+
+CheckIPV6 "$STATIC_IP"
+if [[ $? -eq 0 ]]; then
+    CheckIPV6 "$IPERF3_SERVER_IP"
+    if [[ $? -eq 0 ]]; then
         ipVersion="-6"
     else
         msg="Error: Not both test IPs are IPV6"

--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_server.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_server.sh
@@ -240,6 +240,15 @@ echo "test signal file			= ${TEST_SIGNAL_FILE}"
 echo "test run log folder		= ${TEST_RUN_LOG_FOLDER}"
 
 #
+# Check for internet protocol version
+#
+if [[ $IPERF3_SERVER_IP == *"::"* ]]; then
+    ipVersion="-6"
+else
+    ipVersion="-4"
+fi
+
+#
 # Extract the files from the IPerf tar package
 #
 tar -xzf ./${IPERF_PACKAGE}
@@ -275,7 +284,7 @@ case "$DISTRO" in
 debian*|ubuntu*)
     LogMsg "Updating apt repositories"
     apt-get update
-    
+
     LogMsg "Installing sar on Ubuntu"
     apt-get install sysstat -y
     if [ $? -ne 0 ]; then
@@ -507,7 +516,7 @@ while true; do
 
         for ((i=8001; i<=$number_of_iperf_instances; i++))
         do
-            /root/${rootDir}/src/iperf3 -s -D -4 -p $i
+            /root/${rootDir}/src/iperf3 -s -D $ipVersion -p $i
         done
         x=$(ps -aux | grep iperf | wc -l)
         echo "ps -aux | grep iperf | wc -l: $x"

--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_server.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_panorama_server.sh
@@ -242,7 +242,8 @@ echo "test run log folder		= ${TEST_RUN_LOG_FOLDER}"
 #
 # Check for internet protocol version
 #
-if [[ $IPERF3_SERVER_IP == *"::"* ]]; then
+CheckIPV6 "$IPERF3_SERVER_IP"
+if [[ $? -eq 0 ]]; then
     ipVersion="-6"
 else
     ipVersion="-4"

--- a/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_client.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_client.sh
@@ -233,6 +233,23 @@ echo "iPerf server ip           = ${STATIC_IP2}"
 echo "iPerf server test interface ip        = ${IPERF3_SERVER_IP}"
 echo "user name on server       = ${SERVER_OS_USERNAME}"
 
+#
+# Check for internet protocol version
+#
+if [[ $STATIC_IP == *":"* ]]; then
+    if [[ $IPERF3_SERVER_IP == *":"* ]]; then
+        ipVersion="-6"
+    else
+        msg="Error: Not both test IPs are IPV6"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+        UpdateTestState $ICA_TESTFAILED
+        exit 60
+    fi
+else
+    ipVersion=$null
+fi
+
 git clone https://github.com/Microsoft/ntttcp-for-linux.git
 
 #
@@ -501,7 +518,7 @@ fi
 #
 LogMsg "Starting ntttcp in client mode"
 
-ntttcp -s${IPERF3_SERVER_IP} > ntttcp-for-linux.log 2>&1
+ntttcp -s${IPERF3_SERVER_IP} ${ipVersion} > ntttcp-for-linux.log 2>&1
 if [ $? -ne 0 ]; then
     msg="Error: Unable to start ntttcp client scripts on the client machine"
     LogMsg "${msg}"

--- a/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_client.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_client.sh
@@ -236,8 +236,10 @@ echo "user name on server       = ${SERVER_OS_USERNAME}"
 #
 # Check for internet protocol version
 #
-if [[ $STATIC_IP == *":"* ]]; then
-    if [[ $IPERF3_SERVER_IP == *":"* ]]; then
+CheckIPV6 "$STATIC_IP"
+if [[ $? -eq 0 ]]; then
+    CheckIPV6 "$IPERF3_SERVER_IP"
+    if [[ $? -eq 0 ]]; then
         ipVersion="-6"
     else
         msg="Error: Not both test IPs are IPV6"

--- a/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_server.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_server.sh
@@ -193,7 +193,8 @@ LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_IN
 #
 # Check for internet protocol version
 #
-if [[ $IPERF3_SERVER_IP == *":"* ]]; then
+CheckIPV6 "$IPERF3_SERVER_IP"
+if [[ $? -eq 0 ]]; then
     ipVersion="-6"
 else
     ipVersion=$null

--- a/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_server.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_server.sh
@@ -190,6 +190,15 @@ done
 
 LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
 
+#
+# Check for internet protocol version
+#
+if [[ $IPERF3_SERVER_IP == *":"* ]]; then
+    ipVersion="-6"
+else
+    ipVersion=$null
+fi
+
 git clone https://github.com/Microsoft/ntttcp-for-linux.git
 
 #
@@ -403,7 +412,7 @@ LogMsg "Starting ntttcp in server mode"
 UpdateTestState $ICA_IPERF3RUNNING
 LogMsg "ntttcp server instances are now ready to run"
 
-ntttcp –r
+ntttcp –r${IPERF3_SERVER_IP} ${ipVersion}
 if [ $? -ne 0 ]; then
     msg="Error: Unable to start ntttcp server scripts on the target server machine"
     LogMsg "${msg}"

--- a/WS2012R2/lisa/xml/NET_Performance.xml
+++ b/WS2012R2/lisa/xml/NET_Performance.xml
@@ -42,8 +42,10 @@
         <suite>
             <suiteName>net_perf</suiteName>
             <suiteTests>
-                <suiteTest>ntttcp</suiteTest>
                 <suiteTest>iPerf3_Panorama</suiteTest>
+                <suiteTest>ntttcp</suiteTest>
+                <suiteTest>iPerf3_Panorama_ipv6</suiteTest>
+                <suiteTest>ntttcp_ipv6</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -84,6 +86,40 @@
          </test>
 
          <test>
+            <testName>iPerf3_Panorama_ipv6</testName>
+            <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
+            <testScript>perf_iperf_panorama_client.sh</testScript>
+            <files>remote-scripts/ica/perf_iperf_panorama_client.sh,remote-scripts/ica/perf_iperf_panorama_server.sh,remote-scripts/ica/perf_run_parallelcommands.sh,remote-scripts/ica/perf_capturer.sh,remote-scripts/ica/utils.sh</files>
+            <files>Tools/iperf-3.1.1.tar.gz</files>
+            <postTest>Infrastructure\Analyze-IperfResultsThroughputFromLinuxSar.ps1</postTest>
+            <testParams>
+                <param>TC_COVERED=iperf_upstream</param>
+                <param>IPERF_PACKAGE=iperf-3.1.1.tar.gz</param>
+                <param>STATIC_IP=fd00::4:100</param>
+                <param>NETMASK=64</param>
+                <param>SERVER_OS_USERNAME=root</param>
+                <param>MAC=001600112233</param>
+                <param>VM2NAME=IPERF-Server</param>
+                <param>VM2SERVER=LIS-PERF05</param>
+                <param>IPERF3_SERVER_IP=fd00::4:10</param>
+                <param>INDIVIDUAL_TEST_DURATION=60</param>
+                <param>CONNECTIONS_PER_IPERF3=4</param>
+                <param>TEST_SIGNAL_FILE=iperf3.test.signal</param>
+                <param>TEST_RUN_LOG_FOLDER=iperf3-test-logs</param>
+                <param>SSH_PRIVATE_KEY=rhel5_id_rsa</param>
+                <param>IPERF3_TEST_CONNECTION_POOL=(1 2 4 8 16 32 64 128 256 512 1024 2000 3000 6000)</param>
+            </testParams>
+            <uploadFiles>
+                <file>iPerf3_Client_Logs.zip</file>
+                <file>iPerf3_Server_Logs.zip</file>
+                <file>iPerf3_Panorama_ServerSideScript.log</file>
+                <file>iPerf3_Panorama.log</file>
+            </uploadFiles>
+            <timeout>7200</timeout>
+            <OnError>Continue</OnError>
+         </test>
+
+         <test>
             <testName>ntttcp</testName>
             <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testScript>perf_ntttcp_client.sh</testScript>
@@ -97,6 +133,29 @@
                 <param>VM2NAME=IPERF-Server</param>
                 <param>VM2SERVER=LIS-PERF05</param>
                 <param>IPERF3_SERVER_IP=10.10.10.10</param>
+                <param>SSH_PRIVATE_KEY=rhel5_id_rsa</param>
+            </testParams>
+            <uploadFiles>
+                <file>ntttcp-for-linux.log</file>
+            </uploadFiles>
+            <timeout>7200</timeout>
+            <OnError>Continue</OnError>
+         </test>
+
+         <test>
+            <testName>ntttcp_ipv6</testName>
+            <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
+            <testScript>perf_ntttcp_client.sh</testScript>
+            <files>remote-scripts/ica/perf_ntttcp_client.sh,remote-scripts/ica/perf_ntttcp_server.sh,remote-scripts/ica/utils.sh</files>
+            <testParams>
+                <param>TC_COVERED=ntttcp_upstream</param>
+                <param>STATIC_IP=fd00::4:100</param>
+                <param>NETMASK=64</param>
+                <param>SERVER_OS_USERNAME=root</param>
+                <param>MAC=001600112233</param>
+                <param>VM2NAME=IPERF-Server</param>
+                <param>VM2SERVER=LIS-PERF05</param>
+                <param>IPERF3_SERVER_IP=fd00::4:10</param>
                 <param>SSH_PRIVATE_KEY=rhel5_id_rsa</param>
             </testParams>
             <uploadFiles>


### PR DESCRIPTION
NET: if static IP is ipv6, the interface file will be created accordingly to support it
PERF: Iperf Panorama can now be run with ipv4 or ipv6 address

Tested on RHEL 6, RHEL 7, Ubuntu 15.10 and SLES 12 sp1
