### PR TITLE
Add verifying VCPU can't be offline testcase

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/redhat_downgrade_kernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/redhat_downgrade_kernel.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+
+ICA_TESTRUNNING="TestRunning"         # The test is running
+ICA_TESTCOMPLETED="TestCompleted"     # The test completed successfully
+ICA_TESTABORTED="TestAborted"         # Error during setup of test
+ICA_TESTFAILED="TestFailed"           # Error during execution of test
+
+CONSTANTS_FILE="constants.sh"
+
+LogMsg() {
+    echo `date "+%a %b %d %T %Y"` ": ${1}"
+}
+
+UpdateTestState() {
+    echo $1 > ~/state.txt
+}
+
+UpdateSummary() {
+    echo $1 >> ~/summary.log
+}
+
+cd ~
+UpdateTestState $ICA_TESTRUNNING
+echo "Updating test case state to running"
+
+if [ -e ~/summary.log ]; then
+    echo "Cleaning up previous copies of summary.log"
+    rm -rf ~/summary.log
+fi
+
+touch ~/summary.log
+
+#
+# Source the constants.sh file to pickup definitions from
+# the ICA automation
+#
+if [ -e ./${CONSTANTS_FILE} ]; then
+    source ${CONSTANTS_FILE}
+else
+    msg="Error: no ${CONSTANTS_FILE} file"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 10
+fi
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+mkdir -p /tmp/test_downkernel/
+if [ $? -ne 0 ]; then
+	echo "Error: Unable to create the test directory." >> ~/summary.log
+	UpdateTestState $ICA_TESTABORTED
+fi
+
+#
+# Make sure constants.sh contains the variables we expect
+#
+if [ "${TC_COVERED:-UNDEFINED}" = "UNDEFINED" ]; then
+    msg="The test parameter TC_COVERED is not defined in ${CONSTANTS_FILE}"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 30
+fi
+if [ "${URL:="UNDEFINED"}" = "UNDEFINED" ]; then
+    msg="Error: the test kernel URL parameter is missing!"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+    UpdateTestState $ICA_TESTFAILED
+    exit 30
+fi
+
+if [ "${DOWNKERNEL:-UNDEFINED}" = "UNDEFINED" ]; then
+    msg="The test parameter DOWNKERNEL is not defined in ${CONSTANTS_FILE}"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 30
+fi
+
+#
+# Echo TCs we cover
+#
+echo "Covers ${TC_COVERED}" > ~/summary.log
+
+declare -a rpmPackage
+
+if is_fedora ; then
+	LogMsg "Downloading files..."
+	echo "Downloading files and Installing packages..." >> ~/summary.log
+	cd /tmp/test_downkernel/
+    IFS=',' read -a rpmPackage <<< "$DOWNKERNEL"
+    for file in ${rpmPackage[@]}; do
+        wget $URL/$file
+        rpm -Uvh $file --oldpackage
+	    if [[ $? -ne 0 ]]; then
+		    UpdateSummary "Error: Unable to install the test kernel ${file}!"
+		    UpdateTestState $ICA_TESTABORTED
+		    exit 1
+	    fi
+	done
+
+	echo "Info: The kernel dependecies pacakages have been successfully installed!" >> ~/summary.log
+
+	LogMsg "Test completed successfully"
+	UpdateTestState $ICA_TESTCOMPLETED
+	exit 0
+fi

