### PR TITLE
Added Gen2 support for PXE Install Test Suite

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/pxe_install.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/pxe_install.sh
@@ -225,6 +225,7 @@ elif [ $distro == "sles" ]; then
         fi
         echo "  initrdefi uefi/PXE/initrd" >> /var/lib/tftpboot/uefi/grub.cfg
         echo "  }" >> /var/lib/tftpboot/uefi/grub.cfg
+
     elif [ $generation -eq 1 ]; then
         # Copy boot image files to tftp server
         cp /mnt/boot/x86_64/loader/linux /var/lib/tftpboot/pxelinux/PXE
@@ -244,8 +245,21 @@ elif [ $distro == "ubuntu" ]; then
     # Download latest netboot files
     wget http://archive.ubuntu.com/ubuntu/dists/xenial/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz
     wget http://archive.ubuntu.com/ubuntu/dists/xenial/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux
-    
-    if [ $generation -eq 1 ]; then
+    if [ $generation -eq 2 ]; then
+        # Copy boot image files to tftp server
+        cp linux /var/lib/tftpboot/uefi/PXE/
+        cp initrd.gz /var/lib/tftpboot/uefi/PXE/
+
+        echo "  menuentry 'Ubuntu' {" >> /var/lib/tftpboot/uefi/grub.cfg
+        if [ $willInstall == "no" ]; then
+            echo "  linuxefi uefi/PXE/linux auto=true priority=critical quiet --" >> /var/lib/tftpboot/uefi/grub.cfg
+        else
+            echo "  linuxefi uefi/PXE/linux auto=true priority=critical interface=auto url=http://10.10.10.10/ubuntu16/preseed/ubuntuGen2.seed" >> /var/lib/tftpboot/uefi/grub.cfg
+        fi
+        echo "  initrdefi uefi/PXE/initrd.gz" >> /var/lib/tftpboot/uefi/grub.cfg
+        echo "  }" >> /var/lib/tftpboot/uefi/grub.cfg
+
+    elif [ $generation -eq 1 ]; then
        
         # Copy boot image files to tftp server
         cp linux /var/lib/tftpboot/pxelinux/PXE
@@ -258,7 +272,7 @@ elif [ $distro == "ubuntu" ]; then
         if [ $willInstall == "no" ]; then
             echo "append initrd=ubuntu16/initrd.gz auto=true priority=critical quiet --" >> /var/lib/tftpboot/pxelinux/pxelinux.cfg/default
         else
-            echo "append initrd=ubuntu16/initrd.gz auto=true priority=critical interface=auto file=http://10.10.10.10/ubuntu16/preseed/ubuntu.seed vga=788 ks=http://10.10.10.10/ubuntu16/ks.cfg quiet --" >> /var/lib/tftpboot/pxelinux/pxelinux.cfg/default
+            echo "append initrd=ubuntu16/initrd.gz auto=true priority=critical interface=auto url=http://10.10.10.10/ubuntu16/preseed/ubuntu.seed vga=788 quiet --" >> /var/lib/tftpboot/pxelinux/pxelinux.cfg/default
         fi
     fi    
 fi

--- a/WS2012R2/lisa/xml/PXE_gen2.xml
+++ b/WS2012R2/lisa/xml/PXE_gen2.xml
@@ -41,7 +41,7 @@
         <suite>
             <suiteName>PXE</suiteName>
             <suiteTests>
-                <suiteTest>PXE_basic</suiteTest>   
+                <suiteTest>PXE_basic</suiteTest>  
                 <suiteTest>PXE_install_singleCpu</suiteTest>
                 <suiteTest>PXE_install_SMP</suiteTest>
             </suiteTests>
@@ -55,12 +55,12 @@
             <testScript>setupscripts\pxe_install.ps1</testScript>
             <cleanupScript>setupScripts\RemoveIsoFromDvd.ps1</cleanupScript>
             <testParams>
-                <param>TC_COVERED=PXE-01</param>
+                <param>TC_COVERED=PXE-03</param>
                 <param>VM2NAME=PXE_CLIENT</param>
                 <!-- IsoFilename is mandatory for rhel or sles-->
-                <param>IsoFilename=isoName</param>
-                <param>generation=1</param> 
-                <param>willInstall=no</param> 
+                <!-- <param>IsoFilename=isoName</param>  -->
+                <param>generation=2</param> 
+                <param>willInstall=no</param>   
                 <!-- Mandatory: please complete with rhel, sles or ubuntu -->
                 <param>distro=rhel</param>
             </testParams>
@@ -74,12 +74,12 @@
             <testScript>setupscripts\pxe_install.ps1</testScript>
             <cleanupScript>setupScripts\RemoveIsoFromDvd.ps1</cleanupScript>
             <testParams>
-                <param>TC_COVERED=PXE-04</param>
+                <param>TC_COVERED=PXE-06</param>
                 <param>VM2NAME=PXE_CLIENT</param>
                 <!-- IsoFilename is mandatory for rhel or sles-->
                 <param>IsoFilename=isoName</param>
-                <param>generation=1</param> 
-                <param>willInstall=yes</param>   
+                <param>generation=2</param> 
+                <param>willInstall=yes</param>    
                 <!-- Mandatory: please complete with rhel, sles or ubuntu -->
                 <param>distro=rhel</param>
             </testParams>
@@ -93,15 +93,15 @@
             <testScript>setupscripts\pxe_install.ps1</testScript>
             <cleanupScript>setupScripts\RemoveIsoFromDvd.ps1</cleanupScript>
             <testParams>
-                <param>TC_COVERED=PXE-05</param>
+                <param>TC_COVERED=PXE-07</param>
                 <param>VM2NAME=PXE_CLIENT</param>
                 <!-- IsoFilename is mandatory for rhel or sles-->
-                <param>IsoFilename=isoName</param>
-                <param>generation=1</param> 
+                <!-- <param>IsoFilename=isoName</param> -->
+                <param>generation=2</param> 
                 <param>willInstall=yes</param>  
-                <param>VCPU=4</param>    
+                <param>VCPU=4</param>  
                 <!-- Mandatory: please complete with rhel, sles or ubuntu -->
-                <param>distro=rhel</param>
+                <param>distro=ubuntu</param>
             </testParams>
             <timeout>2400</timeout>
             <OnError>Continue</OnError>
@@ -129,8 +129,8 @@
                <numCPUs>1</numCPUs>
                <memSize>2048</memSize>
                <disableDiff>True</disableDiff>
-               <nic>Legacy,pxe,001600112233</nic>
-               <generation>1</generation>
+               <nic>VMBus,pxe,001600112233</nic>
+               <generation>2</generation>
                <secureBoot>false</secureBoot>
             </hardware>
         </vm>


### PR DESCRIPTION
PXE_gen2.xml creates a generation 2 VM and verifies/installs a supported
linux distro on it.
Supported Linux distributions: RHEL, SLES, Ubuntu

Important: For this test suite to work, you need to have a PXE Server
already set up with tftp, dhcp and http servers