### PR TITLE
NET: basic ipv6 tests added

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NET_LEGACY.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_LEGACY.sh
@@ -163,6 +163,17 @@ if [ "${REMOTE_SERVER:-UNDEFINED}" = "UNDEFINED" ]; then
 	SetTestStateAborted
 fi
 
+#
+# Check for internet protocol version
+#
+
+CheckIPV6 "$REMOTE_SERVER"
+if [[ $? -eq 0 ]]; then
+    pingVersion="ping6"
+else
+    pingVersion="ping"
+fi
+
 # set gateway parameter
 if [ "${GATEWAY:-UNDEFINED}" = "UNDEFINED" ]; then
     if [ "${networkType[2]}" = "External" ]; then
@@ -418,33 +429,11 @@ while [ $__synth_iterator -lt ${#SYNTH_NET_INTERFACES[@]} ]; do
 		UpdateSummary "Trying to ping $REMOTE_SERVER from synthetic interface ${SYNTH_NET_INTERFACES[$__synth_iterator]}"
 
 		# ping the remote host using an easily distinguishable pattern 0xcafed00d`null`syn`null`dhcp`null`
-		ping -I "${SYNTH_NET_INTERFACES[$__synth_iterator]}" -c 10 -p "cafed00d0073796e006468637000" "$REMOTE_SERVER" >/dev/null 2>&1
+		"$pingVersion" -I "${SYNTH_NET_INTERFACES[$__synth_iterator]}" -c 10 -p "cafed00d0073796e006468637000" "$REMOTE_SERVER" >/dev/null 2>&1
 		if [ 0 -eq $? ]; then
 			# ping worked! Do not test any other interface
 			LogMsg "Successfully pinged $REMOTE_SERVER through synthetic ${SYNTH_NET_INTERFACES[$__synth_iterator]} (dhcp)."
 			UpdateSummary "Successfully pinged $REMOTE_SERVER through synthetic ${SYNTH_NET_INTERFACES[$__synth_iterator]} (dhcp)."
-			if [ "$Test_IPv6" != false ] && [ "$Test_IPv6" = "external" ] ; then
-
-				if [ "${PING_SUCC_IPv6:-UNDEFINED}" = "UNDEFINED" ]; then
-				    msg="The test parameter PING_SUCC_IPv6 is not defined in constants file"
-				    LogMsg "$msg"
-					UpdateSummary "$msg"
-					SetTestStateAborted
-					exit 30
-				fi
-
-				LogMsg "Trying to ping $PING_SUCCIPv6 on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-				ping6 -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10  "$PING_SUCC_IPv6"
-				if [ 0 -ne $? ]; then
-					msg="Failed to ping $PING_SUCC_IPv6 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-					LogMsg "$msg"
-					UpdateSummary "$msg"
-					SetTestStateFailed
-					exit 10
-				fi
-
-				UpdateSummary "Successfully pinged $PING_SUCC_IPv6 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-			fi
 			break
 		else
 			LogMsg "Unable to ping $REMOTE_SERVER through synthetic ${SYNTH_NET_INTERFACES[$__synth_iterator]}"
@@ -484,7 +473,7 @@ if [ ${#SYNTH_NET_INTERFACES[@]} -eq $__synth_iterator ]; then
 			LogMsg "Trying to ping $REMOTE_SERVER"
 			UpdateSummary "Trying to ping $REMOTE_SERVER"
 			# ping the remote host using an easily distinguishable pattern 0xcafed00d`null`syn`null`static`null`
-			ping -I "${SYNTH_NET_INTERFACES[$__synth_iterator]}" -c 10 -p "cafed00d0073796e0073746174696300" "$REMOTE_SERVER" >/dev/null 2>&1
+			"$pingVersion" -I "${SYNTH_NET_INTERFACES[$__synth_iterator]}" -c 10 -p "cafed00d0073796e0073746174696300" "$REMOTE_SERVER" >/dev/null 2>&1
 			if [ 0 -eq $? ]; then
 				# ping worked! Remove working element from __invalid_positions list
 				LogMsg "Successfully pinged $REMOTE_SERVER through synthetic ${SYNTH_NET_INTERFACES[$__synth_iterator]} (static)."
@@ -528,33 +517,11 @@ while [ $__legacy_iterator -lt ${#LEGACY_NET_INTERFACES[@]} ]; do
 		UpdateSummary "Trying to ping $REMOTE_SERVER from legacy interface ${LEGACY_NET_INTERFACES[$__legacy_iterator]}"
 
 		# ping the remote host using an easily distinguishable pattern 0xcafed00d`null`leg`null`dhcp`null`
-		ping -I "${LEGACY_NET_INTERFACES[$__legacy_iterator]}" -c 10 -p "cafed00d006c6567006468637000" "$REMOTE_SERVER" >/dev/null 2>&1
+		"$pingVersion" -I "${LEGACY_NET_INTERFACES[$__legacy_iterator]}" -c 10 -p "cafed00d006c6567006468637000" "$REMOTE_SERVER" >/dev/null 2>&1
 		if [ 0 -eq $? ]; then
 			# ping worked!
 			LogMsg "Successfully pinged $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]} (dhcp)."
 			UpdateSummary "Successfully pinged $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]} (dhcp)."
-			if [ "$Test_IPv6" != false ] && [ "$Test_IPv6" = "external" ] ; then
-
-				if [ "${PING_SUCC_IPv6:-UNDEFINED}" = "UNDEFINED" ]; then
-				    msg="The test parameter PING_SUCC_IPv6 is not defined in constants file"
-				    LogMsg "$msg"
-					UpdateSummary "$msg"
-					SetTestStateAborted
-					exit 30
-				fi
-
-				LogMsg "Trying to ping $PING_SUCCIPv6 on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-				ping6 -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10  "$PING_SUCC_IPv6"
-				if [ 0 -ne $? ]; then
-					msg="Failed to ping $PING_SUCC_IPv6 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-					LogMsg "$msg"
-					UpdateSummary "$msg"
-					SetTestStateFailed
-					exit 10
-				fi
-
-				UpdateSummary "Successfully pinged $PING_SUCC_IPv6 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-			fi
 			break
 		else
 			LogMsg "Unable to ping $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]}"
@@ -597,7 +564,7 @@ if [ ${#LEGACY_NET_INTERFACES[@]} -eq $__legacy_iterator ]; then
 			LogMsg "Trying to ping $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]}"
 			UpdateSummary "Trying to ping $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]}"
 			# ping the remote host using an easily distinguishable pattern 0xcafed00d`null`leg`null`static`null`
-			ping -I "${LEGACY_NET_INTERFACES[$__legacy_iterator]}" -c 10 -p "cafed00d006c65670073746174696300" "$REMOTE_SERVER" >/dev/null 2>&1
+			"$pingVersion" -I "${LEGACY_NET_INTERFACES[$__legacy_iterator]}" -c 10 -p "cafed00d006c65670073746174696300" "$REMOTE_SERVER" >/dev/null 2>&1
 			if [ 0 -eq $? ]; then
 				LogMsg "Successfully pinged $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]} (static)."
 				UpdateSummary "Successfully pinged $REMOTE_SERVER through legacy ${LEGACY_NET_INTERFACES[$__legacy_iterator]} (static)."

--- a/WS2012R2/lisa/remote-scripts/ica/NET_PROMISC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_PROMISC.sh
@@ -150,6 +150,17 @@ if [ "${REMOTE_SERVER:-UNDEFINED}" = "UNDEFINED" ]; then
     LogMsg "$msg"
 fi
 
+#
+# Check for internet protocol version
+#
+
+CheckIPV6 "$REMOTE_SERVER"
+if [[ $? -eq 0 ]]; then
+    pingVersion="ping6"
+else
+    pingVersion="ping"
+fi
+
 # set gateway parameter
 if [ "${GATEWAY:-UNDEFINED}" = "UNDEFINED" ]; then
     if [ "${networkType[2]}" = "External" ]; then
@@ -328,6 +339,8 @@ __iterator=0
 
 declare -i __message_count=0
 
+sleep 5
+
 for __iterator in ${!SYNTH_NET_INTERFACES[@]}; do
 
 	LogMsg "Setting ${SYNTH_NET_INTERFACES[$__iterator]} to promisc mode"
@@ -368,7 +381,7 @@ for __iterator in ${!SYNTH_NET_INTERFACES[@]}; do
 	UpdateSummary "Trying to ping $REMOTE_SERVER"
 
 	# ping the remote server
-	ping -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$REMOTE_SERVER"
+	"$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$REMOTE_SERVER"
 
 	if [ 0 -ne $? ]; then
 		msg="Failed to ping $REMOTE_SERVER on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"

--- a/WS2012R2/lisa/remote-scripts/ica/NET_STATIC_MAC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_STATIC_MAC.sh
@@ -192,6 +192,17 @@ if [ "${REMOTE_SERVER:-UNDEFINED}" = "UNDEFINED" ]; then
     LogMsg "$msg"
 fi
 
+#
+# Check for internet protocol version
+#
+
+CheckIPV6 "$REMOTE_SERVER"
+if [[ $? -eq 0 ]]; then
+    pingVersion="ping6"
+else
+    pingVersion="ping"
+fi
+
 # set gateway parameter
 if [ "${GATEWAY:-UNDEFINED}" = "UNDEFINED" ]; then
     if [ "${networkType[2]}" = "External" ]; then
@@ -445,7 +456,7 @@ while [ $__iterator -lt ${#__MAC_NET_INTERFACES[@]} ]; do
 
 done
 
-
+sleep 5
 
 declare -i __iterator
 # ping REMOTE_SERVER if set
@@ -464,7 +475,7 @@ if [ "${REMOTE_SERVER:-UNDEFINED}" != "UNDEFINED" ]; then
 		LogMsg "Trying to ping $REMOTE_SERVER"
 		UpdateSummary "Trying to ping $REMOTE_SERVER"
 		# ping the remote host using an easily distinguishable pattern 0xcafed00d`null`static`null`mac`null`
-		ping -I ${__MAC_NET_INTERFACES[$__iterator]} -c 10 -p "cafed00d00737461746963006d616300" "$REMOTE_SERVER"
+		"$pingVersion" -I ${__MAC_NET_INTERFACES[$__iterator]} -c 10 -p "cafed00d00737461746963006d616300" "$REMOTE_SERVER"
 		if [ 0 -ne $? ]; then
 			msg="Unable to ping $REMOTE_SERVER through interface ${__MAC_NET_INTERFACES[$__iterator]}"
 			LogMsg "$msg"

--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -1269,7 +1269,7 @@ CreateIfupConfigFile()
 				ifup "$__interface_name"
 
 				;;
-			redhat*|centos*)
+			redhat_7)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
@@ -1283,6 +1283,52 @@ CreateIfupConfigFile()
 				cat <<-EOF > "$__file_path"
 					DEVICE="$__interface_name"
 					BOOTPROTO=dhcp
+				EOF
+
+				ifdown "$__interface_name"
+				ifup "$__interface_name"
+
+				;;
+			redhat_6)
+				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
+				if [ ! -d "$(dirname $__file_path)" ]; then
+					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
+					return 3
+				fi
+
+				if [ -e "$__file_path" ]; then
+					LogMsg "CreateIfupConfigFile: Warning will overwrite $__file_path ."
+				fi
+
+				cat <<-EOF > "$__file_path"
+					DEVICE="$__interface_name"
+					BOOTPROTO=dhcp
+					IPV6INIT=yes
+				EOF
+
+				ifdown "$__interface_name"
+				ifup "$__interface_name"
+
+				;;
+			redhat_5)
+				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
+				if [ ! -d "$(dirname $__file_path)" ]; then
+					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
+					return 3
+				fi
+
+				if [ -e "$__file_path" ]; then
+					LogMsg "CreateIfupConfigFile: Warning will overwrite $__file_path ."
+				fi
+
+				cat <<-EOF > "$__file_path"
+					DEVICE="$__interface_name"
+					BOOTPROTO=dhcp
+					IPV6INIT=yes
+				EOF
+
+				cat <<-EOF >> "/etc/sysconfig/network"
+					NETWORKING_IPV6=yes
 				EOF
 
 				ifdown "$__interface_name"
@@ -1392,7 +1438,7 @@ CreateIfupConfigFile()
 				ifdown "$__interface_name"
 				ifup "$__interface_name"
 				;;
-			redhat*|centos*)
+			redhat*)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"

--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -1269,7 +1269,7 @@ CreateIfupConfigFile()
 				ifup "$__interface_name"
 
 				;;
-			redhat_7)
+			redhat_7|centos_7)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
@@ -1289,7 +1289,7 @@ CreateIfupConfigFile()
 				ifup "$__interface_name"
 
 				;;
-			redhat_6)
+			redhat_6|centos_6)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
@@ -1310,7 +1310,7 @@ CreateIfupConfigFile()
 				ifup "$__interface_name"
 
 				;;