--- a/WS2012R2/lisa/remote-scripts/ica/redhat_upgrade_kernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/redhat_upgrade_kernel.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+
+ICA_TESTRUNNING="TestRunning"         # The test is running
+ICA_TESTCOMPLETED="TestCompleted"     # The test completed successfully
+ICA_TESTABORTED="TestAborted"         # Error during setup of test
+ICA_TESTFAILED="TestFailed"           # Error during execution of test
+
+CONSTANTS_FILE="constants.sh"
+
+LogMsg() {
+    echo `date "+%a %b %d %T %Y"` ": ${1}"
+}
+
+UpdateTestState() {
+    echo $1 > ~/state.txt
+}
+
+UpdateSummary() {
+    echo $1 >> ~/summary.log
+}
+
+cd ~
+UpdateTestState $ICA_TESTRUNNING
+echo "Updating test case state to running"
+
+if [ -e ~/summary.log ]; then
+    echo "Cleaning up previous copies of summary.log"
+    rm -rf ~/summary.log
+fi
+
+touch ~/summary.log
+
+#
+# Source the constants.sh file to pickup definitions from
+# the ICA automation
+#
+if [ -e ./${CONSTANTS_FILE} ]; then
+    source ${CONSTANTS_FILE}
+else
+    msg="Error: no ${CONSTANTS_FILE} file"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 10
+fi
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+mkdir -p /tmp/test_upkernel/
+if [ $? -ne 0 ]; then
+	echo "Error: Unable to create the test directory." >> ~/summary.log
+	UpdateTestState $ICA_TESTABORTED
+fi
+
+#
+# Make sure constants.sh contains the variables we expect
+#
+if [ "${TC_COVERED:-UNDEFINED}" = "UNDEFINED" ]; then
+    msg="The test parameter TC_COVERED is not defined in ${CONSTANTS_FILE}"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 30
+fi
+if [ "${URL:="UNDEFINED"}" = "UNDEFINED" ]; then
+    msg="Error: the test kernel URL parameter is missing!"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+    UpdateTestState $ICA_TESTFAILED
+    exit 30
+fi
+if [ "${UPKERNEL:-UNDEFINED}" = "UNDEFINED" ]; then
+    msg="The test parameter UPKERNEL is not defined in ${CONSTANTS_FILE}"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 30
+fi
+
+#
+# Echo TCs we cover
+#
+echo "Covers ${TC_COVERED}" > ~/summary.log
+
+
+
+if is_fedora ; then
+	LogMsg "Downloading files..."
+	echo "Downloading files and Installing packages..." >> ~/summary.log
+	cd /tmp/test_upkernel/
+    IFS=',' read -a rpmPackage <<< "$UPKERNEL"
+    for file in ${rpmPackage[@]}; do
+        wget $URL/$file
+        rpm -Uvh $file
+	    if [[ $? -ne 0 ]]; then
+		    UpdateSummary "Error: Unable to install the test kernel ${file}!"
+		    UpdateTestState $ICA_TESTABORTED
+		    exit 1
+	    fi
+	done
+
+	echo "Info: The kernel dependecies pacakages have been successfully installed!" >> ~/summary.log
+
+	LogMsg "Test completed successfully"
+	UpdateTestState $ICA_TESTCOMPLETED
+	exit 0
+fi

--- a/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved. 
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0  
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+########################################################################
+#
+# VCPU_verify_online.sh
+#
+# Description:
+#	This script was created to automate the testing of VCPU online or offline.
+#   This script will verify if all the CPUs can be offline by checking
+#	the /proc/cpuinfo file.
+#	The VM is configured with 4 CPU cores as part of the setup script,
+#	as each core can't be offline except vcpu0 for a successful test pass.
+#
+#	The test performs the following steps:
+#		1. Configures the VM with 4 cores (see the test case XML definition)	
+#		2. Make sure we have a constants.sh file.
+#		3. Looks for the Hyper-v timer property of each CPU under /proc/cpuinfo
+#		4. Verifies if each CPU can't be offline exinclude VCPU0.
+#     
+#	To pass test parameters into test cases, the host will create
+#	a file named constants.sh.  This file contains one or more
+#	variable definition.
+#
+# Note: The Host of Hyper-V 2012 R2 don't support the CPU online or offline, so
+# To make sure the cpu on guest can't be offline.
+################################################################
+
+ICA_TESTRUNNING="TestRunning"      # The test is running
+ICA_TESTCOMPLETED="TestCompleted"  # The test completed successfully
+ICA_TESTABORTED="TestAborted"      # Error during setup of test
+ICA_TESTFAILED="TestFailed"        # Error during execution of test
+
+CONSTANTS_FILE="constants.sh"
+nonCPU0inter=0
+
+LogMsg()
+{
+    echo `date "+%a %b %d %T %Y"` : ${1}    # To add the timestamp to the log file
+}
+
+UpdateTestState()
+{
+    echo $1 > $HOME/state.txt
+}
+
+#
+# Update LISA with the current status
+#
+cd ~
+UpdateTestState $ICA_TESTRUNNING
+LogMsg "Updating test case state to running"
+
+#
+# Source the constants file
+#
+if [ -e ./${CONSTANTS_FILE} ]; then
+    source ${CONSTANTS_FILE}
+else
+    msg="Error: no ${CONSTANTS_FILE} file"
+    LogMsg $msg
+    echo $msg >> ~/summary.log
+    UpdateTestState $ICA_TESTABORTED
+    exit 10
+fi
+
+if [ -e ~/summary.log ]; then
+    LogMsg "Cleaning up previous copies of summary.log"
+    rm -rf ~/summary.log
+fi
+
+#
+# Identifying the test-case ID
+#
+if [ ! ${TC_COVERED} ]; then
+    LogMsg "The TC_COVERED variable is not defined!"
+	echo "The TC_COVERED variable is not defined!" >> ~/summary.log
+fi
+
+echo "This script covers test case: ${TC_COVERED}" >> ~/summary.log
+
+#
+# Getting the CPUs count
+#
+cpu_count=$(grep -i processor -o /proc/cpuinfo | wc -l)
+echo "${cpu_count} CPU cores detected" >> ~/summary.log
+
+#
+# Verifying all CPUs can't be online except CPU0 
+#
+for ((cpu=1 ; cpu<=$cpu_count ; cpu++)) ;do
+    LogMsg "Checking the $cpu on /sys/device/...."
+    __file_path="/sys/devices/system/cpu/cpu$cpu/online"
+    if [ -e "$__file_path" ]; then
+        echo 0 > $__file_path > /dev/null 2>&1
+        val=`cat $__file_path`
+        if [ $val -ne 0 ]; then
+            LogMsg "The ${cpu} can't be offline!"
+            echo "The ${cpu} can't be offline!" >> ~/summary.log
+        else
+            LogMsg "The ${cpu} can be offline!"
+            echo "The ${cpu} can be offline!" >> ~/summary.log
+            UpdateTestState "TestFailed"
+            exit 80
+        fi
+    fi
+done
+
+LogMsg "Test completed successfully"
+UpdateTestState $ICA_TESTCOMPLETED
+exit 0

