### PR TITLE
fix mirror of getting error num of CPU and covert string to int

### DIFF
--- a/WS2012R2/lisa/setupscripts/ChangeCPU.ps1
+++ b/WS2012R2/lisa/setupscripts/ChangeCPU.ps1
@@ -119,7 +119,7 @@ foreach ($p in $params)
     
     if ($fields[0].Trim() -eq "VCPU")
     {
-        $numCPUs = $fields[1].Trim()
+        $numCPUs = [int]$fields[1].Trim()
     }
     if ($fields[0].Trim() -eq "NumaNodes")
     {
@@ -145,13 +145,16 @@ if ($numCPUs -eq 0)
 #
 # do a sanity check on the value provided in the testParams
 #
-$maxCPUs = 2
+$maxCPUs = 0
 $procs = get-wmiobject -computername $hvServer win32_processor
 if ($procs)
 {
     if ($procs -is [array])
     {
-        $maxCPUs = $procs[0].NumberOfLogicalProcessors
+        foreach ($n in $procs)
+        {
+            $maxCPUs += $n.NumberOfLogicalProcessors
+        }
     }
     else
     {

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -38,7 +38,25 @@
         <suite>
             <suiteName>Core</suiteName>
             <suiteTests>
+            <suiteTest>VMHeartbeat</suiteTest>
+            <suiteTest>TimeSync</suiteTest>
+            <suiteTest>TimeSync_NTP</suiteTest>
+            <suiteTest>TimeSync_SavedVM</suiteTest>
+            <suiteTest>LISShutdownVM</suiteTest>
+            <suiteTest>LISShutDownVMAndResetCpuCount</suiteTest>
+            <suiteTest>VerifyLisModules</suiteTest>
+            <suiteTest>Multi_Cpu_Test</suiteTest>
+            <suiteTest>Verify_LISModules_Version</suiteTest>
+            <suiteTest>VerifyItegratedShutdownService</suiteTest>
+            <suiteTest>RebootDifferentMemSettings</suiteTest>
+            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>FloppyDisk</suiteTest>
+            <suiteTest>CDmount</suiteTest>
+            <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>CheckNuma</suiteTest>
+            <suiteTest>CheckNuma_Maximum</suiteTest>
+            <suiteTest>initrd_modules_check</suiteTest>
+            <suiteTest>check_clocksource</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -38,25 +38,7 @@
         <suite>
             <suiteName>Core</suiteName>
             <suiteTests>
-            <suiteTest>VMHeartbeat</suiteTest>
-            <suiteTest>TimeSync</suiteTest>
-            <suiteTest>TimeSync_NTP</suiteTest>
-            <suiteTest>TimeSync_SavedVM</suiteTest>
-            <suiteTest>LISShutdownVM</suiteTest>
-            <suiteTest>LISShutDownVMAndResetCpuCount</suiteTest>
-            <suiteTest>VerifyLisModules</suiteTest>
-            <suiteTest>Multi_Cpu_Test</suiteTest>
-            <suiteTest>Verify_LISModules_Version</suiteTest>
-            <suiteTest>VerifyItegratedShutdownService</suiteTest>
-            <suiteTest>RebootDifferentMemSettings</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
-            <suiteTest>FloppyDisk</suiteTest>
-            <suiteTest>CDmount</suiteTest>
-            <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>CheckNuma</suiteTest>
-            <suiteTest>CheckNuma_Maximum</suiteTest>
-            <suiteTest>initrd_modules_check</suiteTest>
-            <suiteTest>check_clocksource</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -247,10 +229,11 @@
             </setupScript>
             <testScript>setupScripts\NUMA.ps1</testScript>
             <files>remote-scripts\ica\utils.sh</files>
+		    <timeout>600</timeout>
+		    <onError>Continue</onError>
             <cleanupScript>setupScripts\RevertSnapshot.ps1</cleanupScript>
             <testParams>
                 <param>TC_COVERED=CORE-22</param>
-                <param>vmName=VMName</param>
                 <param>enableDM=no</param>
                 <param>staticMem=2048MB</param>
                 <param>memWeight=0</param>
@@ -272,6 +255,8 @@
             </setupScript>
             <testScript>setupScripts\NUMA.ps1</testScript>
             <files>remote-scripts\ica\utils.sh</files>
+		    <timeout>600</timeout>
+		    <onError>Continue</onError>
             <testParams>
                 <param>TC_COVERED=CORE-23</param>
                 <param>VCPU=8</param>
@@ -292,6 +277,7 @@
                 <param>TC_COVERED=CORE-24</param>
                 <param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko)</param>
             </testparams>
+		    <onError>Continue</onError>
             <timeout>600</timeout>
         </test>
 


### PR DESCRIPTION
1. xml need to add onError or else the following cases can't be run 
2. fix get the maxCPUs
3. convert sting get from xml to int otherwise here is error:
`if ($numCPUs -lt 1 -or $numCPUs -gt $maxCPUs)
166 {
167     "Error: Incorrect VCPU value: $numCPUs (max CPUs = $maxCPUs)"
168 }
`
if $maxCPUs=24 rather than vcpu is set 4 the result is error