-			redhat_5)
+			redhat_5|centos_5)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"
@@ -1438,7 +1438,7 @@ CreateIfupConfigFile()
 				ifdown "$__interface_name"
 				ifup "$__interface_name"
 				;;
-			redhat*)
+			redhat*|centos*)
 				__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface_name"
 				if [ ! -d "$(dirname $__file_path)" ]; then
 					LogMsg "CreateIfupConfigFile: $(dirname $__file_path) does not exist! Something is wrong with the network config!"

--- a/WS2012R2/lisa/xml/NET_Tests_IPv6.xml
+++ b/WS2012R2/lisa/xml/NET_Tests_IPv6.xml
@@ -29,7 +29,7 @@
                 <to>myself@mycompany.com</to>
             </recipients>
             <sender>myself@mycompany.com</sender>
-            <subject>LIS_Network_tests_IPv6_run_on_2012R2</subject>
+            <subject>LIS_Network_tests_run_on_2012R2</subject>
             <smtpServer>mysmtphost.mycompany.com</smtpServer>
         </email>
     </global>
@@ -39,17 +39,24 @@
             <suiteName>Network</suiteName>
             <suiteTests>
                 <suiteTest>External</suiteTest>
-                <suiteTest>InternalNetwork</suiteTest>
-                <suiteTest>GuestOnlyNetwork</suiteTest>
+                <!-- <suiteTest>InternalNetwork</suiteTest> -->
+                <!-- <suiteTest>GuestOnlyNetwork</suiteTest> -->
                 <suiteTest>MultipleNIC</suiteTest>