--- a/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
@@ -70,6 +70,11 @@ cd ~
 UpdateTestState $ICA_TESTRUNNING
 LogMsg "Updating test case state to running"
 
+if [ -e ~/summary.log ]; then
+    LogMsg "Cleaning up previous copies of summary.log"
+    rm -rf ~/summary.log
+fi
+
 #
 # Source the constants file
 #
@@ -81,11 +86,6 @@ else
     echo $msg >> ~/summary.log
     UpdateTestState $ICA_TESTABORTED
     exit 10
-fi
-
-if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
-    rm -rf ~/summary.log
 fi
 
 #

--- a/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
@@ -105,7 +105,7 @@ cpu_count=$(grep -i processor -o /proc/cpuinfo | wc -l)
 echo "${cpu_count} CPU cores detected" >> ~/summary.log
 
 #
-# Verifying all CPUs can't be online except CPU0 
+# Verifying all CPUs can't be offline except CPU0 
 #
 for ((cpu=1 ; cpu<=$cpu_count ; cpu++)) ;do
     LogMsg "Checking the $cpu on /sys/device/...."

--- a/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/vcpu_verify_online.sh
@@ -74,6 +74,7 @@ if [ -e ~/summary.log ]; then
     LogMsg "Cleaning up previous copies of summary.log"
     rm -rf ~/summary.log
 fi
+touch ~/summary.log
 
 #
 # Source the constants file

