### PR TITLE
New test suite added: Manual Memory Hot Add

### DIFF
--- a/WS2012R2/lisa/setupscripts/ManualMem_Configure.ps1
+++ b/WS2012R2/lisa/setupscripts/ManualMem_Configure.ps1
@@ -1,0 +1,191 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+
+<#
+.Synopsis
+ Configure Manual Memory for given Virtual Machines (no DM).
+
+   .Parameter vmName
+    Name of the VM which will be asssigned a new Memory value
+
+    .Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+    .Parameter testParams
+    Test data for this test case
+
+    .Example
+    setupScripts\ManualMem_Configure.ps1 -vmName VM -hvServer localhost -testParams "vmName=VM;startupMem=2GB"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+
+# Convert a string to int64 for use with the Set-VMMemory cmdlet
+function ConvertToMemSize([String] $memString, [String]$hvServer)
+{
+    $memSize = [Int64] 0
+
+    if ($memString.EndsWith("MB"))
+    {
+        $num = $memString.Replace("MB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1MB
+    }
+    elseif ($memString.EndsWith("GB"))
+    {
+        $num = $memString.Replace("GB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1GB
+    }
+    elseif( $memString.EndsWith("%"))
+    {
+        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
+        if (-not $osInfo)
+        {
+            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
+            return $False
+        }
+
+        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
+        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
+        $num = [Int64] ($memPercent * $hostMemCapacity)
+
+        # Align on a 4k boundry
+        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
+    }
+    # we received the number of bytes
+    else
+    {
+        $memSize = ([Convert]::ToInt64($memString))
+    }
+
+    return $memSize
+}
+
+
+#
+# Check input arguments
+#
+if (-not $vmName){
+    "Error: VM name is null. "
+    return $false
+}
+
+if (-not $hvServer){
+    "Error: hvServer is null"
+    return $false
+}
+
+if (-not $testParams){
+  "Error: testParams is null"
+  return $false
+}
+
+# No dynamic memory needed; set false as default
+$DM_Enabled = $false
+
+[int64]$startupMem = 0
+
+#
+# Parse the testParams string, then process each parameter
+#
+$params = $testParams.Split(';')
+
+foreach ($p in $params)
+{
+    $temp = $p.Trim().Split('=')
+
+    if ($temp.Length -ne 2)
+    {
+        # Ignore and move on to the next parameter
+        continue
+    }
+
+    elseif($temp[0].Trim() -eq "startupMem")
+    {
+
+      $startupMem = ConvertToMemSize $temp[1].Trim() $hvServer
+
+      if ($startupMem -le 0)
+      {
+        "Error: Unable to convert startupMem to int64."
+        return $false
+      }
+
+      "startupMem: $startupMem"
+    }
+
+    # check if we have all variables set
+    if ($vmName -and $DM_Enabled -eq $false -and $startupMem)
+    {
+
+      # make sure VM is off
+      if (Get-VM -Name $vmName -ComputerName $hvServer |  Where { $_.State -like "Running" })
+      {
+
+        "Stopping VM $vmName"
+        Stop-VM $vmName -force
+
+        if (-not $?)
+        {
+          "Error: Unable to shut $vmName down (in order to set Memory parameters)"
+          return $false
+        }
+
+        # wait for VM to finish shutting down
+        $timeout = 60
+        while (Get-VM -Name $vmName -ComputerName $hvServer |  Where { $_.State -notlike "Off" })
+        {
+          if ($timeout -le 0)
+          {
+            "Error: Unable to shutdown $vmName"
+            return $false
+          }
+
+          start-sleep -s 5
+          $timeout = $timeout - 5
+        }
+
+      }
+
+      # Verify VM Version is 7
+      $version = Get-VM -Name $vmName -ComputerName $hvServer | select -ExpandProperty Version
+      if ( $version -ne "7.0" )
+      {
+        "Error: $vmName is version $version. It needs to be 7.0"
+        return $false
+      }
+
+      Set-VMMemory -vmName $vmName -ComputerName $hvServer -DynamicMemoryEnabled $DM_Enabled `
+                      -StartupBytes $startupMem 
+      if (-not $?)
+      {
+        "Error: Unable to set VM Memory for $vmName."
+        "DM enabled: $DM_Enabled"
+        "startup Mem: $startupMem"
+        return $false
+      }
+    }
+
+}
+
+Write-Output $true
+return $true

--- a/WS2012R2/lisa/setupscripts/ManualMem_HotAdd.ps1
+++ b/WS2012R2/lisa/setupscripts/ManualMem_HotAdd.ps1
@@ -1,0 +1,442 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+
+<#
+.Synopsis
+ --THIS TEST IS THRESHOLD ONLY--
+ Verify that memory assigned to VM changes when adding or removing a big amount (e.g. 2GB).
+
+ Description:
+    Verify that memory changes if a big chunk of memory is added or removed.
+
+   Only 1 VM is required for this test.
+
+   .Parameter vmName
+    Name of the VM to remove NIC from .
+
+    .Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+    .Parameter testParams
+    Test data for this test case
+
+    .Example
+    setupscripts\ManualMem_HotAdd.ps1 -vmName nameOfVM -hvServer localhost -testParams 
+    'sshKey=KEY;ipv4=IPAddress;rootDir=path\to\dir; TC_COVERED=??; startupMem=2GB; testMem=4GB'
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+# Convert a string to int64 for use with the Set-VMMemory cmdlet
+function ConvertToMemSize([String] $memString, [String]$hvServer)
+{
+    $memSize = [Int64] 0
+
+    if ($memString.EndsWith("MB")){
+        $num = $memString.Replace("MB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1MB
+    }
+    elseif ($memString.EndsWith("GB")){
+        $num = $memString.Replace("GB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1GB
+    }
+    elseif( $memString.EndsWith("%")){
+        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
+        if (-not $osInfo)
+        {
+            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
+            return $False
+        }
+
+        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
+        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
+        $num = [Int64] ($memPercent * $hostMemCapacity)
+
+        # Align on a 4k boundry
+        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
+    }
+    # we received the number of bytes
+    else{
+        $memSize = ([Convert]::ToInt64($memString))
+    }
+
+    return $memSize
+}
+
+function checkStressNg([String]$conIpv4, [String]$sshKey)
+{
+    $cmdToVM = @"
+#!/bin/bash
+        command -v stress-ng
+        sts=`$?
+        exit `$sts
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "CheckStress-ng.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+        Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+    # check the return Value of SendFileToVM
+    if (-not $retVal){
+        return $false
+    }
+
+    # execute command
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+}
+
+# we need a scriptblock in order to pass this function to start-job
+$scriptBlock = {
+  # function for starting stress-ng
+  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir)
+  {
+
+  # because function is called as job, setup rootDir and source TCUtils again
+  if (Test-Path $rootDir){
+    Set-Location -Path $rootDir
+    if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+    }
+    "Changed working directory to $rootDir"
+  }
+  else{
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
+  }
+
+  # Source TCUitls.ps1 for getipv4 and other functions
+  if (Test-Path ".\setupScripts\TCUtils.ps1"){
+    . .\setupScripts\TCUtils.ps1
+    "Sourced TCUtils.ps1"
+  }
+  else{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+  }
+
+
+      $cmdToVM = @"
+#!/bin/bash
+        __freeMem=`$(cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }')
+        __freeMem=`$((__freeMem/1024))
+        echo ConsumeMemory: Free Memory found `$__freeMem MB >> /root/HotAdd.log 2>&1
+        __threads=32
+        __chunks=`$((`$__freeMem / `$__threads))
+        echo "Going to start `$__threads instance(s) of stress-ng every 2 seconds, each consuming 128MB memory" >> /root/HotAdd.log 2>&1
+        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t 120 --backoff 1500000
+        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
+        wait
+        exit 0
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "ConsumeMem.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+      Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+
+    # check the return Value of SendFileToVM
+    if (-not $retVal[-1]){
+      return $false
+    }
+
+    # execute command as job
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+  }
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+#
+# Check input arguments
+#
+if ($vmName -eq $null){
+    "Error: VM name is null"
+    return $False
+}
+
+if ($hvServer -eq $null){
+    "Error: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null){
+    "Error: testParams is null"
+    return $False
+}
+
+# Write out test Params
+$testParams
+
+# sshKey used to authenticate ssh connection and send commands
+$sshKey = $null
+
+# IP Address of first VM
+$ipv4 = $null
+
+# change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?){
+  "Mandatory param RootDir=Path; not found!"
+  return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir){
+  Set-Location -Path $rootDir
+  if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+  }
+  "Changed working directory to $rootDir"
+}
+else{
+  "Error: RootDir = $rootDir is not a valid path"
+  return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1"){
+  . .\setupScripts\TCUtils.ps1
+}
+else{
+  "Error: Could not find setupScripts\TCUtils.ps1"
+  return $false
+}
+
+$params = $testParams.Split(";")
+foreach ($p in $params){
+    $fields = $p.Split("=")
+
+    switch ($fields[0].Trim()){
+      "TC_COVERED"    { $TC_COVERED = $fields[1].Trim() }
+      "ipv4"          { $ipv4     = $fields[1].Trim() }
+      "sshKey"        { $sshKey        = $fields[1].Trim() }
+      "testMem"  { 
+        $testMem  = ConvertToMemSize $fields[1].Trim() $hvServer
+
+        if ($testMem -le 0)
+        {
+          "Error: Unable to convert testMem to int64."
+          return $false
+        }
+
+        "testMem: $testMem"
+      }
+      "startupMem"  { 
+        $startupMem  = ConvertToMemSize $fields[1].Trim() $hvServer
+
+        if ($startupMem -le 0)
+        {
+          "Error: Unable to convert startupMem to int64."
+          return $false
+        }
+
+        "startupMem: $startupMem"
+      }
+    }
+}
+
+if (-not $sshKey){
+  "Error: Please pass the sshKey to the script."
+  return $false
+}
+
+if (-not $testMem){
+  "Error: memTest is not set!"
+  return $false
+}
+
+"This script covers test case: ${TC_COVERED}"
+
+$vm1 = Get-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
+
+if (-not $vm1){
+  "Error: VM $vmName does not exist"
+  return $false
+}
+
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = checkStressNg $ipv4 $sshKey
+if (-not $retVal){
+    "Stress-ng is not installed! Please install it before running the memory stress tests."
+    return $false
+}
+
+"Stress-ng is installed! Will begin running memory stress tests shortly."
+
+# Get memory stats from vm1
+start-sleep -s 10
+$sleepPeriod = 60
+
+# get VM1 memory from host and guest
+while ($sleepPeriod -gt 0){
+  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+
+  [int64]$vm1BeforeAssignedGuest = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+
+  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm1BeforeAssignedGuest -gt 0){
+    break
+  }
+
+  $sleepPeriod-= 5
+  start-sleep -s 5
+}
+
+if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm1BeforeAssignedGuest -le 0){
+  "Error: vm1 $vmName reported 0 memory (assigned or demand)."
+  return $False
+}
+
+"Memory stats after $vmName started reporting "
+"  ${vmName}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
+
+# Set new memory value
+for ($i=0; $i -lt 3; $i++){
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    # Get memory data from guest
+    [int64]$vm1AfterAssignedGuest = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    break
+  }
+}
+
+if ( $i -eq 3 ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+if ($testMem -ge $startupMem){
+  [int64]$deltaMemGuest = ($vm1AfterAssignedGuest - $vm1BeforeAssignedGuest) / 1024
+}
+else{
+  [int64]$deltaMemGuest = ($vm1BeforeAssignedGuest - $vm1AfterAssignedGuest) / 1024
+}
+"Free memory difference before - after assigning the new memory value: ${deltaMemGuest} MB"
+if ( $deltaMemGuest -lt 1000){
+    "Error: Guest reports that memory value hasn't increased or decreased enough!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: Initial Memory - $vm1BeforeAssignedGuest KB :: After setting new value - $vm1AfterAssignedGuest"
+    return $false 
+}
+
+"Memory stats after $vmName memory was changed "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+"  Reported free memory inside ${vmName}: Before - $vm1BeforeAssignedGuest KB | After - $vm1AfterAssignedGuest KB"
+
+# Send Command to consume
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir) ConsumeMemory $ip $sshKey $rootDir } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir)
+if (-not $?){
+  "Error: Unable to start job for creating pressure on $vmName"
+  return $false
+}
+
+# sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
+start-sleep -s 50
+
+# get memory stats while stress-ng is running
+[int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
+[int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
+"Memory stats after $vmName started stress-ng"
+"  ${vmName}: assigned - $vm1Assigned | demand - $vm1Demand"
+
+if ($vm1Demand -le $vm1BeforeDemand){
+  "Error: Memory Demand did not increase after starting stress-ng"
+  return $false
+}
+
+# Wait for jobs to finish now and make sure they exited successfully
+$timeout = 120
+$firstJobStatus = $false
+while ($timeout -gt 0){
+  if ($job1.Status -like "Completed"){
+    $firstJobStatus = $true
+    $retVal = Receive-Job $job1
+    if (-not $retVal[-1]){
+      "Error: Consume Memory script returned false on VM1 $vmName"
+      return $false
+    }
+    $diff = $totalTimeout - $timeout
+    "Job finished in $diff seconds."
+  }
+
+  if ($firstJobStatus){
+    break
+  }
+
+  $timeout -= 1
+  start-sleep -s 1
+}
+start-sleep -s 5
+
+# get memory stats after strss-ng stopped running
+[int64]$vm1AfterStressAssigned = ($vm1.MemoryAssigned/1MB)
+[int64]$vm1AfterStressDemand = ($vm1.MemoryDemand/1MB)
+"Memory stats after $vmName stress-ng run"
+"  ${vmName}: assigned - $vm1AfterStressAssigned | demand - $vm1AfterStressDemand"
+
+if ($vm1AfterStressDemand -ge $vm1Demand){
+  "Error: Memory Demand did not decrease after stress-ng stopped"
+  return $false
+}
+
+"VM changed its memory and ran memory stress tests successfully!"
+return $true

--- a/WS2012R2/lisa/setupscripts/ManualMem_HotAdd_Chunks.ps1
+++ b/WS2012R2/lisa/setupscripts/ManualMem_HotAdd_Chunks.ps1
@@ -1,0 +1,467 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+
+<#
+.Synopsis
+ --THIS TEST IS THRESHOLD ONLY--
+ Verify that memory assigned to VM changes.
+
+ Description:
+   Verify that memory changes if small chunks memory are added or removed.
+   "decrease" parameter will be set "no" for HotAdd case and "yes" for HotRemove case
+
+   Only 1 VM is required for this test.
+
+   .Parameter vmName
+    Name of the VM to test Manual Memory Add/Remove .
+
+    .Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+    .Parameter testParams
+    Test data for this test case
+
+    .Example
+    setupscripts\ManualMem_HotAdd_Chunks.ps1 -vmName nameOfVM -hvServer localhost -testParams 
+    'sshKey=KEY;ipv4=IPAddress;rootDir=path\to\dir; TC_COVERED=??; startupMem=2GB;chunkMem=128MB; decrease=no'
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+# Convert a string to int64 for use with the Set-VMMemory cmdlet
+function ConvertToMemSize([String] $memString, [String]$hvServer)
+{
+    $memSize = [Int64] 0
+
+    if ($memString.EndsWith("MB")){
+        $num = $memString.Replace("MB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1MB
+    }
+    elseif ($memString.EndsWith("GB")){
+        $num = $memString.Replace("GB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1GB
+    }
+    elseif( $memString.EndsWith("%")){
+        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
+        if (-not $osInfo){
+            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
+            return $False
+        }
+
+        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
+        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
+        $num = [Int64] ($memPercent * $hostMemCapacity)
+
+        # Align on a 4k boundry
+        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
+    }
+    # we received the number of bytes
+    else{
+        $memSize = ([Convert]::ToInt64($memString))
+    }
+
+    return $memSize
+}
+
+function checkStressNg([String]$conIpv4, [String]$sshKey)
+{
+    $cmdToVM = @"
+#!/bin/bash
+        command -v stress-ng
+        sts=`$?
+        exit `$sts
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "CheckStress-ng.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+        Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+
+    # delete file unless the Leave_trail param was set to yes.
+    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0){
+        Remove-Item ".\${filename}"
+    }
+
+    # check the return Value of SendFileToVM
+    if (-not $retVal){
+        return $false
+    }
+
+    # execute command
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+}
+
+# we need a scriptblock in order to pass this function to start-job
+$scriptBlock = {
+  # function for starting stress-ng
+  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir)
+  {
+
+  # because function is called as job, setup rootDir and source TCUtils again
+  if (Test-Path $rootDir){
+    Set-Location -Path $rootDir
+    if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+    }
+    "Changed working directory to $rootDir"
+  }
+  else{
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
+  }
+
+  # Source TCUitls.ps1 for getipv4 and other functions
+  if (Test-Path ".\setupScripts\TCUtils.ps1"){
+    . .\setupScripts\TCUtils.ps1
+    "Sourced TCUtils.ps1"
+  }
+  else{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+  }
+
+      $cmdToVM = @"
+#!/bin/bash
+        __freeMem=`$(cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }')
+        __freeMem=`$((__freeMem/1024))
+        echo ConsumeMemory: Free Memory found `$__freeMem MB >> /root/HotAdd.log 2>&1
+        __threads=32
+        __chunks=`$((`$__freeMem / `$__threads))
+        echo "Going to start `$__threads instance(s) of stress-ng every 2 seconds, each consuming 128MB memory" >> /root/HotAdd.log 2>&1
+        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t 120 --backoff 1500000
+        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
+        wait
+        exit 0
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "ConsumeMem.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+      Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+
+    # delete file unless the Leave_trail param was set to yes.
+    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0){
+      Remove-Item ".\${filename}"
+    }
+
+    # check the return Value of SendFileToVM
+    if (-not $retVal[-1]){
+      return $false
+    }
+
+    # execute command as job
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+  }
+}
+
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+#
+# Check input arguments
+#
+if ($vmName -eq $null){
+    "Error: VM name is null"
+    return $False
+}
+
+if ($hvServer -eq $null){
+    "Error: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null){
+    "Error: testParams is null"
+    return $False
+}
+
+# Write out test Params
+$testParams
+
+# sshKey used to authenticate ssh connection and send commands
+$sshKey = $null
+
+# IP Address of first VM
+$ipv4 = $null
+
+# change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?){
+  "Mandatory param RootDir=Path; not found!"
+  return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir){
+  Set-Location -Path $rootDir
+  if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+  }
+  "Changed working directory to $rootDir"
+}
+else{
+  "Error: RootDir = $rootDir is not a valid path"
+  return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1"){
+  . .\setupScripts\TCUtils.ps1
+}
+else{
+  "Error: Could not find setupScripts\TCUtils.ps1"
+  return $false
+}
+
+$params = $testParams.Split(";")
+foreach ($p in $params){
+    $fields = $p.Split("=")
+
+    switch ($fields[0].Trim()){
+      "TC_COVERED"    { $TC_COVERED = $fields[1].Trim() } 
+      "ipv4"          { $ipv4       = $fields[1].Trim() }
+      "sshKey"        { $sshKey     = $fields[1].Trim() }
+      "decrease"      { $decrease   = $fields[1].Trim() }
+      "startupMem"  { 
+        $startupMem = ConvertToMemSize $fields[1].Trim() $hvServer
+
+        if ($startupMem -le 0){
+          "Error: Unable to convert startupMem to int64."
+          return $false
+        }
+
+        "startupMem: $startupMem"
+      }
+      "chunkMem"  { 
+        $chunkMem  = ConvertToMemSize $fields[1].Trim() $hvServer
+
+        if ($chunkMem -le 0){
+          "Error: Unable to convert chunkMem to int64."
+          return $false
+        }
+
+        "chunkMem: $chunkMem"
+      }
+    }
+}
+
+if (-not $sshKey){
+  "Error: Please pass the sshKey to the script."
+  return $false
+}
+
+if (-not $startupMem){
+  "Error: startupMem is not set!"
+  return $false
+}
+
+"This script covers test case: ${TC_COVERED}"
+
+$vm1 = Get-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
+
+if (-not $vm1){
+  "Error: VM $vmName does not exist"
+  return $false
+}
+
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = checkStressNg $ipv4 $sshKey
+
+if (-not $retVal){
+    "Stress-ng is not installed! Please install it before running the memory stress tests."
+    return $false
+}
+
+"Stress-ng is installed! Will begin running memory stress tests shortly."
+
+# Get memory stats from vm1
+start-sleep -s 10
+$sleepPeriod = 60
+
+# get VM1 memory from host and guest
+while ($sleepPeriod -gt 0){
+  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+
+  [int64]$vm1BeforeAssignedGuest = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+
+  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm1BeforeAssignedGuest -gt 0){
+    break
+  }
+
+  $sleepPeriod-= 5
+  start-sleep -s 5
+
+}
+
+if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm1BeforeAssignedGuest -le 0){
+  "Error: vm1 $vmName reported 0 memory (assigned or demand)."
+  return $False
+}
+
+"Memory stats after $vmName started reporting "
+"  ${vmName}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
+
+$testMem = $startupMem
+# Set new memory value
+for ($i=1; $i -lt 5; $i++){
+  # Modify testMem accordingly to testcase (increase or decrease)
+  if ($decrease -like "no"){
+      $testMem =  $testMem + $chunkMem
+  }
+  else{
+      $testMem =  $testMem - $chunkMem
+  }
+
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    "Memory stats after ${i} run"
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+
+    [int64]$vm1AfterAssignedGuest = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    Start-sleep -s 5
+  }
+}
+
+[int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+if ( $vm1AfterAssigned -eq $vm1BeforeAssigned ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+# Verify memory reported inside guest VM
+if ($decrease -like "no"){
+   [int64]$deltaMemGuest = ($vm1AfterAssignedGuest - $vm1BeforeAssignedGuest) / 1024
+}
+else{
+   [int64]$deltaMemGuest = ($vm1BeforeAssignedGuest - $vm1AfterAssignedGuest) / 1024
+}
+
+"Free memory difference reported by guest vm before - after assigning the new memory value: ${deltaMemGuest} MB"
+if ( $deltaMemGuest -lt 128){
+    "Error: Guest reports that memory value hasn't increased or decreased enough!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: Initial Memory - $vm1BeforeAssignedGuest KB :: After setting new value - $vm1AfterAssignedGuest"
+    return $false 
+}
+
+"Memory stats after $vmName memory was changed "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+
+# Send Command to consume
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir) ConsumeMemory $ip $sshKey $rootDir } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir)
+if (-not $?){
+  "Error: Unable to start job for creating pressure on $vmName"
+  return $false
+}
+
+# sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
+start-sleep -s 50
+
+# get memory stats while stress-ng is running
+[int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
+[int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
+"Memory stats after $vmName started stress-ng"
+"  ${vmName}: assigned - $vm1Assigned | demand - $vm1Demand"
+
+if ($vm1Demand -le $vm1BeforeDemand){
+  "Error: Memory Demand did not increase after starting stress-ng"
+  return $false
+}
+
+# Wait for jobs to finish now and make sure they exited successfully
+$timeout = 120
+$firstJobStatus = $false
+while ($timeout -gt 0){
+  if ($job1.Status -like "Completed"){
+    $firstJobStatus = $true
+    $retVal = Receive-Job $job1
+    if (-not $retVal[-1]){
+      "Error: Consume Memory script returned false on VM1 $vmName"
+      return $false
+    }
+    $diff = $totalTimeout - $timeout
+    "Job finished in $diff seconds."
+  }
+
+  if ($firstJobStatus){
+    break
+  }
+
+  $timeout -= 1
+  start-sleep -s 1
+}
+start-sleep -s 5
+
+# get memory stats after strss-ng stopped running
+[int64]$vm1AfterStressAssigned = ($vm1.MemoryAssigned/1MB)
+[int64]$vm1AfterStressDemand = ($vm1.MemoryDemand/1MB)
+"Memory stats after $vmName stress-ng run"
+"  ${vmName}: assigned - $vm1AfterStressAssigned | demand - $vm1AfterStressDemand"
+
+if ($vm1AfterStressDemand -ge $vm1Demand){
+  "Error: Memory Demand did not decrease after stress-ng stopped"
+  return $false
+}
+
+"VM changed its memory and ran memory stress tests successfully!"
+return $true

--- a/WS2012R2/lisa/setupscripts/ManualMem_MultipleAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/ManualMem_MultipleAddRemove.ps1
@@ -1,0 +1,546 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+
+<#
+.Synopsis
+ --THIS TEST IS THRESHOLD ONLY--
+ Verify that demand changes with memory pressure inside the VM.
+
+ Description:
+   Verify that memory changes if multiple memory add/remove operations are done.
+
+   Only 1 VM is required for this test.
+
+   .Parameter vmName
+    Name of the VM to remove NIC from .
+
+    .Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+    .Parameter testParams
+    Test data for this test case
+
+    .Example
+    setupscripts\ManualMem_MultipleAddRemove.ps1 -vmName nameOfVM -hvServer localhost -testParams 
+    'sshKey=KEY;ipv4=IPAddress;rootDir=path\to\dir; TC_COVERED=??; startupMem=2GB'
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+# Convert a string to int64 for use with the Set-VMMemory cmdlet
+function ConvertToMemSize([String] $memString, [String]$hvServer)
+{
+    $memSize = [Int64] 0
+
+    if ($memString.EndsWith("MB")){
+        $num = $memString.Replace("MB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1MB
+    }
+    elseif ($memString.EndsWith("GB")){
+        $num = $memString.Replace("GB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1GB
+    }
+    elseif( $memString.EndsWith("%")){
+        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
+        if (-not $osInfo){
+            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
+            return $False
+        }
+
+        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
+        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
+        $num = [Int64] ($memPercent * $hostMemCapacity)
+
+        # Align on a 4k boundry
+        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
+    }
+    # we received the number of bytes
+    else{
+        $memSize = ([Convert]::ToInt64($memString))
+    }
+
+    return $memSize
+}
+
+function checkStressNg([String]$conIpv4, [String]$sshKey)
+{
+    $cmdToVM = @"
+#!/bin/bash
+        command -v stress-ng
+        sts=`$?
+        exit `$sts
+"@
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "CheckStress-ng.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+        Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+
+    # check the return Value of SendFileToVM
+    if (-not $retVal){
+        return $false
+    }
+
+    # execute command
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+}
+
+# we need a scriptblock in order to pass this function to start-job
+$scriptBlock = {
+  # function for starting stress-ng
+  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir)
+  {
+
+  # because function is called as job, setup rootDir and source TCUtils again
+  if (Test-Path $rootDir){
+    Set-Location -Path $rootDir
+    if (-not $?){
+      "Error: Could not change directory to $rootDir !"
+      return $false
+    }
+    "Changed working directory to $rootDir"
+  }
+  else{
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
+  }
+
+  # Source TCUitls.ps1 for getipv4 and other functions
+  if (Test-Path ".\setupScripts\TCUtils.ps1"){
+    . .\setupScripts\TCUtils.ps1
+    "Sourced TCUtils.ps1"
+  }
+  else{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+  }
+
+      $cmdToVM = @"
+#!/bin/bash
+        __freeMem=`$(cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }')
+        __freeMem=`$((__freeMem/1024))
+        echo ConsumeMemory: Free Memory found `$__freeMem MB >> /root/HotAdd.log 2>&1
+        __threads=8
+        __chunks=`$((`$__freeMem / `$__threads))
+        echo "Going to start `$__threads instance(s) of stress-ng every 2 seconds, each consuming 128MB memory" >> /root/HotAdd.log 2>&1
+        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t 120 --backoff 1500000
+        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
+        wait
+        exit 0
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "ConsumeMem.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+      Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+
+    # check the return Value of SendFileToVM
+    if (-not $retVal[-1]){
+      return $false
+    }
+
+    # execute command as job
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+  }
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+#
+# Check input arguments
+#
+if ($vmName -eq $null){
+    "Error: VM name is null"
+    return $False
+}
+
+if ($hvServer -eq $null){
+    "Error: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null){
+    "Error: testParams is null"
+    return $False
+}
+
+# Write out test Params
+$testParams
+
+# sshKey used to authenticate ssh connection and send commands
+$sshKey = $null
+
+# IP Address of first VM
+$ipv4 = $null
+
+# Name of first VM
+$vm1Name = $null
+
+# change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?){
+  "Mandatory param RootDir=Path; not found!"
+  return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir){
+  Set-Location -Path $rootDir
+  if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+  }
+  "Changed working directory to $rootDir"
+}
+else{
+  "Error: RootDir = $rootDir is not a valid path"
+  return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1"){
+  . .\setupScripts\TCUtils.ps1
+}
+else{
+  "Error: Could not find setupScripts\TCUtils.ps1"
+  return $false
+}
+
+$params = $testParams.Split(";")
+foreach ($p in $params){
+    $fields = $p.Split("=")
+
+    switch ($fields[0].Trim()){
+      "TC_COVERED"    { $TC_COVERED = $fields[1].Trim() }
+      "ipv4"          { $ipv4       = $fields[1].Trim() }
+      "sshKey"        { $sshKey     = $fields[1].Trim() }
+      "startupMem"  { 
+        $startupMem = ConvertToMemSize $fields[1].Trim() $hvServer
+
+        if ($startupMem -le 0){
+          "Error: Unable to convert startupMem to int64."
+          return $false
+        }
+        "startupMem: $startupMem"
+      }
+    }
+
+}
+
+if (-not $sshKey){
+  "Error: Please pass the sshKey to the script."
+  return $false
+}
+
+if (-not $startupMem){
+  "Error: startupMem is not set!"
+  return $false
+}
+
+"This script covers test case: ${TC_COVERED}"
+
+$vm1 = Get-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
+
+if (-not $vm1){
+  "Error: VM $vmName does not exist"
+  return $false
+}
+
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = checkStressNg $ipv4 $sshKey
+
+if (-not $retVal){
+    "Stress-ng is not installed! Please install it before running the memory stress tests."
+    return $false
+}
+
+"Stress-ng is installed!"
+
+# Get memory stats from vm1
+start-sleep -s 10
+$sleepPeriod = 60
+
+# get VM1 memory from host and guest
+while ($sleepPeriod -gt 0){
+  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+
+  [int64]$vm1BeforeIncrease = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+  "Free memory reported by guest VM before increase: $vm1BeforeIncrease"
+
+  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm1BeforeIncrease -gt 0){
+    break
+  }
+
+  $sleepPeriod-= 5
+  start-sleep -s 5
+}
+
+if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm1BeforeIncrease -le 0){
+  "Error: vm1 $vmName reported 0 memory (assigned or demand)."
+  return $False
+}
+"Memory stats after $vmName started reporting "
+"  ${vmName}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
+
+# Change 1 - Increase
+$testMem = $startupMem + 2147483648
+
+# Set new memory value
+for ($i=0; $i -lt 3; $i++){
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    [int64]$vm1AfterIncrease = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    "Free memory reported by guest VM after increase: $vm1AfterIncrease KB"
+    break
+  }
+}
+
+if ( $i -eq 3 ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+if ( ($vm1AfterIncrease - $vm1BeforeIncrease) -le 2000000){
+    "Error: Guest reports that memory value hasn't increased enough!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: Initial Memory - $vm1BeforeIncrease KB :: After setting new value - $vm1AfterIncrease"
+    return $false 
+}
+"Memory stats after $vmName memory was increased by 2GB "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+
+# Change 2 - Decrease
+Start-sleep -s 10
+$testMem = $testMem - 2147483648
+
+# Set new memory value
+for ($i=0; $i -lt 3; $i++){
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    [int64]$vm1AfterDecrease = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    "Free memory reported by guest VM after decrease: $vm1AfterDecrease KB"
+    break
+  }
+}
+
+if ( $i -eq 3 ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vm1Name memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+if ( ($vm1AfterIncrease - $vm1AfterDecrease) -le 2000000){
+    "Error: Guest reports that memory value hasn't decreased enough!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: Initial Memory - $vm1AfterIncrease KB :: After setting new value - $vm1AfterDecrease KB"
+    return $false 
+}
+"Memory stats after $vmName memory was decreased by 2GB "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+
+# Change 3 - Increase by 1GB
+Start-sleep -s 10
+$testMem = $testMem + 1073741824
+
+# Set new memory value
+for ($i=0; $i -lt 3; $i++){
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    [int64]$vm1AfterIncrease = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    "Free memory reported by guest VM guest VM after increase: $vm1AfterIncrease KB"
+    break
+  }
+}
+
+if ( $i -eq 3 ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vm1Name memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+if ( ($vm1AfterIncrease - $vm1AfterDecrease) -le 1000000){
+    "Error: Guest reports that memory value hasn't decreased enough!"
+    "Memory stats after $vm1Name memory was changed "
+    "  ${vmName}: Initial Memory - $vm1AfterDecrease KB :: After setting new value - $vm1AfterIncrease KB"
+    return $false 
+}
+"Memory stats after $vmName memory was decreased by 2GB "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+
+
+# Change 4 - Decrease by 2GB
+Start-sleep -s 10
+$testMem = $testMem - 2147483648
+# Set new memory value
+for ($i=0; $i -lt 3; $i++){
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    [int64]$vm1AfterDecrease = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    "Free memory reported by guest VM guest VM after increase: $vm1AfterDecrease KB"
+    break
+  }
+}
+
+if ( $i -eq 3 ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vm1Name memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+if ( ($vm1AfterIncrease - $vm1AfterDecrease) -le 2000000){
+    "Error: Guest reports that memory value hasn't decreased enough!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: Initial Memory - $vm1AfterIncrease KB :: After setting new value - $vm1AfterDecrease KB"
+    return $false 
+}
+"Memory stats after $vmName memory was decreased by 2GB "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+
+# Send Command to consume
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir) ConsumeMemory $ip $sshKey $rootDir } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir)
+if (-not $?){
+  "Error: Unable to start job for creating pressure on $vmName"
+  return $false
+}
+
+# sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
+start-sleep -s 50
+
+# get memory stats while stress-ng is running
+[int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
+[int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
+"Memory stats after $vmName started stress-ng"
+"  ${vmName}: assigned - $vm1Assigned | demand - $vm1Demand"
+
+if ($vm1Demand -le $vm1BeforeDemand){
+  "Error: Memory Demand did not increase after starting stress-ng"
+  return $false
+}
+
+# Wait for jobs to finish now and make sure they exited successfully
+$timeout = 120
+$firstJobStatus = $false
+while ($timeout -gt 0){
+  if ($job1.Status -like "Completed"){
+    $firstJobStatus = $true
+    $retVal = Receive-Job $job1
+    if (-not $retVal[-1]){
+      "Error: Consume Memory script returned false on VM1 $vmName"
+      return $false
+    }
+    $diff = $totalTimeout - $timeout
+    "Job finished in $diff seconds."
+  }
+
+  if ($firstJobStatus){
+    break
+  }
+
+  $timeout -= 1
+  start-sleep -s 1
+}
+start-sleep -s 5
+
+# get memory stats after strss-ng stopped running
+[int64]$vm1AfterStressAssigned = ($vm1.MemoryAssigned/1MB)
+[int64]$vm1AfterStressDemand = ($vm1.MemoryDemand/1MB)
+"Memory stats after $vmName stress-ng run"
+"  ${vmName}: assigned - $vm1AfterStressAssigned | demand - $vm1AfterStressDemand"
+
+if ($vm1AfterStressDemand -ge $vm1Demand){
+  "Error: Memory Demand did not decrease after stress-ng stopped"
+  return $false
+}
+
+"VM changed its memory and ran memory stress tests successfully!"
+return $true

--- a/WS2012R2/lisa/setupscripts/ManualMem_StressHotRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/ManualMem_StressHotRemove.ps1
@@ -1,0 +1,430 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+
+<#
+.Synopsis
+ --THIS TEST IS THRESHOLD ONLY--
+ Verify that can remove memory while stress tool is running.
+
+ Description:
+    Verify that memory changes while stress tool is running.
+
+   Only 1 VM is required for this test.
+
+   .Parameter vmName
+    Name of the VM to remove NIC from .
+
+    .Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+    .Parameter testParams
+    Test data for this test case
+
+    .Example
+    setupscripts\ManualMem_StressHotRemove.ps1 -vmName nameOfVM -hvServer localhost -testParams 
+    'sshKey=KEY; ipv4=IPAddress; rootDir=path\to\dir; TC_COVERED=??; startupMem=2GB'
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+# Convert a string to int64 for use with the Set-VMMemory cmdlet
+function ConvertToMemSize([String] $memString, [String]$hvServer)
+{
+    $memSize = [Int64] 0
+
+    if ($memString.EndsWith("MB")){
+        $num = $memString.Replace("MB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1MB
+    }
+    elseif ($memString.EndsWith("GB")){
+        $num = $memString.Replace("GB","")
+        $memSize = ([Convert]::ToInt64($num)) * 1GB
+    }
+    elseif( $memString.EndsWith("%")){
+        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
+        if (-not $osInfo){
+            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
+            return $False
+        }
+
+        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
+        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
+        $num = [Int64] ($memPercent * $hostMemCapacity)
+
+        # Align on a 4k boundry
+        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
+    }
+    # we received the number of bytes
+    else{
+        $memSize = ([Convert]::ToInt64($memString))
+    }
+
+    return $memSize
+}
+
+function checkStressNg([String]$conIpv4, [String]$sshKey)
+{
+    $cmdToVM = @"
+#!/bin/bash
+        command -v stress-ng
+        sts=`$?
+        exit `$sts
+"@
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "CheckStress-ng.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+        Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+    # check the return Value of SendFileToVM
+    if (-not $retVal){
+        return $false
+    }
+
+    # execute command
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+    return $retVal
+}
+
+# we need a scriptblock in order to pass this function to start-job
+$scriptBlock = {
+  # function for starting stress-ng
+  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir)
+  {
+
+  # because function is called as job, setup rootDir and source TCUtils again
+  if (Test-Path $rootDir){
+    Set-Location -Path $rootDir
+    if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+    }
+    "Changed working directory to $rootDir"
+  }
+  else{
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
+  }
+
+  # Source TCUitls.ps1 for getipv4 and other functions
+  if (Test-Path ".\setupScripts\TCUtils.ps1"){
+    . .\setupScripts\TCUtils.ps1
+    "Sourced TCUtils.ps1"
+  }
+  else{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+  }
+
+      $cmdToVM = @"
+#!/bin/bash
+        __freeMem=`$(cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }')
+        __freeMem=`$((__freeMem/1024))
+        echo ConsumeMemory: Free Memory found `$__freeMem MB >> /root/HotAdd.log 2>&1
+        # Will stress only half of free memory
+        __freeMem=`$((__freeMem/2))
+        echo ConsumeMemory: Memory to be stressed: `$__freeMem MB >> /root/HotAdd.log 2>&1
+        __threads=16
+        __chunks=`$((`$__freeMem / `$__threads))
+        echo "Going to start `$__threads instance(s) of stress-ng every 2 seconds, each consuming `$__chunks memory" >> /root/HotAdd.log 2>&1
+        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t 150 --backoff 1500000
+        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
+        wait
+        exit 0
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "ConsumeMem.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}"){
+      Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+    # check the return Value of SendFileToVM
+    if (-not $retVal[-1]){
+      return $false
+    }
+
+    # execute command as job
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+    return $retVal
+  }
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+#
+# Check input arguments
+#
+if ($vmName -eq $null){
+    "Error: VM name is null"
+    return $False
+}
+
+if ($hvServer -eq $null){
+    "Error: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null){
+    "Error: testParams is null"
+    return $False
+}
+
+# Write out test Params
+$testParams
+
+# sshKey used to authenticate ssh connection and send commands
+$sshKey = $null
+
+# IP Address of first VM
+$ipv4 = $null
+
+# Name of first VM
+$vm1Name = $null
+
+# change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?){
+  "Mandatory param RootDir=Path; not found!"
+  return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir){
+  Set-Location -Path $rootDir
+  if (-not $?){
+    "Error: Could not change directory to $rootDir !"
+    return $false
+  }
+  "Changed working directory to $rootDir"
+}
+else{
+  "Error: RootDir = $rootDir is not a valid path"
+  return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1"){
+  . .\setupScripts\TCUtils.ps1
+}
+else{
+  "Error: Could not find setupScripts\TCUtils.ps1"
+  return $false
+}
+
+$params = $testParams.Split(";")
+foreach ($p in $params){
+    $fields = $p.Split("=")
+
+    switch ($fields[0].Trim()){
+      "TC_COVERED"    { $TC_COVERED = $fields[1].Trim() }
+      "ipv4"          { $ipv4       = $fields[1].Trim() }
+      "sshKey"        { $sshKey     = $fields[1].Trim() }
+      "startupMem"  { 
+        $startupMem  = ConvertToMemSize $fields[1].Trim() $hvServer
+
+        if ($startupMem -le 0){
+          "Error: Unable to convert startupMem to int64."
+          return $false
+        }
+        "startupMem: $startupMem"
+      }
+    }
+}
+
+if (-not $sshKey){
+  "Error: Please pass the sshKey to the script."
+  return $false
+}
+
+"This script covers test case: ${TC_COVERED}"
+
+$vm1 = Get-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
+
+if (-not $vm1){
+  "Error: VM $vmName does not exist"
+  return $false
+}
+
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = checkStressNg $ipv4 $sshKey
+
+if (-not $retVal){
+    "Stress-ng is not installed! Please install it before running the memory stress tests."
+    return $false
+}
+
+"Stress-ng is installed! Will begin running memory stress tests shortly."
+
+# Get memory stats from vm1
+start-sleep -s 10
+$sleepPeriod = 60
+
+# get VM1 memory from host and guest
+while ($sleepPeriod -gt 0){
+  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+
+  [int64]$vm1BeforeAssignedGuest = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+
+  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm1BeforeAssignedGuest -gt 0){
+    break
+  }
+
+  $sleepPeriod-= 5
+  start-sleep -s 5
+}
+
+if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm1BeforeAssignedGuest -le 0){
+  "Error: vm1 $vmName reported 0 memory (assigned or demand)."
+  return $False
+}
+
+"Memory stats after $vmName started reporting "
+"  ${vmName}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
+
+# Send Command to consume
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir) ConsumeMemory $ip $sshKey $rootDir } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir)
+if (-not $?){
+  "Error: Unable to start job for creating pressure on $vmName"
+  return $false
+}
+
+# sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
+start-sleep -s 80
+
+# get memory stats while stress-ng is running
+[int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
+[int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
+"Memory stats after $vm1Name started stress-ng"
+"  ${vmName}: assigned - $vm1Assigned | demand - $vm1Demand"
+
+if ($vm1Demand -le $vm1BeforeDemand){
+  "Error: Memory Demand did not increase after starting stress-ng"
+  return $false
+}
+
+# Memory value to be assigned will be 300mb higher than memory demand (below that we might receive an error)
+[int64]$testMem = $vm1.MemoryDemand + 314572800
+
+# Adjust testMem value if it's not an even number
+[int64]$testMem = $testMem / 1048576
+if ($testMem % 2 -eq 0 ){
+  [int64]$testMem = $testMem * 1048576
+}   
+else{
+  [int64]$testMem = $testMem + 1
+  [int64]$testMem = $testMem * 1048576
+}
+
+# Set new memory value
+for ($i=0; $i -lt 3; $i++){
+  Set-VMMemory -VMName $vmName  -ComputerName $hvServer -DynamicMemoryEnabled $false -StartupBytes $testMem 
+  Start-sleep -s 5
+  if ($vm1.MemoryAssigned -eq $testMem){
+    [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB) 
+
+    [int64]$vm1AfterAssignedGuest = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
+    break
+  }
+}
+
+[int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
+if ( $vm1AfterAssigned -eq $vm1BeforeAssigned ){
+  "Error: VM failed to change memory!"
+  "LIS 4.1 or kernel version 4.4 required"
+  return $false
+}
+
+if ( $vm1AfterAssigned -ne ($testMem/1MB)  ){
+    "Error: Memory assigned doesn't match the memory set as parameter!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+    return $false
+}
+
+if ($vm1AfterAssignedGuest -ge $vm1BeforeAssignedGuest){
+    "Error: Guest reports that memory value hasn't decreased!"
+    "Memory stats after $vmName memory was changed "
+    "  ${vmName}: Initial Memory - $vm1BeforeAssignedGuest KB :: After setting new value - $vm1AfterAssignedGuest KB"
+    return $false 
+}
+
+"Memory stats after $vmName memory was changed "
+"  ${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
+"  Reported free memory inside ${vmName}: Before - $vm1BeforeAssignedGuest KB | After - $vm1AfterAssignedGuest KB"
+
+# Wait for jobs to finish now and make sure they exited successfully
+$timeout = 120
+$firstJobStatus = $false
+while ($timeout -gt 0){
+  if ($job1.Status -like "Completed"){
+    $firstJobStatus = $true
+    $retVal = Receive-Job $job1
+    if (-not $retVal[-1]){
+      "Error: Consume Memory script returned false on VM $vmName"
+      return $false
+    }
+    $diff = $totalTimeout - $timeout
+    "Job finished in $diff seconds."
+  }
+  if ($firstJobStatus){
+    break
+  }
+
+  $timeout -= 1
+  start-sleep -s 1
+}
+start-sleep -s 5
+
+# get memory stats after strss-ng stopped running
+[int64]$vm1AfterStressAssigned = ($vm1.MemoryAssigned/1MB)
+[int64]$vm1AfterStressDemand = ($vm1.MemoryDemand/1MB)
+"Memory stats after $vmName stress-ng run"
+"  ${vmName}: assigned - $vm1AfterStressAssigned | demand - $vm1AfterStressDemand"
+
+if ($vm1AfterStressDemand -ge $vm1Demand){
+  "Error: Memory Demand did not decrease after stress-ng stopped"
+  return $false
+}
+
+"VM changed its memory and ran memory stress tests successfully!"
+return $true

--- a/WS2012R2/lisa/xml/ManualMem_HotAdd_Tests.xml
+++ b/WS2012R2/lisa/xml/ManualMem_HotAdd_Tests.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+    Licensed under the Apache License, Version 2.0 (the ""License"");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+    ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+    PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+    See the Apache Version 2.0 License for specific language governing
+    permissions and limitations under the License.
+-->
+
+<!-- THIS TEST SUITE IS THRESHOLD ONLY -->
+<config>
+    <global>
+        <logfileRootDir>TestResults</logfileRootDir>
+        <defaultSnapshot>ICABase</defaultSnapshot>
+        <email>
+            <recipients>
+                <to>myboss@mycompany.com</to>
+                <to>myself@mycompany.com</to>
+            </recipients>
+            <sender>myself@mycompany.com</sender>
+            <subject>LIS_Manual_Memory_tests_run_on_2012R2</subject>
+            <smtpServer>mysmtphost.mycompany.com</smtpServer>
+        </email>
+    </global>
+
+       <testSuites>
+        <suite>
+            <suiteName>ManualMemory</suiteName>
+            <suiteTests>
+                <suiteTest>ManualMem_HotAdd</suiteTest>      
+                <suiteTest>ManualMem_HotRemove</suiteTest> 
+                <suiteTest>ManualMem_SmallIncrease128</suiteTest>  
+                <suiteTest>ManualMem_SmallDecrease128</suiteTest> 
+                <suiteTest>ManualMem_SmallIncrease100</suiteTest>  
+                <suiteTest>ManualMem_SmallDecrease100</suiteTest>
+                <suiteTest>ManualMem_MultipleAddRemove</suiteTest>
+                <suiteTest>ManualMem_StressHotRemove</suiteTest>
+            </suiteTests>
+        </suite>
+    </testSuites>
+
+    <testCases>
+        <test>
+            <testName>ManualMem_HotAdd</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_HotAdd.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-01</param>                                   
+                <param>startupMem=2GB</param>
+                <param>testMem=4GB</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_HotRemove</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_HotAdd.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-02</param>                                   
+                <param>startupMem=4GB</param>
+                <param>testMem=2GB</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_SmallIncrease128</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_HotAdd_Chunks.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-03</param>                                   
+                <param>startupMem=1536MB</param>
+                <param>chunkMem=128MB</param>
+                <param>decrease=no</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_SmallDecrease128</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_HotAdd_Chunks.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-04</param>                                   
+                <param>startupMem=2560MB</param>
+                <param>chunkMem=128MB</param>
+                <param>decrease=yes</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_SmallIncrease100</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_HotAdd_Chunks.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-05</param>                                   
+                <param>startupMem=1648MB</param>
+                <param>chunkMem=100MB</param>
+                <param>decrease=no</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_SmallDecrease100</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_HotAdd_Chunks.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-06</param>                                   
+                <param>startupMem=2448MB</param>
+                <param>chunkMem=100MB</param>
+                <param>decrease=yes</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_MultipleAddRemove</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_MultipleAddRemove.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-07</param>                                   
+                <param>startupMem=2GB</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+
+        <test>
+            <testName>ManualMem_StressHotRemove</testName>
+            <setupScript>setupscripts\ManualMem_Configure.ps1</setupScript>
+            <testScript>setupscripts\ManualMem_StressHotRemove.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=MemHotAdd-08</param>                                   
+                <param>startupMem=4GB</param>
+            </testParams>
+            <timeout>1200</timeout>
+        </test>
+    </testCases>
+
+    <VMs>
+        <vm>
+            <hvServer>localhost</hvServer>
+            <vmName>VM</vmName>
+            <os>Linux</os>
+            <ipv4></ipv4>
+            <sshKey>KEY.ppk</sshKey>
+            <suite>ManualMemory</suite>
+        </vm>
+    </VMs>
+</config>


### PR DESCRIPTION
This suite tests the memory Hot Add capability while Dynamic Memory is
disabled. It has 8 testcases: 

- HotAdd (increase memory with a big value, e.g 2GB)
- HotRemove ( decrease memory with a big value, e.g. 2GB)
- SmallIncrease128 (increase memory with 128MB chunks - 4 repeats) 
- SmallDecrease128 (decrease memory with 128MB chunks - 4 repeats) 
- SmallIncrease100 (increase memory with 100MB chunks - 4 repeats) 
- SmallDecrease100 (decrease memory with 100MB chunks - 4 repeats)  
- MultipleAddRemove ( increase and decrease memory with big values, e.g. 1-2 GB )
- StressHotRemove ( decrease memory while stress test is running)

All tests include a stress test to verify if VM can run workloads after the memory changed.