+                <suiteTest>LegacySyntheticNetwork</suiteTest>
                 <suiteTest>StaticMAC</suiteTest>
-                <suiteTest>ChangeNetTypeInternal</suiteTest>
-                <suiteTest>ChangeNetTypeGuest</suiteTest>
+                <suiteTest>NetworkMode</suiteTest>
+                <!-- <suiteTest>ChangeNetTypeInternal</suiteTest> -->
+                <!-- <suiteTest>ChangeNetTypeGuest</suiteTest> -->
+                <suiteTest>JumboFrame</suiteTest>
+                <suiteTest>OperState</suiteTest>
                 <suiteTest>CopyLargeFile</suiteTest>
+                <suiteTest>CopyFileDifferentMTU</suiteTest>
                 <suiteTest>VlanTagging</suiteTest>
                 <suiteTest>VlanTrunking</suiteTest>
-                <suiteTest>JumboFrame</suiteTest>
-                <suiteTest>LegacySyntheticNetwork</suiteTest>
+                <!-- <suiteTest>Network_Hang_Vxlan</suiteTest> -->
+                <!-- The following tests require a Generation 2 VM -->
+                <suiteTest>HotAddMultiNIC</suiteTest>
+                <suiteTest>BootNoNicHotAddNic</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -60,31 +67,26 @@
             <setupScript>SetupScripts\NET_ADD_NIC_MAC.ps1</setupScript>
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112200</param>
-                <param>TC_COVERED=NET-05</param>
-                <param>Test_IPv6=external</param>
-                <param>PING_SUCC=8.8.8.8</param>
-                <param>PING_FAIL=192.168.2.1</param>
-                <param>PING_FAIL2=10.10.10.5</param>
-                <!-- <param>GATEWAY=192.168.0.1</param> -->
+                <param>TC_COVERED=NET-02</param>
+                <param>PING_SUCC=2001:4860:4860::8888</param>
+                <param>PING_FAIL=fd30:0000:0000</param>
             </testParams>
             <testScript>NET_TEST_NETWORK.sh</testScript>
             <files>remote-scripts/ica/NET_TEST_NETWORK.sh,remote-scripts/ica/utils.sh</files>
             <cleanupScript>SetupScripts\NET_REMOVE_NIC_MAC.ps1</cleanupScript>
             <timeout>800</timeout>
         </test>
