### PR TITLE
fix the list of checking modules

### DIFF
--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -289,7 +289,7 @@
             <files>remote-scripts/ica/modules_check.sh</files>
             <testparams>
                 <param>TC_COVERED=CORE-24</param>
-                <param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko hid-hyperv.ko hyperv_fb.ko)</param>
+                <param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko)</param>
             </testparams>
             <timeout>600</timeout>
         </test>

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -289,7 +289,7 @@
             <files>remote-scripts/ica/modules_check.sh</files>
             <testparams>
                 <param>TC_COVERED=CORE-24</param>
-                <param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hv_utils.ko hyperv-keyboard.ko hid-hyperv.ko)</param>
+                <param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko hid-hyperv.ko hyperv_fb.ko)</param>
             </testparams>
             <timeout>600</timeout>
         </test>


### PR DESCRIPTION
The hv_utils.ko that used to connect with integration serviceisn't necessary in VM temporary booting process, however the hyperv_fb.ko should add into checking list, so that the it is used when VM is booted. 