--- a/WS2012R2/lisa/setupscripts/Kernel.ps1
+++ b/WS2012R2/lisa/setupscripts/Kernel.ps1
@@ -1,0 +1,240 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+
+<#
+.Synopsis
+    Verify the kernel upgrade/downgrade on RHEL guest.
+.Description
+    Ensure the kernel upgrade/downgrade successfully on RHEL VM.
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>redhat_update_kernel</testName>
+            <testScript>setupscripts\kernel.ps1</testScript>
+            <files>remote-scripts\ica\redhat_upgrade_kernel.sh,remote-scripts\ica\redhat_downgrade_kernel.sh,remote-scripts\ica\utils.sh</files>
+            <testParams>
+                <param>URL=http://PATH/TO/TEST/KERNEL</param>
+                <param>DOWNKERNEL=kernel-3.10.0-305.el7.x86_64.rpm</param>
+                <param>UPKERNEL=kernel-abi-whitelists-3.10.0-364.el7.noarch.rpm,kernel-3.10.0-364.el7.x86_64.rpm</param>
+                <param>TC_COVERED=KERNEL-01</param>
+            </testParams>
+            <timeout>900</timeout>
+            <OnError>Continue</OnError>
+        </test>
+.Parameter vmName
+    Name of the VM to read intrinsic data from.
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+.Parameter testParams
+    Test data for this test case
+.Parameter of URL
+    The address to download kernel
+.Parameter of DOWNKERNEL
+    The kernel to downgrade
+.Paramter of UPKERNEL
+    The kernel of upgrade
+.Example
+    setupScripts\KvpBasic.ps1 -vmName "myVm" -hvServer "localhost -TestParams "rootDir=c:\lisa\trunk\lisa;URL=http://../pub/kernel/;DOWNKERNEL=kernel-3.10.0-305.el7.x86_64.rpm;UPKERNEL=kernel-abi-whitelists-3.10.0-364.el7.noarch.rpm,kernel-3.10.0-364.el7.x86_64.rpm;TC_COVERED=KERNEL-01;"
+.Link
+
+    None.
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+function CheckResults(){
+    #
+    # Checking test results
+    #
+    $stateFile = "state.txt"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} .
+
+    if ($?) {
+        if (test-path $stateFile){
+            $contents = Get-Content $stateFile
+            if ($null -ne $contents){
+                if ($contents.Contains('TestCompleted') -eq $True) {                    
+                    Write-Output "Info: Test ended successfully"
+                    $retVal = $True
+                }
+                if ($contents.Contains('TestAborted') -eq $True) {
+                    Write-Output "Info: State file contains TestAborted failed"
+                    $retVal = $False                           
+                }
+                if ($contents.Contains('TestFailed') -eq $True) {
+                    Write-Output "Info: State file contains TestFailed failed"
+                    $retVal = $False                           
+                }
+            }    
+            else {
+                Write-Output "ERROR: state file is empty!"
+                $retVal = $False    
+            }
+        }
+        
+    }
+    return $retval
+}
+
+#
+# MAIN SCRIPT
+#
+$retVal = $false
+$sshKey = $null
+$ipv4 = $null
+$UpKernel = $null
+$DownKernel = $null
+
+#
+# Check input arguments
+#
+if ($vmName -eq $null) {
+    "Error: VM name is null"
+    return $retVal
+}
+
+if ($hvServer -eq $null) {
+    "Error: hvServer is null"
+    return $retVal
+}
+
+$params = $testParams.Split(";")
+
+foreach ($p in $params) {
+    $fields = $p.Split("=")
+    
+    switch ($fields[0].Trim()) {
+        "rootDir"   { $rootDir = $fields[1].Trim() }
+        "sshKey" { $sshKey  = $fields[1].Trim() }
+        "ipv4"   {$ipv4 = $fields[1].Trim()}
+        "TestLogDir" {$logdir = $fields[1].Trim()}
+        "UpKernel" {$UpKernel = $fields[1].Trim()}
+        "DownKernel" {$DownKernel = $fields[1].Trim()}
+        default  {}
+    }
+}
+
+if ($null -eq $sshKey) {
+    "Error: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4) {
+    "Error: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if (-not $rootDir)
+{
+    "Warn : no rootdir was specified"
+}
+else
+{
+    cd $rootDir
+}
+$kernelupArgs = $UpKernel.Trim().Split(',')
+$kernelUpVersion = $kernelupArgs[1].Trim()
+
+$kernelDownArgs = $DownKernel.Trim().Split(',')
+$kernelDownVersion = $kernelDownArgs[0].Trim()
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+
+$retVal = SendCommandToVM $ipv4 $sshKey "cd /root && dos2unix redhat_upgrade_kernel.sh && chmod u+x redhat_upgrade_kernel.sh && ./redhat_upgrade_kernel.sh"
+
+#
+# Rebooting the VM in order to change new kernel
+#
+$retVal = SendCommandToVM $ipv4 $sshKey "reboot"
+Write-Output "Rebooting the VM."
+
+
+#
+# Waiting the VM to start up
+#
+Write-Output "Waiting the VM to have a connection..."
+do {
+    sleep 5
+} until(Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue | ? { $_.TcpTestSucceeded } )
+
+$kernelPackage =  echo y | bin\plink -i ssh\${sshKey} root@${ipv4} "uname -r"
+if (not $kernelUpVersion -match $kernelPackage)
+{
+    Write-Output "The Kernel version have some problem"
+    return $False
+} 
+
+
+bin\pscp -q -i ssh\${sshKey} root@${ipv4}:summary.log $logdir
+$retVal = CheckResults $sshKey $ipv4
+if (-not $retVal)
+{
+    "ERROR: Upgrade Results are not as expected(configuration problems). Test Aborted."
+    return $false
+}
+
+#
+# Waiting the VM to have a connection
+#
+Write-Output "Checking the VM connection after kernel downupgrade..."
+$retVal = SendCommandToVM $ipv4 $sshKey "cd /root && dos2unix redhat_downgrade_kernel.sh && chmod u+x redhat_downgrade_kernel.sh && ./redhat_downgrade_kernel.sh"
+
+#
+# Rebooting the VM in order to change new kernel
+#
+$retVal = SendCommandToVM $ipv4 $sshKey "reboot"
+Write-Output "Rebooting the VM."
+#
+# Waiting the VM to start up
+#
+Write-Output "Waiting the VM to have a connection..."
+
+do {
+    sleep 5
+} until(Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue | ? { $_.TcpTestSucceeded } )
+
+$kernelPackage =  echo y | bin\plink -i ssh\${sshKey} root@${ipv4} "uname -r"
+if (not $kernelDownVersion -match $kernelPackage)
+{
+    Write-Output "The Kernel version have some problem"
+    return $False
+}
+
+$retVal = CheckResults $sshKey $ipv4
+if (-not $retVal)
+{
+    "ERROR: Downgrade Results are not as expected(configuration problems). Test Aborted."
+    return $false
+}
+return $retVal

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -52,6 +52,7 @@
             <suiteTest>StressReloadModules</suiteTest>
             <suiteTest>FloppyDisk</suiteTest>
             <suiteTest>CDmount</suiteTest>
+            <suiteTest>VCPU_verify_online</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -220,6 +221,19 @@
             <noReboot>False</noReboot>
         </test>
 
+        <test>
+		<testName>VCPU_verify_online</testName>
+		<testScript>vcpu_verify_online.sh</testScript>
+		<setupScript>setupScripts\ChangeCPU.ps1</setupScript>
+		<files>remote-scripts/ica/vcpu_verify_online.sh</files>
+		<timeout>600</timeout>
+		<onError>Continue</onError>
+		<noReboot>False</noReboot>
+		<testParams>
+            		<param>TC_COVERED=CORE-21</param>
+			<param>vCPU=4</param>
+            	</testParams>
+        </test>
     </testCases>
 
     <VMs>

--- a/WS2012R2/lisa/xml/RedHat_test_kernel.xml
+++ b/WS2012R2/lisa/xml/RedHat_test_kernel.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+ Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+ Copyright (c) Microsoft Corporation
+
+ All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the ""License"");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+ ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+ PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+ See the Apache Version 2.0 License for specific language governing
+ permissions and limitations under the License.
+-->
+
+<config>
+    <global>
+        <logfileRootDir>TestResults</logfileRootDir>
+        <defaultSnapshot>ICABase</defaultSnapshot>
+        <email>
+            <recipients>
+                <to>myself@mycompany.com</to>
+            </recipients>
+            <sender>myself@mycompany.com</sender>
+            <subject>Redhat test kernel update Test Results</subject>
+            <smtpServer>mysmtphost.mycompany.com</smtpServer>
+        </email>
+       <!-- Optional testParams go here -->
+    </global>
+
+    <testSuites>
+        <suite>
+            <suiteName>Redhat</suiteName>
+            <suiteTests>
+                <suiteTest>redhat_update_kernel</suiteTest>
+            </suiteTests>
+        </suite>
+    </testSuites>
+
+    <testCases>
+        <test>
+            <testName>redhat_update_kernel</testName>
+            <testScript>setupscripts\kernel.ps1</testScript>
+            <files>remote-scripts\ica\redhat_upgrade_kernel.sh,remote-scripts\ica\redhat_downgrade_kernel.sh,remote-scripts\ica\utils.sh</files>
+            <testParams>
+                <!--<param>URL=http://PATH/TO/TEST/KERNEL</param>-->
+                <param>URL=http://10.66.10.35/pub/kernel/</param>
+                <param>DOWNKERNEL=kernel-3.10.0-305.el7.x86_64.rpm</param>
+                <param>UPKERNEL=kernel-abi-whitelists-3.10.0-364.el7.noarch.rpm,kernel-3.10.0-364.el7.x86_64.rpm</param>
+                <param>TC_COVERED=KERNEL-01</param>
+            </testParams>
+            <timeout>900</timeout>
+            <OnError>Continue</OnError>
+        </test>
+    </testCases>
+
+    <VMs>        
+	    <vm>
+            <hvServer>localhost</hvServer>
+            <vmName>RHEL-7.2-20151030.0</vmName>
+            <os>Linux</os>
+            <ipv4></ipv4>
+            <sshKey>id_rsa.ppk</sshKey>
+            <suite>Redhat</suite>
+        </vm>
+    </VMs>
+</config>


### PR DESCRIPTION
Add case to make sure the vcpu can't be offline on Guest. The Hyper-V 2012 R2 don't support CPU onlining or offlining, so the guest also can't be offline. 