-        
+
         <test>
             <testName>InternalNetwork</testName>
             <setupScript>SetupScripts\NET_ADD_NIC_MAC.ps1</setupScript>
             <testParams>
                 <param>NIC=NetworkAdapter,Internal,Internal,001600112200</param>
-                <param>TC_COVERED=NET-04</param>
-                <param>Test_IPv6=internal</param>
+                <param>TC_COVERED=NET-03</param>
                 <param>STATIC_IP=192.168.0.2</param>
                 <param>NETMASK=255.255.255.0</param>
                 <param>PING_SUCC=192.168.0.1</param>
                 <param>PING_FAIL=8.8.8.8</param>
-                <param>PING_FAIL2=192.168.2.2</param>
             </testParams>
             <testScript>NET_TEST_NETWORK.sh</testScript>
             <files>remote-scripts/ica/NET_TEST_NETWORK.sh,remote-scripts/ica/utils.sh</files>
@@ -101,13 +103,10 @@
             </setupScript>
             <testParams>
                 <param>NIC=NetworkAdapter,Private,Private,001600112200</param>
-                <param>Test_IPv6=private</param>
-                <param>TC_COVERED=NET-06</param>
+                <param>TC_COVERED=NET-04</param>
                 <param>STATIC_IP=10.10.10.1</param>
                 <param>STATIC_IP2=10.10.10.2</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>VM2NAME=vm2Name</param>
-                <param>SnapshotName=ICABase</param>
             </testParams>
             <testScript>setupscripts\NET_PRIVATE_NETWORK.ps1</testScript>
             <files>remote-scripts/ica/utils.sh</files>
@@ -124,14 +123,9 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112200</param>
                 <param>NIC=NetworkAdapter,External,External,001600112201</param>
-                <param>TC_COVERED=NET-07</param>
-                <param>Test_IPv6=external</param>
-                <!-- <param>NETMASK=255.255.255.0</param> -->
-                <param>PING_SUCC=8.8.8.8</param>
-                <param>PING_FAIL=192.168.2.1</param>
-                <param>PING_FAIL2=10.10.10.5</param>
-                <!-- <param>GATEWAY=192.168.0.1</param> -->
-                <param>SnapshotName=ICABase</param>
+                <param>TC_COVERED=NET-05</param>
+                <param>PING_SUCC=2001:4860:4860::8888</param>
+                <param>PING_FAIL=fd30:0000:0000</param>
             </testParams>
             <testScript>NET_TEST_NETWORK.sh</testScript>
             <files>remote-scripts/ica/NET_TEST_NETWORK.sh,remote-scripts/ica/utils.sh</files>
@@ -149,13 +143,10 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112200</param>
                 <param>NIC=LegacyNetworkAdapter,External,External,001600112201</param>
-                <param>TC_COVERED=NET-08</param>
-                <param>Test_IPv6=external</param>
-                <param>REMOTE_SERVER=8.8.8.8</param>
+                <param>TC_COVERED=NET-06</param>
+                <param>REMOTE_SERVER=2001:4860:4860::8888</param>
                 <param>LO_IGNORE=yes</param>
-                <!-- <param>GATEWAY=192.168.0.1</param> -->
                 <param>VCPU=1</param>
-                <param>SnapshotName=ICABase</param>
             </testParams>
             <testScript>NET_LEGACY.sh</testScript>
             <files>remote-scripts/ica/NET_LEGACY.sh,remote-scripts/ica/utils.sh</files>
@@ -168,17 +159,33 @@
             <setupScript>SetupScripts\NET_ADD_NIC_MAC.ps1</setupScript>
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112233</param>
-                <param>TC_COVERED=NET-09</param>
-                <param>Test_IPv6=external</param>
+                <param>TC_COVERED=NET-07</param>
                 <param>MAC=00:16:00:11:22:33</param>
-                <param>REMOTE_SERVER=8.8.8.8</param>
+                <param>REMOTE_SERVER=2001:4860:4860::8888</param>
                 <param>LO_IGNORE=yes</param>
-                <!-- <param>GATEWAY=192.168.0.1</param> -->
             </testParams>
             <testScript>NET_STATIC_MAC.sh</testScript>
             <files>remote-scripts/ica/NET_STATIC_MAC.sh,remote-scripts/ica/utils.sh</files>
             <cleanupScript>SetupScripts\NET_REMOVE_NIC_MAC.ps1</cleanupScript>
             <timeout>800</timeout>
+        </test>
+
+        <test>
+            <testName>NetworkMode</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
+            </setupScript>
+            <testScript>NET_PROMISC.sh</testScript>
+            <files>remote-scripts/ica/NET_PROMISC.sh,remote-scripts/ica/utils.sh</files>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,External,001600112200</param>
+                <param>TC_COVERED=NET-08</param>
+                <param>REMOTE_SERVER=2001:4860:4860::8888</param>
+            </testParams>
+            <cleanupScript>SetupScripts\NET_REMOVE_NIC_MAC.ps1</cleanupScript>
+            <noReboot>False</noReboot>
+            <timeout>600</timeout>
         </test>
 
         <!-- The following two tests are actually one single TC -->
@@ -190,8 +197,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112200</param>
                 <param>SWITCH=NetworkAdapter,Internal,Internal,001600112200</param>
-                <param>TC_COVERED=NET-13</param>
-                <param>Test_IPv6=internal</param>
+                <param>TC_COVERED=NET-09</param>
                 <param>STATIC_IP=192.168.0.2</param>
                 <param>NETMASK=255.255.255.0</param>
                 <param>PING_SUCC=192.168.0.1</param>
@@ -215,15 +221,12 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112200</param>
                 <param>SWITCH=NetworkAdapter,Private,Private,001600112200</param>
-                <param>TC_COVERED=NET-13</param>
-                <param>Test_IPv6=private</param>
+                <param>TC_COVERED=NET-09</param>
                 <param>STATIC_IP=10.10.10.1</param>
                 <param>STATIC_IP2=10.10.10.2</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>VM2NAME=vm2Name</param>
                 <param>PING_FAIL=8.8.8.8</param>
                 <param>PING_FAIL2=192.168.0.1</param>
-                <param>SnapshotName=ICABase</param>
             </testParams>
             <pretest>setupScripts\NET_SWITCH_NIC_MAC.ps1</pretest>
             <testScript>setupscripts\NET_PRIVATE_NETWORK.ps1</testScript>
@@ -232,8 +235,6 @@
             <timeout>800</timeout>
         </test>
 
-        <!-- The preceding three tests are actually one single TC -->
-
         <test>
             <testName>JumboFrame</testName>
             <setupScript>
@@ -241,15 +242,14 @@
                 <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
                 <file>setupscripts\StartVM.ps1</file>
             </setupScript>
+            <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testparams>
-                <param>NIC=NetworkAdapter,External,External,001600112200</param>
-                <param>TC_COVERED=NET-14</param>
-                <param>Test_IPv6=external</param>
-                <param>STATIC_IP2=10.10.10.10</param>
-                <param>NETMASK=255.255.254.0</param>
-                <param>VM2NAME=vm2Name</param>
-                <param>SnapshotName=ICABase</param>
-                <param>SSH_PRIVATE_KEY=sshKey</param>
+                <param>NIC=NetworkAdapter,Private,Private,001600112200</param>
+                <param>TC_COVERED=NET-10</param>
+                <param>STATIC_IP=10.10.10.10</param>
+                <param>STATIC_IP2=10.10.10.20</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>MAC=001600112233</param>
                 <param>REMOTE_USER=root</param>
             </testparams>
             <testScript>NET_JUMBO_FRAMES.sh</testScript>
@@ -261,21 +261,33 @@
         </test>
 
         <test>
+            <testName>OperState</testName>
+             <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
+            </setupScript>
+            <testParams>
+                <param>NIC=NetworkAdapter,None,None,001600112200</param>
+                <param>TC_COVERED=NET-11</param>
+            </testParams>
+            <testScript>NET_OPERSTATE.sh</testScript>
+            <files>remote-scripts/ica/NET_OPERSTATE.sh,remote-scripts/ica/utils.sh</files>
+            <cleanupScript>SetupScripts\NET_REMOVE_NIC_MAC.ps1</cleanupScript>
+            <timeout>800</timeout>
+        </test>
+
+        <test>
             <testName>CopyLargeFile</testName>
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
                 <file>setupscripts\StartVM.ps1</file>
             </setupScript>
+            <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testParams>
                 <param>NIC=NetworkAdapter,External,External,001600112200</param>
-                <param>TC_COVERED=NET-01</param>
-                <param>Test_IPv6=external</param>
-                <param>STATIC_IP2=10.10.10.10</param>
-                <param>NETMASK=255.255.255.0</param>
-                <param>VM2NAME=vm2Name</param>
-                <param>SnapshotName=ICABase</param>
-                <param>SSH_PRIVATE_KEY=sshKey</param>
+                <param>TC_COVERED=NET-12</param>
+                <param>MAC=001600112233</param>
                 <param>ZERO_FILE=yes</param>
                 <param>FILE_SIZE_GB=2</param>
                 <param>REMOTE_USER=root</param>
@@ -287,27 +299,25 @@
         </test>
 
         <test>
-            <testName>VlanTrunking</testName>
+            <testName>CopyFileDifferentMTU</testName>
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
+                <file>setupscripts\StartVM.ps1</file>
             </setupScript>
+            <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testParams>
-                <param>NIC=NetworkAdapter,Private,Private,001600112200</param>
-                <param>TC_COVERED=NET-01</param>
-                <param>Test_IPv6=private</param>
-                <!-- <param>STATIC_IP=10.10.10.1</param> -->
-                <!-- <param>STATIC_IP2=10.10.10.2</param> -->
-                <!-- <param>NETMASK=255.255.255.0</param> -->
-                <param>VM2NAME=VM2Name</param>
-                <param>VM_VLAN_ID=2</param>
-                <param>NATIVE_VLAN_ID=10</param>
-                <param>SnapshotName=ICABase</param>
+                <param>NIC=NetworkAdapter,External,External,001600112200</param>
+                <param>TC_COVERED=NET-13</param>
+                <param>MAC=001600112233</param>
+                <param>ZERO_FILE=yes</param>
+                <param>FILE_SIZE_GB=1</param>
+                <param>REMOTE_USER=root</param>
             </testParams>
-            <testScript>SetupScripts\NET_VLAN_TRUNKING.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files>
+            <testScript>NET_Copy_Different_MTU.sh</testScript>
+            <files>remote-scripts/ica/NET_Copy_Different_MTU.sh,remote-scripts/ica/utils.sh</files>
             <cleanupScript>SetupScripts\NET_REMOVE_NIC_MAC.ps1</cleanupScript>
-            <timeout>800</timeout>
+            <timeout>1800</timeout>
         </test>
 
         <test>
@@ -317,15 +327,12 @@
                 <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
             </setupScript>
             <testParams>
-                <param>NIC=NetworkAdapter,External,External,001600112200</param>
-                <param>TC_COVERED=NET-01</param>
-                <param>Test_IPv6=external</param>
-                <!-- <param>STATIC_IP=10.10.10.1</param> -->
-                <!-- <param>STATIC_IP2=10.10.10.2</param> -->
-                <!-- <param>NETMASK=255.255.254.0</param> -->
-                <param>VM2NAME=VM2Name</param>
-                <param>VLAN_ID=2</param>
-                <param>SnapshotName=ICABase</param>
+            <param>NIC=NetworkAdapter,External,External,001600112200</param>
+            <param>TC_COVERED=NET-14</param>
+            <!-- <param>STATIC_IP=10.10.10.1</param> -->
+            <!-- <param>STATIC_IP2=10.10.10.2</param> -->
+            <!-- <param>NETMASK=255.255.254.0</param> -->
+            <param>VLAN_ID=2</param>
             </testParams>
             <testScript>SetupScripts\NET_VLAN_TAGGING.ps1</testScript>
             <files>remote-scripts/ica/utils.sh</files>
@@ -333,7 +340,42 @@
             <timeout>1000</timeout>
         </test>
 
-        <!-- The following 2 tests require a Gen 2 VM -->
+        <test>
+            <testName>VlanTrunking</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\NET_ADD_NIC_MAC.ps1</file>
+            </setupScript>
+            <testParams>
+                <param>NIC=NetworkAdapter,Private,Private,001600112200</param>
+                <param>TC_COVERED=NET-15</param>
+                <!-- <param>STATIC_IP=10.10.10.1</param> -->
+                <!-- <param>STATIC_IP2=10.10.10.2</param> -->
+                <!-- <param>NETMASK=255.255.255.0</param> -->
+                <param>VM_VLAN_ID=2</param>
+                <param>NATIVE_VLAN_ID=10</param>
+            </testParams>
+            <testScript>SetupScripts\NET_VLAN_TRUNKING.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
+            <cleanupScript>SetupScripts\NET_REMOVE_NIC_MAC.ps1</cleanupScript>
+            <timeout>800</timeout>
+        </test>
+
+        <test>
+            <testName>Network_Hang_Vxlan</testName>
+            <setupScript>SetupScripts\NET_ADD_NIC_MAC.ps1</setupScript>
+            <testParams>
+                <param>NIC=NetworkAdapter,Private,Private,001600112200</param>
+                <param>STATIC_IP1=10.10.10.10</param>
+                <param>STATIC_IP2=10.10.10.20</param>
+                <param>NETMASK=255.255.255.0</param>
+            </testParams>
+            <testScript>setupscripts\NET_Hang_Vxlan.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
+            <timeout>800</timeout>
+        </test>
+
+        <!-- The following test requires a Gen 2 VM -->
         <test>
             <testName>HotAddMultiNIC</testName>
             <testScript>SetupScripts\NET_HotAddMultiNIC.ps1</testScript>
@@ -347,6 +389,7 @@
             </testparams>
         </test>
 
+        <!-- The following test requires a Gen 2 VM -->
         <test>
             <testName>BootNoNicHotAddNic</testName>
             <testScript>SetupScripts\NET_BootNoNICHotAddNIC.ps1</testScript>
@@ -368,8 +411,12 @@
             <os>Linux</os>
             <ipv4></ipv4>
             <sshKey>sshKey.ppk</sshKey>
+            <testParams>
+                <param>VM2NAME=vm2Name</param>
+                <param>SSH_PRIVATE_KEY=identity_file</param>
+                <param>SnapshotName=ICABase</param>
+            </testParams>
             <suite>Network</suite>
         </vm>
     </VMs>
-
 </config>


### PR DESCRIPTION
Tested on RHEL 5, 6, 7, SLES 11 sp4, 12 sp1, Ubuntu 15.10

ipv6 tests are not working on RHEL 6.