### PR TITLE
Added Production Checkpoint test suite

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/PC_Stop_VSS_Daemon.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/PC_Stop_VSS_Daemon.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+ICA_TESTRUNNING="TestRunning"
+ICA_TESTCOMPLETED="TestCompleted"
+ICA_TESTABORTED="TestAborted"
+
+#######################################################################
+# Adds a timestamp to the log file
+#######################################################################
+LogMsg()
+{
+    echo `date "+%a %b %d %T %Y"` : ${1}
+}
+
+#######################################################################
+# Updates the summary.log file
+#######################################################################
+UpdateSummary()
+{
+    echo $1 >> ~/summary.log
+}
+
+#######################################################################
+# Keeps track of the state of the test
+#######################################################################
+UpdateTestState()
+{
+    echo $1 > ~/state.txt
+}
+
+#######################################################################
+# Main script body
+#######################################################################
+
+# Create the state.txt file so ICA knows we are running
+UpdateTestState $ICA_TESTRUNNING
+
+# Cleanup any old summary.log files
+if [ -e ~/summary.log ]; then
+    rm -rf ~/summary.log
+fi
+
+# Source the constants file
+if [ -e constants.sh ]; then
+    . constants.sh
+else
+    LogMsg "WARN: Unable to source the constants file."
+fi
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+
+
+if is_rhel7 ; then #If the system is using systemd we use systemctl
+    if [[ "$(systemctl is-active hypervvssd)" == "active" ]] || \
+       [[ "$(systemctl is-active hv_vss_daemon)" == "active" ]]; then
+
+        LogMsg "VSS Daemon is running, we will try to stop it gracefully"
+        /bin/systemctl stop hypervvssd.service
+        if [ $? -ne 0 ]; then
+            LogMsg "ERROR: Failed to stop VSS Daemon"
+            UpdateTestState $ICA_TESTABORTED
+            exit 1
+        fi
+        LogMsg "Succesfully stopped the VSS Daemon"
+        UpdateTestState $ICA_TESTCOMPLETED
+        exit 0
+
+    elif [[ "$(systemctl is-active hypervvssd)" == "unknown" ]] && \
+         [[ "$(systemctl is-active hv_vss_daemon)" == "unknown" ]]; then
+
+        LogMsg "ERROR: VSS Daemon not installed, test aborted"
+        UpdateTestState $ICA_TESTABORTED
+        exit 1
+
+    else
+        LogMsg "ERROR: VSS Daemon is installed but not running. Test aborted"
+        UpdateTestState $ICA_TESTABORTED
+        exit 1
+    fi
+
+else # For older systems we use ps
+    if [[ $(ps -ef | grep 'hypervvssd') ]] || \
+       [[ $(ps -ef | grep '[h]v_vss_daemon') ]]; then
+
+        LogMsg "VSS Daemon is running"
+        service hypervvssd stop
+        if [ $? -ne 0 ]; then
+            LogMsg "ERROR: Failed to stop VSS Daemon"
+            UpdateTestState $ICA_TESTABORTED
+            exit 1
+        fi
+        LogMsg "Succesfully stopped the VSS Daemon"
+        UpdateTestState $ICA_TESTCOMPLETED
+        exit 0
+    else
+        LogMsg "ERROR: VSS Daemon not running, test aborted"
+        UpdateTestState $ICA_TESTABORTED
+        exit 1
+    fi
+fi

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint.ps1
@@ -1,0 +1,448 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+
+<#
+.Synopsis
+    Verify Production Checkpoint feature.
+
+.Description
+    Tests to see if the virtual machine Production Checkpoint operation
+    works as expected. Steps:
+     - Create a file on VM
+     - Take a Production Checkpoint
+     - Create a second file on VM
+     - Revert to the Production Checkpoint
+     - Boot the VM, only the first file should exist
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>ProductionCheckpoint</testName>
+            <testScript>setupscripts\Production_checkpoint.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-01</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+
+.Example
+    setupScripts\Production_checkpoint.ps1 -vmName "myVm" -hvServer "localhost"
+     -TestParams "TC_COVERED=PC-01"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# Runs a remote script on the VM an returns the log.
+#######################################################################
+function RunRemoteScript($remoteScript)
+{
+    $retValue = $False
+    $stateFile     = "state.txt"
+    $TestCompleted = "TestCompleted"
+    $TestAborted   = "TestAborted"
+    $TestRunning   = "TestRunning"
+    $timeout       = 6000
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}"
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "./runtest.sh"
+
+    # Return the state file
+    while ($timeout -ne 0 )
+    {
+    .\bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} . #| out-null
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $stateFile)
+        {
+            $contents = Get-Content -Path $stateFile
+            if ($null -ne $contents)
+            {
+                    if ($contents -eq $TestCompleted)
+                    {
+                        Write-Output "Info : state file contains Testcompleted"
+                        $retValue = $True
+                        break
+
+                    }
+
+                    if ($contents -eq $TestAborted)
+                    {
+                         Write-Output "Info : State file contains TestAborted failed. "
+                         break
+
+                    }
+                    #Start-Sleep -s 1
+                    $timeout--
+
+                    if ($timeout -eq 0)
+                    {
+                        Write-Output "Error : Timed out on Test Running , Exiting test execution."
+                        break
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn : state file is empty"
+                break
+            }
+
+        }
+        else
+        {
+             Write-Host "Warn : ssh reported success, but state file was not copied"
+             break
+        }
+    }
+    else #
+    {
+         Write-Output "Error : pscp exit status = $sts"
+         Write-Output "Error : unable to pull state.txt from VM."
+         break
+    }
+    }
+
+    # Get the logs
+    $remoteScriptLog = $remoteScript+".log"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${remoteScriptLog} .
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $remoteScriptLog)
+        {
+            $contents = Get-Content -Path $remoteScriptLog
+            if ($null -ne $contents)
+            {
+                    if ($null -ne ${TestLogDir})
+                    {
+                        move "${remoteScriptLog}" "${TestLogDir}\${remoteScriptLog}"
+
+                    }
+
+                    else
+                    {
+                        Write-Output "INFO: $remoteScriptLog is copied in ${rootDir}"
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn: $remoteScriptLog is empty"
+            }
+        }
+        else
+        {
+             Write-Output "Warn: ssh reported success, but $remoteScriptLog file was not copied"
+        }
+    }
+
+    # Cleanup
+    del state.txt -ErrorAction "SilentlyContinue"
+    del runtest.sh -ErrorAction "SilentlyContinue"
+
+    return $retValue
+}
+
+#######################################################################
+# Create a file on the VM.
+#######################################################################
+function CreateFile([string] $fileName)
+{
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "touch ${fileName}"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to create file" | Out-File -Append $summaryLog
+        return $False
+    }
+
+    return  $True
+}
+
+#######################################################################
+# Checks if test file is present or not.
+#######################################################################
+function CheckFile([string] $fileName)
+{
+    $retVal = $true
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "stat ${fileName} 2>/dev/null" | out-null
+    if (-not $?)
+    {
+        $retVal = $false
+    }
+
+    return  $retVal
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+$retVal = $false
+
+# Define and cleanup the summaryLog
+$summaryLog  = "${vmName}_summary.log"
+echo "Covers Production Checkpoint Testing" > $summaryLog
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $retVal
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED"  { $TC_COVERED = $fields[1].Trim() }
+    "sshKey"      { $sshKey = $fields[1].Trim() }
+    "ipv4"        { $ipv4 = $fields[1].Trim() }
+    "rootdir"     { $rootDir = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+echo $params
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source the TCUtils.ps1 file
+. .\setupscripts\TCUtils.ps1
+
+#Check if the host supports production checkpoints
+$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
+if (-not $osInfo)
+{
+    "Error: Unable to collect Operating System information"
+    return $False
+}
+
+[System.Int32]$buildNR = $osInfo.BuildNumber
+
+if ($buildNR -le 10500){
+    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
+    return $false
+}
+
+# Check if the Vm VHD in not on the same drive as the backup destination
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+if (-not $vm)
+{
+    "Error: VM '${vmName}' does not exist"
+    return $False
+}
+
+# Send utils.sh to VM
+echo y | .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\utils.sh root@${ipv4}:
+if (-not $?)
+{
+    Write-Output "ERROR: Unable to copy utils.sh to the VM"
+    return $False
+}
+
+# Check to see Linux VM is running VSS backup daemon
+$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+Write-Output "VSS Daemon is running " >> $summaryLog
+
+# Create a file on the VM
+$sts = CreateFile "TestFile1"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR: Can not create file"
+    return $False
+}
+
+#Check if we can set the Production Checkpoint as default
+if ($vm.CheckpointType -ne "ProductionOnly"){
+    Set-VM -Name $vmName -CheckpointType ProductionOnly
+    if (-not $?)
+    {
+       Write-Output "Error: Could not set Production as Checkpoint type"  | Out-File -Append $summaryLog
+       return $false
+    }
+}
+
+$random = Get-Random -minimum 1024 -maximum 4096
+$snapshot = "TestSnapshot_$random"
+Checkpoint-VM -Name $vmName -SnapshotName $snapshot -ComputerName $hvServer
+if (-not $?)
+{
+    Write-Output "Error: Could not create checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+# Create another file on the VM
+$sts = CreateFile "TestFile2"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR: Can not create file"
+    return $False
+}
+
+Restore-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer -Confirm:$false
+if (-not $?)
+{
+    Write-Output "Error: Could not restore checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+#
+# Starting the VM
+#
+Start-VM $vmName -ComputerName $hvServer
+
+#
+# Waiting for the VM to run again and respond to SSH - port 22
+#
+$timeout = 300
+while ($timeout -gt 0) {
+    if ( (TestPort $ipv4) ) {
+        break
+    }
+
+    Start-Sleep -seconds 2
+    $timeout -= 2
+}
+
+if ($timeout -eq 0) {
+    Write-Output "Error: Test case timed out waiting for VM to boot" | Out-File -Append $summaryLog
+    return $False
+}
+
+$sts = CheckFile "TestFile1"
+if (-not $sts)
+{
+    Write-Output "ERROR: TestFile1 is not present"
+    Write-Output "TestFile1 should be present on the VM" >> $summaryLog
+    return $False
+}
+
+$sts = CheckFile "TestFile2"
+if ($sts)
+{
+    Write-Output "ERROR: TestFile2 is present"
+    Write-Output "TestFile2 should not be present on the VM" >> $summaryLog
+    return $False
+}
+
+Write-Output "Only the first file is present. Test succeeded" >> $summaryLog
+#
+# Delete the snapshot
+#
+"Info : Deleting Snapshot ${Snapshot} of VM ${vmName}"
+Remove-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer
+if ( -not $?)
+{
+   Write-Output "Error: Could not delete snapshot"  | Out-File -Append $summaryLog
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_3Chain_VHD.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_3Chain_VHD.ps1
@@ -1,0 +1,742 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+
+<#
+.Synopsis
+    Verify Production Checkpoint feature.
+
+.Description
+    This script will create a new VM with a 3-chained differencing disk 
+    attached based on the source vm vhd/x. 
+    If the source Vm has more than 1 snapshot, they will be removed except
+    the latest one. If the VM has no snapshots, the script will create one.
+    After that it will proceed with making a Production Checkpoint on the
+    new VM.
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>ProductionCheckpoint_3Chain_VHD</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\Production_checkpoint_3Chain_VHD.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-09</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+
+.Example
+    setupScripts\Production_checkpoint_3Chain_VHD.ps1 -vmName "myVm" -hvServer "localhost"
+     -TestParams "TC_COVERED=PC-09;snapshotname=ICABase"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# Runs a remote script on the VM an returns the log.
+#######################################################################
+function RunRemoteScript($remoteScript)
+{
+    $retValue = $False
+    $stateFile     = "state.txt"
+    $TestCompleted = "TestCompleted"
+    $TestAborted   = "TestAborted"
+    $TestRunning   = "TestRunning"
+    $timeout       = 6000
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}"
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "./runtest.sh"
+
+    # Return the state file
+    while ($timeout -ne 0 )
+    {
+    .\bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} . #| out-null
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $stateFile)
+        {
+            $contents = Get-Content -Path $stateFile
+            if ($null -ne $contents)
+            {
+                    if ($contents -eq $TestCompleted)
+                    {
+                        Write-Output "Info : state file contains Testcompleted"
+                        $retValue = $True
+                        break
+
+                    }
+
+                    if ($contents -eq $TestAborted)
+                    {
+                         Write-Output "Info : State file contains TestAborted failed. "
+                         break
+
+                    }
+                    #Start-Sleep -s 1
+                    $timeout--
+
+                    if ($timeout -eq 0)
+                    {
+                        Write-Output "Error : Timed out on Test Running , Exiting test execution."
+                        break
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn : state file is empty"
+                break
+            }
+
+        }
+        else
+        {
+             Write-Host "Warn : ssh reported success, but state file was not copied"
+             break
+        }
+    }
+    else #
+    {
+         Write-Output "Error : pscp exit status = $sts"
+         Write-Output "Error : unable to pull state.txt from VM."
+         break
+    }
+    }
+
+    # Get the logs
+    $remoteScriptLog = $remoteScript+".log"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${remoteScriptLog} .
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $remoteScriptLog)
+        {
+            $contents = Get-Content -Path $remoteScriptLog
+            if ($null -ne $contents)
+            {
+                    if ($null -ne ${TestLogDir})
+                    {
+                        move "${remoteScriptLog}" "${TestLogDir}\${remoteScriptLog}"
+
+                    }
+
+                    else
+                    {
+                        Write-Output "INFO: $remoteScriptLog is copied in ${rootDir}"
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn: $remoteScriptLog is empty"
+            }
+        }
+        else
+        {
+             Write-Output "Warn: ssh reported success, but $remoteScriptLog file was not copied"
+        }
+    }
+
+    # Cleanup
+    del state.txt -ErrorAction "SilentlyContinue"
+    del runtest.sh -ErrorAction "SilentlyContinue"
+
+    return $retValue
+}
+
+#######################################################################
+# Fix snapshots. If there are more then 1 remove all except latest.
+#######################################################################
+function FixSnapshots($vmName, $hvServer)
+{
+    # Get all the snapshots
+    $vmsnapshots = Get-VMSnapshot -VMName $vmName
+    $snapnumber = ${vmsnapshots}.count
+
+    # Get latest snapshot
+    $latestsnapshot = Get-VMSnapshot -VMName $vmName | sort CreationTime | select -Last 1
+    $LastestSnapName = $latestsnapshot.name
+    
+    # Delete all snapshots except the latest
+    if ($snapnumber -gt 1)
+    {
+        Write-Output "INFO: $vmName has $snapnumber snapshots. Removing all except $LastestSnapName"
+        foreach ($snap in $vmsnapshots) 
+        {
+            if ($snap.id -ne $latestsnapshot.id)
+            {
+                $snapName = ${snap}.Name
+                $sts = Remove-VMSnapshot -Name $snap.Name -VMName $vmName -ComputerName $hvServer
+                if (-not $?)
+                {
+                    Write-Output "ERROR: Unable to remove snapshot $snapName of ${vmName}: `n${sts}"
+                    return $False
+                }
+                Write-Output "INFO: Removed snapshot $snapName"
+            }
+
+        }
+    }
+
+    # If there are no snapshots, create one.
+    ElseIf ($snapnumber -eq 0)
+    {
+        Write-Output "INFO: There are no snapshots for $vmName. Creating one ..."
+        $sts = Checkpoint-VM -VMName $vmName -ComputerName $hvServer 
+        if (-not $?)
+        {
+           Write-Output "ERROR: Unable to create snapshot of ${vmName}: `n${sts}"
+           return $False
+        }
+
+    }
+
+    return $True
+}
+
+#######################################################################
+# To Get Parent VHD from VM.
+#######################################################################
+function GetParentVHD($vmName, $hvServer)
+{
+    $ParentVHD = $null     
+
+    $VmInfo = Get-VM -Name $vmName 
+    if (-not $VmInfo)
+        { 
+             Write-Error -Message "Error: Unable to collect VM settings for ${vmName}" -ErrorAction SilentlyContinue
+             return $False
+        }    
+    
+    if ( $VmInfo.Generation -eq "" -or $VmInfo.Generation -eq 1  )
+        {
+            $Disks = $VmInfo.HardDrives
+            foreach ($VHD in $Disks)
+                {
+                    if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "IDE"  ))
+                        {
+                            $Path = Get-VHD $VHD.Path
+                            if ([string]::IsNullOrEmpty($Path.ParentPath))
+                                {
+                                    $ParentVHD = $VHD.Path
+                                }
+                            else{
+                                    $ParentVHD =  $Path.ParentPath
+                                }
+
+                            Write-Host "Parent VHD Found: $ParentVHD "
+                        }
+                }            
+        }
+    if ( $VmInfo.Generation -eq 2 )
+        {
+            $Disks = $VmInfo.HardDrives
+            foreach ($VHD in $Disks)
+                {
+                    if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "SCSI"  ))
+                        {
+                            $Path = Get-VHD $VHD.Path
+                            if ([string]::IsNullOrEmpty($Path.ParentPath))
+                                {
+                                    $ParentVHD = $VHD.Path
+                                }
+                            else{
+                                    $ParentVHD =  $Path.ParentPath
+                                }
+                            Write-Host "Parent VHD Found: $ParentVHD "
+                        }
+                }  
+        }
+
+    if ( -not ($ParentVHD.EndsWith(".vhd") -xor $ParentVHD.EndsWith(".vhdx") ))
+    {
+        Write-Error -Message " Parent VHD is Not correct please check VHD, Parent VHD is: $ParentVHD " -ErrorAction SilentlyContinue
+        return $False
+    }
+    return $ParentVHD    
+}
+
+#######################################################################
+# To Create Grand Child VHD from Parent VHD.
+#######################################################################
+function CreateGChildVHD($ParentVHD)
+{
+    $GChildVHD = $null
+    $ChildVHD  = $null
+
+    $hostInfo = Get-VMHost -ComputerName $hvServer
+        if (-not $hostInfo)
+        {
+             Write-Error -Message "Error: Unable to collect Hyper-V settings for ${hvServer}" -ErrorAction SilentlyContinue
+             return $False
+        }
+
+    $defaultVhdPath = $hostInfo.VirtualHardDiskPath
+        if (-not $defaultVhdPath.EndsWith("\"))
+        {
+            $defaultVhdPath += "\"
+        }
+
+    # Create Child VHD
+    if ($ParentVHD.EndsWith("x") )
+    {
+        $ChildVHD = $defaultVhdPath+$vmName+"-child.vhdx"
+        $GChildVHD = $defaultVhdPath+$vmName+"-Gchild.vhdx"
+
+    }
+    else
+    {
+        $ChildVHD = $defaultVhdPath+$vmName+"-child.vhd"
+        $GChildVHD = $defaultVhdPath+$vmName+"-Gchild.vhd"
+    }
+
+    if ( Test-Path  $ChildVHD )
+    {
+        Write-Host "Deleting existing VHD $ChildVHD"        
+        del $ChildVHD
+    }
+
+     if ( Test-Path  $GChildVHD )
+    {
+        Write-Host "Deleting existing VHD $GChildVHD"        
+        del $GChildVHD
+    }
+
+    # Create Child VHD  
+    New-VHD -ParentPath:$ParentVHD -Path:$ChildVHD     
+    if (-not $?)
+    {
+       Write-Error -Message "Error: Unable to create child VHD"  -ErrorAction SilentlyContinue
+       return $False
+    }
+
+    # Create Grand Child VHD    
+    $newVHD = New-VHD -ParentPath:$ChildVHD -Path:$GChildVHD
+    if (-not $?)
+    {
+       Write-Error -Message "Error: Unable to create Grand child VHD" -ErrorAction SilentlyContinue
+       return $False
+    }
+
+    return $GChildVHD
+}
+
+#######################################################################
+# Create a file on the VM.
+#######################################################################
+function CreateFile([string] $fileName)
+{
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "touch ${fileName}" 
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to create file" | Out-File -Append $summaryLog
+        return $False
+    }
+
+    return  $True
+}
+
+#######################################################################
+# Checks if test file is present or not.
+#######################################################################
+function CheckFile([string] $fileName)
+{
+    $retVal = $true
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "stat ${fileName} 2>/dev/null" | out-null
+    if (-not $?)
+    {
+        $retVal = $false
+    }
+
+    return  $retVal
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+$retVal = $false
+
+# Define and cleanup the summaryLog
+$summaryLog  = "${vmName}_summary.log"
+echo "Covers Production Checkpoint Testing" > $summaryLog
+
+$vmNameChild = "${vmName}_ChildVM"
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $retVal
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED"  { $TC_COVERED = $fields[1].Trim() }
+    "sshKey"      { $sshKey = $fields[1].Trim() }
+    "ipv4"        { $ipv4 = $fields[1].Trim() }
+    "rootdir"     { $rootDir = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+echo $params
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source the TCUtils.ps1 file
+. .\setupscripts\TCUtils.ps1
+
+#Check if the host supports production checkpoints
+$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
+if (-not $osInfo)
+{
+    "Error: Unable to collect Operating System information"
+    return $False
+}
+
+[System.Int32]$buildNR = $osInfo.BuildNumber
+
+if ($buildNR -le 10500){
+    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
+    return $false
+}
+
+# Check if the Vm VHD in not on the same drive as the backup destination
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+if (-not $vm)
+{
+    "Error: VM '${vmName}' does not exist"
+    return $False
+}
+
+# Send utils.sh to VM
+echo y | .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\utils.sh root@${ipv4}:
+if (-not $?)
+{
+    Write-Output "ERROR: Unable to copy utils.sh to the VM"
+    return $False
+}
+
+# Check to see Linux VM is running VSS backup daemon
+$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+Write-Output "VSS Daemon is running " >> $summaryLog
+
+# Stop the running VM so we can create New VM from this parent disk.
+$timeout = 50
+StopVMViaSSH $vmName $hvServer $timeout $sshKey
+
+# Add Check to make sure if the VM is shutdown then Proceed
+$sts = WaitForVMToStop $vmName $hvServer $timeout
+if (-not $sts)
+{
+   Write-Output "Error: Unable to Shut Down VM"
+   return $False
+}
+
+# Clean snapshots
+Write-Output "INFO: Cleaning up snapshots..."
+$sts = FixSnapshots $vmName $hvServer
+if (-not $sts[-1])
+{
+    Write-Output "Error: Cleaning snapshots on $vmname failed."
+    return $False
+}
+
+# Get Parent VHD 
+$ParentVHD = GetParentVHD $vmName -$hvServer
+if(-not $ParentVHD)
+{
+    "Error: Error getting Parent VHD of VM $vmName"
+    return $False
+} 
+
+Write-Output "INFO: Successfully Got Parent VHD"
+
+# Create Child and Grand Child VHD
+$CreateVHD = CreateGChildVHD $ParentVHD
+if(-not $CreateVHD)
+{
+    Write-Output "Error: Error Creating Child and Grand Child VHD of VM $vmName"
+    return $False
+} 
+
+Write-Output "INFO: Successfully Created GrandChild VHD"
+
+# Now create New VM out of this VHD.
+# New VM is static hardcoded since we do not need it to be dynamic
+$GChildVHD = $CreateVHD[-1]
+
+# Get-VM 
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+
+# Get the VM Network adapter so we can attach it to the new vm.
+$VMNetAdapter = Get-VMNetworkAdapter $vmName
+if (-not $?)
+    {
+       Write-Output "Error: Get-VMNetworkAdapter" 
+       return $false
+    }
+
+# Get VM Generation
+$vm_gen = $vm.Generation
+
+# Create the GChildVM
+$newVm = New-VM -Name $vmNameChild -VHDPath $GChildVHD -MemoryStartupBytes 1024MB -SwitchName $VMNetAdapter[0].SwitchName -Generation $vm_gen
+if (-not $?)
+    {
+       Write-Output "Error: Creating New VM" 
+       return $False
+    }
+
+# Disable secure boot
+if ($vm_gen -eq 2)
+{
+    Set-VMFirmware -VMName $vmNameChild -EnableSecureBoot Off
+    if(-not $?)
+    {
+        Write-Output "Error: Unable to disable secure boot"
+        return $false
+    }
+}
+
+echo "New 3 Chain VHD VM $vmNameChild Created: Success" >> $summaryLog
+Write-Output "INFO: New 3 Chain VHD VM $vmNameChild Created"
+
+$timeout = 500
+$sts = Start-VM -Name $vmNameChild -ComputerName $hvServer 
+if (-not (WaitForVMToStartKVP $vmNameChild $hvServer $timeout ))
+{
+    Write-Output "Error: ${vmNameChild} failed to start"
+    return $False
+}
+
+Write-Output "INFO: New VM $vmNameChild started"
+
+#Check if we can set the Production Checkpoint as default
+$vmChild = Get-VM -Name $vmNameChild -ComputerName $hvServer
+if ($vmChild.CheckpointType -ne "ProductionOnly"){
+    Set-VM -Name $vmNameChild -CheckpointType ProductionOnly
+    if (-not $?)
+    {
+       Write-Output "Error: Could not set Production as Checkpoint type"  | Out-File -Append $summaryLog
+       return $false
+    }
+}
+
+# Get new IPV4
+$ipv4 =  GetIPv4 $vmNameChild $hvServer
+if (-not $?){
+    Write-Output "Error: Getting IPV4 of New VM"
+    return $False
+}
+
+Write-Output "INFO: New VM's IP is $ipv4" 
+echo y | .\bin\plink -i ssh\${sshKey} root@${ipv4} "exit"
+
+# Create a file on the child VM
+$sts = CreateFile "TestFile1"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR: Can not create file"
+    return $False
+}
+
+
+# Take a Production Checkpoint
+$random = Get-Random -minimum 1024 -maximum 4096
+$snapshot = "TestSnapshot_$random"
+Checkpoint-VM -Name $vmNameChild -SnapshotName $snapshot -ComputerName $hvServer
+if (-not $?)
+{
+    Write-Output "Error: Could not create checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+# Create another file on the VM
+$sts = CreateFile "TestFile2"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR: Can not create file"
+    return $False
+}
+
+Restore-VMSnapshot -VMName $vmNameChild -Name $snapshot -ComputerName $hvServer -Confirm:$false
+if (-not $?)
+{
+    Write-Output "Error: Could not restore checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+#
+# Starting the child VM
+#
+$sts = Start-VM -Name $vmNameChild -ComputerName $hvServer 
+if (-not (WaitForVMToStartKVP $vmNameChild $hvServer $timeout ))
+{
+    Write-Output "Error: ${vmNameChild} failed to start"
+     return $False
+}
+
+Write-Output "INFO: New VM ${vmNameChild} started"
+
+# Check the files created earlier. The first one should be present, the second one shouldn't
+$sts = CheckFile "TestFile1"
+if (-not $sts)
+{
+    Write-Output "ERROR: TestFile1 is not present"
+    Write-Output "TestFile1 should be present on the VM" >> $summaryLog
+    return $False
+}
+
+$sts = CheckFile "TestFile2"
+if ($sts)
+{
+    Write-Output "ERROR: TestFile2 is present"
+    Write-Output "TestFile2 should not be present on the VM" >> $summaryLog
+    return $False
+}
+Write-Output "Only the first file is present. Test succeeded" >> $summaryLog
+
+#
+# Delete the snapshot
+#
+"Info : Deleting Snapshot ${Snapshot} of VM ${vmName}"
+Remove-VMSnapshot -VMName $vmNameChild -Name $snapshot -ComputerName $hvServer
+if ( -not $?)
+{
+   Write-Output "Error: Could not delete snapshot"  | Out-File -Append $summaryLog
+}
+
+# Stop child VM
+StopVMViaSSH $vmNameChild $hvServer $timeout $sshKey
+
+# Add Check to make sure if the VM is shutdown then Proceed
+$sts = WaitForVMToStop $vmNameChild $hvServer $timeout
+if (-not $sts)
+{
+   Write-Output "Error: Unable to Shut Down VM"
+   return $False
+}
+
+# Clean Delete New VM created 
+$sts = Remove-VM -Name $vmNameChild -Confirm:$false -Force
+if (-not $?)
+    {
+      Write-Output "Error: Deleting New VM $vmNameChild"  
+    } 
+
+Write-Output "INFO: Deleted VM $vmNameChild"
+
+return $true

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_ISO_NoNetwork.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_ISO_NoNetwork.ps1
@@ -1,0 +1,488 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+
+<#
+.Synopsis
+    Verify Production Checkpoint feature.
+
+.Description
+    This script will stop networking and attach a CD ISO to the vm. 
+    After that it will proceed with making a Production Checkpoint on test VM
+    and check if the ISO is still mounted
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>ProductionCheckpoint_ISO_NoNetwork</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\Production_checkpoint_ISO_NoNetwork.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-08</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+
+.Example
+    setupScripts\STOR_TakeRevert_Snapshot.ps1 -vmName "myVm" -hvServer "localhost"
+     -TestParams "TC_COVERED=PC-08;snapshotname=ICABase"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# Runs a remote script on the VM an returns the log.
+#######################################################################
+function RunRemoteScript($remoteScript)
+{
+    $retValue = $False
+    $stateFile     = "state.txt"
+    $TestCompleted = "TestCompleted"
+    $TestAborted   = "TestAborted"
+    $TestRunning   = "TestRunning"
+    $timeout       = 6000
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}"
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "./runtest.sh"
+
+    # Return the state file
+    while ($timeout -ne 0 )
+    {
+    .\bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} . #| out-null
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $stateFile)
+        {
+            $contents = Get-Content -Path $stateFile
+            if ($null -ne $contents)
+            {
+                    if ($contents -eq $TestCompleted)
+                    {
+                        Write-Output "Info : state file contains Testcompleted"
+                        $retValue = $True
+                        break
+
+                    }
+
+                    if ($contents -eq $TestAborted)
+                    {
+                         Write-Output "Info : State file contains TestAborted failed. "
+                         break
+
+                    }
+                    #Start-Sleep -s 1
+                    $timeout--
+
+                    if ($timeout -eq 0)
+                    {
+                        Write-Output "Error : Timed out on Test Running , Exiting test execution."
+                        break
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn : state file is empty"
+                break
+            }
+
+        }
+        else
+        {
+             Write-Host "Warn : ssh reported success, but state file was not copied"
+             break
+        }
+    }
+    else #
+    {
+         Write-Output "Error : pscp exit status = $sts"
+         Write-Output "Error : unable to pull state.txt from VM."
+         break
+    }
+    }
+
+    # Get the logs
+    $remoteScriptLog = $remoteScript+".log"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${remoteScriptLog} .
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $remoteScriptLog)
+        {
+            $contents = Get-Content -Path $remoteScriptLog
+            if ($null -ne $contents)
+            {
+                    if ($null -ne ${TestLogDir})
+                    {
+                        move "${remoteScriptLog}" "${TestLogDir}\${remoteScriptLog}"
+
+                    }
+
+                    else
+                    {
+                        Write-Output "INFO: $remoteScriptLog is copied in ${rootDir}"
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn: $remoteScriptLog is empty"
+            }
+        }
+        else
+        {
+             Write-Output "Warn: ssh reported success, but $remoteScriptLog file was not copied"
+        }
+    }
+
+    # Cleanup
+    del state.txt -ErrorAction "SilentlyContinue"
+    del runtest.sh -ErrorAction "SilentlyContinue"
+
+    return $retValue
+}
+
+######################################################################
+# Runs a remote script on the VM without checking the log 
+#######################################################################
+function RunRemoteScriptNoState($remoteScript)
+{
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh 
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }      
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh" 
+        return $False
+    }
+    
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}" 
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "at -f runtest.sh now" 
+    if (-not $?)
+    {
+        Write-Output "Error: Unable to submit runtest.sh to the vm"
+        return $False
+    }
+
+    del runtest.sh
+    return $True
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+$retVal = $false
+
+# Define and cleanup the summaryLog
+$summaryLog  = "${vmName}_summary.log"
+echo "Covers Production Checkpoint Testing" > $summaryLog
+$remoteScript = "STOR_VSS_StopNetwork.sh"
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $retVal
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED"  { $TC_COVERED = $fields[1].Trim() }
+    "sshKey"      { $sshKey = $fields[1].Trim() }
+    "ipv4"        { $ipv4 = $fields[1].Trim() }
+    "rootdir"     { $rootDir = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+echo $params
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source the TCUtils.ps1 file
+. .\setupscripts\TCUtils.ps1
+
+#Check if the host supports production checkpoints
+$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
+if (-not $osInfo)
+{
+    "Error: Unable to collect Operating System information"
+    return $False
+}
+
+[System.Int32]$buildNR = $osInfo.BuildNumber
+
+if ($buildNR -le 10500){
+    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
+    return $false
+}
+
+# Check if the Vm VHD in not on the same drive as the backup destination
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+if (-not $vm)
+{
+    "Error: VM '${vmName}' does not exist"
+    return $False
+}
+
+# Send utils.sh to VM
+echo y | .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\utils.sh root@${ipv4}:
+if (-not $?)
+{
+    Write-Output "ERROR: Unable to copy utils.sh to the VM"
+    return $False
+}
+
+# Check to see Linux VM is running VSS backup daemon
+$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+Write-Output "VSS Daemon is running " >> $summaryLog
+
+# Insert CD/DVD .
+$CdPath = ".\bin\CDTEST.iso"
+Set-VMDvdDrive -VMName $vmName -ComputerName $hvServer -Path $CdPath
+if (-not $?)
+    {
+        "Error: Unable to Add ISO $CdPath" 
+        return $False
+    }
+
+Write-Output "Attached DVD: Success" >> $summaryLog
+
+# Bring down the network. 
+RunRemoteScriptNoState $remoteScript
+
+Start-Sleep -Seconds 3
+
+# Make sure network is down.
+$sts = ping $ipv4
+$pingresult = $False
+foreach ($line in $sts)
+{
+   if (( $line -Like "*unreachable*" ) -or ($line -Like "*timed*")) 
+   {
+       $pingresult = $True
+   }
+}
+
+if ($pingresult) {
+    Write-Output "Network Down: Success"
+    Write-Output "Network Down: Success" >> $summaryLog
+} else {
+    Write-Output "Network Down: Failed" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+#Check if we can set the Production Checkpoint as default
+if ($vm.CheckpointType -ne "ProductionOnly"){
+    Set-VM -Name $vmName -CheckpointType ProductionOnly
+    if (-not $?)
+    {
+       Write-Output "Error: Could not set Production as Checkpoint type"  | Out-File -Append $summaryLog
+       return $false
+    }
+}
+
+$random = Get-Random -minimum 1024 -maximum 4096
+$snapshot = "TestSnapshot_$random"
+Checkpoint-VM -Name $vmName -SnapshotName $snapshot -ComputerName $hvServer
+if (-not $?)
+{
+    Write-Output "Error: Could not create checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+Restore-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer -Confirm:$false
+if (-not $?)
+{
+    Write-Output "Error: Could not restore checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+# Starting the VM
+Start-VM $vmName -ComputerName $hvServer
+
+#
+# Waiting for the VM to run again and respond to SSH - port 22
+#
+$timeout = 300
+while ($timeout -gt 0) {
+    if ( (TestPort $ipv4) ) {
+        break
+    }
+
+    Start-Sleep -seconds 2
+    $timeout -= 2
+}
+
+if ($timeout -eq 0) {
+    Write-Output "Error: Test case timed out waiting for VM to boot" | Out-File -Append $summaryLog
+    return $False
+}
+
+# Check if ISO file is still present
+$isoInfo = Get-VMDvdDrive -VMName $vmName -ComputerName $hvServer
+if ($isoInfo.Path -like "*CDTEST*" -eq $False){
+    Write-Output "Error: The ISO is missing from the VM" | Out-File -Append $summaryLog
+    return $False 
+}
+Write-Output "The ISO file is present. Test succeeded" >> $summaryLog
+
+#
+# Delete the snapshot
+#
+"Info : Deleting Snapshot ${Snapshot} of VM ${vmName}"
+Remove-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer
+if ( -not $?)
+{
+   Write-Output "Error: Could not delete snapshot"  | Out-File -Append $summaryLog
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_failback.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_failback.ps1
@@ -1,0 +1,390 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+
+<#
+.Synopsis
+    Verify Production Checkpoint feature.
+
+.Description
+    This script will check the Production Checkpoint failback feature.
+    VSS daemon will be stopped inside the VM and Hyper-V should be able
+    to create a standard checkpoint in this case. 
+    The test will pass if a Standard Checkpoint will be made in this case.
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>ProductionCheckpoint_Failback</testName>
+            <testScript>setupscripts\Production_checkpoint_failback.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-02</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+
+.Example
+    setupScripts\STOR_TakeRevert_Snapshot.ps1 -vmName "myVm" -hvServer "localhost" 
+    -TestParams "TC_COVERED=PC-02"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# Runs a remote script on the VM an returns the log.
+#######################################################################
+function RunRemoteScript($remoteScript)
+{
+    $retValue = $False
+    $stateFile     = "state.txt"
+    $TestCompleted = "TestCompleted"
+    $TestAborted   = "TestAborted"
+    $TestRunning   = "TestRunning"
+    $timeout       = 6000
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}"
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "./runtest.sh"
+
+    # Return the state file
+    while ($timeout -ne 0 )
+    {
+    .\bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} . #| out-null
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $stateFile)
+        {
+            $contents = Get-Content -Path $stateFile
+            if ($null -ne $contents)
+            {
+                    if ($contents -eq $TestCompleted)
+                    {
+                        Write-Output "Info : state file contains Testcompleted"
+                        $retValue = $True
+                        break
+
+                    }
+
+                    if ($contents -eq $TestAborted)
+                    {
+                         Write-Output "Info : State file contains TestAborted failed. "
+                         break
+
+                    }
+                    #Start-Sleep -s 1
+                    $timeout--
+
+                    if ($timeout -eq 0)
+                    {
+                        Write-Output "Error : Timed out on Test Running , Exiting test execution."
+                        break
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn : state file is empty"
+                break
+            }
+
+        }
+        else
+        {
+             Write-Host "Warn : ssh reported success, but state file was not copied"
+             break
+        }
+    }
+    else #
+    {
+         Write-Output "Error : pscp exit status = $sts"
+         Write-Output "Error : unable to pull state.txt from VM."
+         break
+    }
+    }
+
+    # Get the logs
+    $remoteScriptLog = $remoteScript+".log"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${remoteScriptLog} .
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $remoteScriptLog)
+        {
+            $contents = Get-Content -Path $remoteScriptLog
+            if ($null -ne $contents)
+            {
+                    if ($null -ne ${TestLogDir})
+                    {
+                        move "${remoteScriptLog}" "${TestLogDir}\${remoteScriptLog}"
+
+                    }
+
+                    else
+                    {
+                        Write-Output "INFO: $remoteScriptLog is copied in ${rootDir}"
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn: $remoteScriptLog is empty"
+            }
+        }
+        else
+        {
+             Write-Output "Warn: ssh reported success, but $remoteScriptLog file was not copied"
+        }
+    }
+
+    # Cleanup
+    del state.txt -ErrorAction "SilentlyContinue"
+    del runtest.sh -ErrorAction "SilentlyContinue"
+
+    return $retValue
+}
+
+#######################################################################
+# Create a file on the VM.
+#######################################################################
+function CreateFile([string] $fileName)
+{
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "touch ${fileName}"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to create file" | Out-File -Append $summaryLog
+        return $False
+    }
+
+    return  $True
+}
+
+#######################################################################
+# Checks if test file is present or not.
+#######################################################################
+function CheckFile([string] $fileName)
+{
+    $retVal = $true
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "stat ${fileName} 2>/dev/null" | out-null
+    if (-not $?)
+    {
+        $retVal = $false
+    }
+
+    return  $retVal
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+$retVal = $false
+
+
+# Define and cleanup the summaryLog
+$summaryLog  = "${vmName}_summary.log"
+echo "Covers Production Checkpoint Testing" > $summaryLog
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $retVal
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED"  { $TC_COVERED = $fields[1].Trim() }
+    "sshKey"      { $sshKey = $fields[1].Trim() }
+    "ipv4"        { $ipv4 = $fields[1].Trim() }
+    "rootdir"     { $rootDir = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+echo $params
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source the TCUtils.ps1 file
+. .\setupscripts\TCUtils.ps1
+
+#Check if the host supports production checkpoints
+$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
+if (-not $osInfo)
+{
+    "Error: Unable to collect Operating System information"
+    return $False
+}
+
+[System.Int32]$buildNR = $osInfo.BuildNumber
+
+if ($buildNR -le 10500){
+    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
+    return $false
+}
+
+# Check if the Vm VHD in not on the same drive as the backup destination
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+if (-not $vm)
+{
+    "Error: VM '${vmName}' does not exist"
+    return $False
+}
+
+# Send utils.sh to VM
+echo y | .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\utils.sh root@${ipv4}:
+if (-not $?)
+{
+    Write-Output "ERROR: Unable to copy utils.sh to the VM"
+    return $False
+}
+
+# Check to see Linux VM is running VSS backup daemon
+$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+#Stop the VSS daemon gracefully
+$sts = RunRemoteScript "PC_Stop_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+Write-Output "VSS Daemon was successfully stopped" >> $summaryLog
+
+#Check if we can set the Production Checkpoint as default
+if ($vm.CheckpointType -ne "Production"){
+    Set-VM -Name $vmName -CheckpointType Production
+    if (-not $?)
+    {
+       Write-Output "Error: Could not set Production as Checkpoint type"  | Out-File -Append $summaryLog
+       return $false
+    }
+}
+
+$random = Get-Random -minimum 1024 -maximum 4096
+$snapshot = "TestSnapshot_$random"
+Checkpoint-VM -Name $vmName -SnapshotName $snapshot -ComputerName $hvServer
+if (-not $?)
+{
+    Write-Output "Error: Could not create a Standard Checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+#
+# Delete the snapshot
+#
+"Info : Deleting Snapshot ${Snapshot} of VM ${vmName}"
+Remove-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer
+if ( -not $?)
+{
+   Write-Output "Error: Could not delete snapshot"  | Out-File -Append $summaryLog
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_iSCSI.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_iSCSI.ps1
@@ -1,0 +1,492 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+
+<#
+.Synopsis
+    Verify Production Checkpoint feature.
+
+.Description
+    This script will connect to a iSCSI target, format and mount the iSCSI disk.
+    After that it will proceed with making a Production Checkpoint on test VM.
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>ProductionCheckpoint_iSCSI</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\Production_checkpoint_iSCSI.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-10</param>
+                <param>TargetIP=TARGET_IP</param>
+                <param>IQN=TARGET_IQN</param>
+                <param>FILESYS=ext4</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+
+.Example
+    setupScripts\STOR_TakeRevert_Snapshot.ps1 -vmName "myVm" -hvServer "localhost"
+     -TestParams "TC_COVERED=PC-10;snapshotname=ICABase; FILESYS=ext4;
+     IQN=TARGET_IQN; TargetIP=TARGET_IP"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# Runs a remote script on the VM an returns the log.
+#######################################################################
+function RunRemoteScript($remoteScript)
+{
+    $retValue = $False
+    $stateFile     = "state.txt"
+    $TestCompleted = "TestCompleted"
+    $TestAborted   = "TestAborted"
+    $TestRunning   = "TestRunning"
+    $timeout       = 6000
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}"
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "./runtest.sh"
+
+    # Return the state file
+    while ($timeout -ne 0 )
+    {
+    .\bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} . #| out-null
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $stateFile)
+        {
+            $contents = Get-Content -Path $stateFile
+            if ($null -ne $contents)
+            {
+                    if ($contents -eq $TestCompleted)
+                    {
+                        Write-Output "Info : state file contains Testcompleted"
+                        $retValue = $True
+                        break
+
+                    }
+
+                    if ($contents -eq $TestAborted)
+                    {
+                         Write-Output "Info : State file contains TestAborted failed. "
+                         break
+
+                    }
+                    #Start-Sleep -s 1
+                    $timeout--
+
+                    if ($timeout -eq 0)
+                    {
+                        Write-Output "Error : Timed out on Test Running , Exiting test execution."
+                        break
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn : state file is empty"
+                break
+            }
+
+        }
+        else
+        {
+             Write-Host "Warn : ssh reported success, but state file was not copied"
+             break
+        }
+    }
+    else #
+    {
+         Write-Output "Error : pscp exit status = $sts"
+         Write-Output "Error : unable to pull state.txt from VM."
+         break
+    }
+    }
+
+    # Get the logs
+    $remoteScriptLog = $remoteScript+".log"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${remoteScriptLog} .
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $remoteScriptLog)
+        {
+            $contents = Get-Content -Path $remoteScriptLog
+            if ($null -ne $contents)
+            {
+                    if ($null -ne ${TestLogDir})
+                    {
+                        move "${remoteScriptLog}" "${TestLogDir}\${remoteScriptLog}"
+
+                    }
+
+                    else
+                    {
+                        Write-Output "INFO: $remoteScriptLog is copied in ${rootDir}"
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn: $remoteScriptLog is empty"
+            }
+        }
+        else
+        {
+             Write-Output "Warn: ssh reported success, but $remoteScriptLog file was not copied"
+        }
+    }
+
+    # Cleanup
+    del state.txt -ErrorAction "SilentlyContinue"
+    del runtest.sh -ErrorAction "SilentlyContinue"
+
+    return $retValue
+}
+
+#######################################################################
+# Create a file on the VM.
+#######################################################################
+function CreateFile([string] $fileName)
+{
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "touch ${fileName}"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to create file" | Out-File -Append $summaryLog
+        return $False
+    }
+
+    return  $True
+}
+
+#######################################################################
+# Checks if test file is present or not.
+#######################################################################
+function CheckFile([string] $fileName)
+{
+    $retVal = $true
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "stat ${fileName} 2>/dev/null" | out-null
+    if (-not $?)
+    {
+        $retVal = $false
+    }
+
+    return  $retVal
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+$retVal = $false
+
+# Define and cleanup the summaryLog
+$summaryLog  = "${vmName}_summary.log"
+echo "Covers Production Checkpoint Testing" > $summaryLog
+
+# Define the guest partition script
+$remoteScript = "STOR_VSS_ISCSI_PartitionDisks.sh"
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $retVal
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED"  { $TC_COVERED = $fields[1].Trim() }
+    "sshKey"      { $sshKey = $fields[1].Trim() }
+    "ipv4"        { $ipv4 = $fields[1].Trim() }
+    "rootdir"     { $rootDir = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+echo $params
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source the TCUtils.ps1 file
+. .\setupscripts\TCUtils.ps1
+
+#Check if the host supports production checkpoints
+$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
+if (-not $osInfo)
+{
+    "Error: Unable to collect Operating System information"
+    return $False
+}
+
+[System.Int32]$buildNR = $osInfo.BuildNumber
+
+if ($buildNR -le 10500){
+    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
+    return $false
+}
+
+# Check if the Vm VHD in not on the same drive as the backup destination
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+if (-not $vm)
+{
+    "Error: VM '${vmName}' does not exist"
+    return $False
+}
+
+# Send utils.sh to VM
+echo y | .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\utils.sh root@${ipv4}:
+if (-not $?)
+{
+    Write-Output "ERROR: Unable to copy utils.sh to the VM"
+    return $False
+}
+
+# Check to see Linux VM is running VSS backup daemon
+$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+Write-Output "VSS Daemon is running " >> $summaryLog
+
+# Run the remote script
+$sts = RunRemoteScript $remoteScript
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    Write-Output "Here are the remote logs:`n`n###################"
+    $logfilename = ".\$remoteScript.log"
+    Get-Content $logfilename
+    Write-Output "###################`n"
+    return $False
+}
+Write-Output "$remoteScript execution on VM: Success"
+Write-Output "Here are the remote logs:`n`n###################"
+$logfilename = ".\$remoteScript.log"
+Get-Content $logfilename
+Write-Output "###################`n"
+Write-Output "$remoteScript execution on VM: Success" >> $summaryLog
+del $remoteScript.log
+
+
+# Create a file on the VM
+$sts1 = CreateFile "/mnt/1/TestFile1"
+$sts1 = CreateFile "/mnt/2/TestFile1"
+if (-not $sts1[-1] -Or -not $sts2[-1])
+{
+    Write-Output "ERROR: Can not create file"
+    return $False
+}
+
+Start-Sleep -seconds 30
+
+#Check if we can set the Production Checkpoint as default
+if ($vm.CheckpointType -ne "ProductionOnly"){
+    Set-VM -Name $vmName -CheckpointType ProductionOnly
+    if (-not $?)
+    {
+       Write-Output "Error: Could not set Production as Checkpoint type"  | Out-File -Append $summaryLog
+       return $false
+    }
+}
+
+$random = Get-Random -minimum 1024 -maximum 4096
+$snapshot = "TestSnapshot_$random"
+Checkpoint-VM -Name $vmName -SnapshotName $snapshot -ComputerName $hvServer
+if (-not $?)
+{
+    Write-Output "Error: Could not create checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+# Create another file on the VM
+$sts1 = CreateFile "/mnt/1/TestFile2"
+$sts2 = CreateFile "/mnt/2/TestFile2"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR: Cannot create file"
+    return $False
+}
+
+Restore-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer -Confirm:$false
+if (-not $?)
+{
+    Write-Output "Error: Could not restore checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+#
+# Starting the VM
+#
+Start-VM $vmName -ComputerName $hvServer
+
+#
+# Waiting for the VM to run again and respond to SSH - port 22
+#
+$timeout = 300
+while ($timeout -gt 0) {
+    if ( (TestPort $ipv4) ) {
+        break
+    }
+
+    Start-Sleep -seconds 2
+    $timeout -= 2
+}
+
+if ($timeout -eq 0) {
+    Write-Output "Error: Test case timed out waiting for VM to boot" | Out-File -Append $summaryLog
+    return $False
+}
+
+# Mount the partitions
+.\bin\plink -i ssh\${sshKey} root@${ipv4} "mount /dev/sdb1 /mnt/1; mount /dev/sdb2 /mnt/2"
+if ($TC_COVERED -eq "PC-06"){
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "mount /dev/sdc1 /mnt/1; mount /dev/sdc2 /mnt/2"
+}
+
+# Check the files
+$sts1 = CheckFile "/mnt/1/TestFile1"
+$sts2 = CheckFile "/mnt/2/TestFile1"
+if (-not $sts1 -Or -not $sts2)
+{
+    Write-Output "ERROR: TestFile1 is not present"
+    Write-Output "TestFile1 should be present on the VM" >> $summaryLog
+    return $False
+}
+
+$sts1 = CheckFile "/mnt/1/TestFile2"
+$sts2 = CheckFile "/mnt/2/TestFile2"
+if ($sts1 -Or $sts2)
+{
+    Write-Output "ERROR: TestFile2 is present"
+    Write-Output "TestFile2 should not be present on the VM" >> $summaryLog
+    return $False
+}
+
+Write-Output "Only the first file is present. Test succeeded" >> $summaryLog
+#
+# Delete the snapshot
+#
+"Info : Deleting Snapshot ${Snapshot} of VM ${vmName}"
+# First, unmount the partitions
+.\bin\plink -i ssh\${sshKey} root@${ipv4} "umount /dev/sdb1 /mnt/1; umount /dev/sdb2 /mnt/2"
+if ($TC_COVERED -eq "PC-06"){
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "umount /dev/sdc1 /mnt/1; umount /dev/sdc2 /mnt/2"
+}
+
+Remove-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer
+if ( -not $?)
+{
+   Write-Output "Error: Could not delete snapshot"  | Out-File -Append $summaryLog
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_partition.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_partition.ps1
@@ -1,0 +1,493 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+
+<#
+.Synopsis
+    Verify Production Checkpoint feature.
+
+.Description
+    This script will format and mount connected disk in the VM.
+    After that it will proceed with making a Production Checkpoint on test VM.
+
+    A typical test case definition for this test script would look
+    similar to the following:
+        <test>
+            <testName>ProductionCheckpoint_btrfs</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\AddHardDisk.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Production_checkpoint_partition.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-05</param>
+                <param>IDE=0,1,Dynamic</param>
+                <param>FILESYS=btrfs</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+.Parameter vmName
+    Name of the VM to perform the test with.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    A semicolon separated list of test parameters.
+
+.Example
+    setupScripts\STOR_TakeRevert_Snapshot.ps1 -vmName "myVm" -hvServer "localhost" 
+    -TestParams "TC_COVERED=PC-05;snapshotName=ICABase;IDE=0,1,Dynamic;FILESYS=ext4"
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# Runs a remote script on the VM an returns the log.
+#######################################################################
+function RunRemoteScript($remoteScript)
+{
+    $retValue = $False
+    $stateFile     = "state.txt"
+    $TestCompleted = "TestCompleted"
+    $TestAborted   = "TestAborted"
+    $TestRunning   = "TestRunning"
+    $timeout       = 6000
+
+    "./${remoteScript} > ${remoteScript}.log" | out-file -encoding ASCII -filepath runtest.sh
+
+    .\bin\pscp -i ssh\${sshKey} .\runtest.sh root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy runtest.sh to the VM"
+       return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\${remoteScript} root@${ipv4}:
+    if (-not $?)
+    {
+       Write-Output "ERROR: Unable to copy ${remoteScript} to the VM"
+       return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix ${remoteScript} 2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on ${remoteScript}"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to run dos2unix on runtest.sh"
+        return $False
+    }
+
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x ${remoteScript}   2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x ${remoteScript}"
+        return $False
+    }
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod +x runtest.sh  2> /dev/null"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to chmod +x runtest.sh " -
+        return $False
+    }
+
+    # Run the script on the vm
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "./runtest.sh"
+
+    # Return the state file
+    while ($timeout -ne 0 )
+    {
+    .\bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${stateFile} . #| out-null
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $stateFile)
+        {
+            $contents = Get-Content -Path $stateFile
+            if ($null -ne $contents)
+            {
+                    if ($contents -eq $TestCompleted)
+                    {
+                        Write-Output "Info : state file contains Testcompleted"
+                        $retValue = $True
+                        break
+
+                    }
+
+                    if ($contents -eq $TestAborted)
+                    {
+                         Write-Output "Info : State file contains TestAborted failed. "
+                         break
+
+                    }
+                    #Start-Sleep -s 1
+                    $timeout--
+
+                    if ($timeout -eq 0)
+                    {
+                        Write-Output "Error : Timed out on Test Running , Exiting test execution."
+                        break
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn : state file is empty"
+                break
+            }
+
+        }
+        else
+        {
+             Write-Host "Warn : ssh reported success, but state file was not copied"
+             break
+        }
+    }
+    else #
+    {
+         Write-Output "Error : pscp exit status = $sts"
+         Write-Output "Error : unable to pull state.txt from VM."
+         break
+    }
+    }
+
+    # Get the logs
+    $remoteScriptLog = $remoteScript+".log"
+
+    bin\pscp -q -i ssh\${sshKey} root@${ipv4}:${remoteScriptLog} .
+    $sts = $?
+    if ($sts)
+    {
+        if (test-path $remoteScriptLog)
+        {
+            $contents = Get-Content -Path $remoteScriptLog
+            if ($null -ne $contents)
+            {
+                    if ($null -ne ${TestLogDir})
+                    {
+                        move "${remoteScriptLog}" "${TestLogDir}\${remoteScriptLog}"
+
+                    }
+
+                    else
+                    {
+                        Write-Output "INFO: $remoteScriptLog is copied in ${rootDir}"
+                    }
+
+            }
+            else
+            {
+                Write-Output "Warn: $remoteScriptLog is empty"
+            }
+        }
+        else
+        {
+             Write-Output "Warn: ssh reported success, but $remoteScriptLog file was not copied"
+        }
+    }
+
+    # Cleanup
+    del state.txt -ErrorAction "SilentlyContinue"
+    del runtest.sh -ErrorAction "SilentlyContinue"
+
+    return $retValue
+}
+
+#######################################################################
+# Create a file on the VM.
+#######################################################################
+function CreateFile([string] $fileName)
+{
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "touch ${fileName}"
+    if (-not $?)
+    {
+        Write-Output "ERROR: Unable to create file" | Out-File -Append $summaryLog
+        return $False
+    }
+
+    return  $True
+}
+
+#######################################################################
+# Checks if test file is present or not.
+#######################################################################
+function CheckFile([string] $fileName)
+{
+    $retVal = $true
+    .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "stat ${fileName} 2>/dev/null" | out-null
+    if (-not $?)
+    {
+        $retVal = $false
+    }
+
+    return  $retVal
+}
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+$retVal = $false
+
+# Define and cleanup the summaryLog
+$summaryLog  = "${vmName}_summary.log"
+echo "Covers Production Checkpoint Testing" > $summaryLog
+
+# Define the guest partition script
+$remoteScript = "PartitionDisks.sh"
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $retVal
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED"  { $TC_COVERED = $fields[1].Trim() }
+    "sshKey"      { $sshKey = $fields[1].Trim() }
+    "ipv4"        { $ipv4 = $fields[1].Trim() }
+    "rootdir"     { $rootDir = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+echo $params
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source the TCUtils.ps1 file
+. .\setupscripts\TCUtils.ps1
+
+#Check if the host supports production checkpoints
+$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
+if (-not $osInfo)
+{
+    "Error: Unable to collect Operating System information"
+    return $False
+}
+
+[System.Int32]$buildNR = $osInfo.BuildNumber
+
+if ($buildNR -le 10500){
+    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
+    return $false
+}
+
+# Check if the Vm VHD in not on the same drive as the backup destination
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+if (-not $vm)
+{
+    "Error: VM '${vmName}' does not exist"
+    return $False
+}
+
+# Send utils.sh to VM
+echo y | .\bin\pscp -i ssh\${sshKey} .\remote-scripts\ica\utils.sh root@${ipv4}:
+if (-not $?)
+{
+    Write-Output "ERROR: Unable to copy utils.sh to the VM"
+    return $False
+}
+
+# Check to see Linux VM is running VSS backup daemon
+$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    return $False
+}
+
+Write-Output "VSS Daemon is running " >> $summaryLog
+
+# Run the remote script
+$sts = RunRemoteScript $remoteScript
+if (-not $sts[-1])
+{
+    Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+    Write-Output "ERROR: Running $remoteScript script failed on VM!"
+    Write-Output "Here are the remote logs:`n`n###################"
+    $logfilename = ".\$remoteScript.log"
+    Get-Content $logfilename
+    Write-Output "###################`n"
+    return $False
+}
+Write-Output "$remoteScript execution on VM: Success"
+Write-Output "Here are the remote logs:`n`n###################"
+$logfilename = ".\$remoteScript.log"
+Get-Content $logfilename
+Write-Output "###################`n"
+Write-Output "$remoteScript execution on VM: Success" >> $summaryLog
+del $remoteScript.log
+
+
+# Create a file on the VM
+$sts1 = CreateFile "/mnt/1/TestFile1"
+$sts1 = CreateFile "/mnt/2/TestFile1"
+if (-not $sts1[-1] -Or -not $sts2[-1])
+{
+    Write-Output "ERROR: Can not create file"
+    return $False
+}
+
+Start-Sleep -seconds 30
+
+#Check if we can set the Production Checkpoint as default
+if ($vm.CheckpointType -ne "ProductionOnly"){
+    Set-VM -Name $vmName -CheckpointType ProductionOnly
+    if (-not $?)
+    {
+       Write-Output "Error: Could not set Production as Checkpoint type"  | Out-File -Append $summaryLog
+       return $false
+    }
+}
+
+$random = Get-Random -minimum 1024 -maximum 4096
+$snapshot = "TestSnapshot_$random"
+Checkpoint-VM -Name $vmName -SnapshotName $snapshot -ComputerName $hvServer
+if (-not $?)
+{
+    Write-Output "Error: Could not create checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+# Create another file on the VM
+$sts1 = CreateFile "/mnt/1/TestFile2"
+$sts2 = CreateFile "/mnt/2/TestFile2"
+if (-not $sts[-1])
+{
+    Write-Output "ERROR: Cannot create file"
+    return $False
+}
+
+Restore-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer -Confirm:$false
+if (-not $?)
+{
+    Write-Output "Error: Could not restore checkpoint" | Out-File -Append $summaryLog
+    $error[0].Exception.Message
+    return $False
+}
+
+#
+# Starting the VM
+#
+Start-VM $vmName -ComputerName $hvServer
+
+#
+# Waiting for the VM to run again and respond to SSH - port 22
+#
+$timeout = 300
+while ($timeout -gt 0) {
+    if ( (TestPort $ipv4) ) {
+        break
+    }
+
+    Start-Sleep -seconds 2
+    $timeout -= 2
+}
+
+if ($timeout -eq 0) {
+    Write-Output "Error: Test case timed out waiting for VM to boot" | Out-File -Append $summaryLog
+    return $False
+}
+
+# Mount the partitions
+.\bin\plink -i ssh\${sshKey} root@${ipv4} "mount /dev/sdb1 /mnt/1; mount /dev/sdb2 /mnt/2"
+if ($TC_COVERED -eq "PC-06"){
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "mount /dev/sdc1 /mnt/1; mount /dev/sdc2 /mnt/2"
+}
+
+# Check the files
+$sts1 = CheckFile "/mnt/1/TestFile1"
+$sts2 = CheckFile "/mnt/2/TestFile1"
+if (-not $sts1 -Or -not $sts2)
+{
+    Write-Output "ERROR: TestFile1 is not present"
+    Write-Output "TestFile1 should be present on the VM" >> $summaryLog
+    return $False
+}
+
+$sts1 = CheckFile "/mnt/1/TestFile2"
+$sts2 = CheckFile "/mnt/2/TestFile2"
+if ($sts1 -Or $sts2)
+{
+    Write-Output "ERROR: TestFile2 is present"
+    Write-Output "TestFile2 should not be present on the VM" >> $summaryLog
+    return $False
+}
+
+Write-Output "Only the first file is present. Test succeeded" >> $summaryLog
+#
+# Delete the snapshot
+#
+"Info : Deleting Snapshot ${Snapshot} of VM ${vmName}"
+# First, unmount the partitions
+.\bin\plink -i ssh\${sshKey} root@${ipv4} "umount /dev/sdb1 /mnt/1; umount /dev/sdb2 /mnt/2"
+if ($TC_COVERED -eq "PC-06"){
+    .\bin\plink -i ssh\${sshKey} root@${ipv4} "umount /dev/sdc1 /mnt/1; umount /dev/sdc2 /mnt/2"
+}
+
+Remove-VMSnapshot -VMName $vmName -Name $snapshot -ComputerName $hvServer
+if ( -not $?)
+{
+   Write-Output "Error: Could not delete snapshot"  | Out-File -Append $summaryLog
+}
+
+return $true

--- a/WS2012R2/lisa/xml/Production_Checkpoint.xml
+++ b/WS2012R2/lisa/xml/Production_Checkpoint.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+    Copyright (c) Microsoft Corporation
+
+
+    All rights reserved. 
+    Licensed under the Apache License, Version 2.0 (the ""License"");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0  
+
+
+    THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+    ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+    PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+
+    See the Apache Version 2.0 License for specific language governing
+    permissions and limitations under the License.
+-->
+
+<config>
+    <global>
+        <logfileRootDir>TestResults</logfileRootDir>
+        <defaultSnapshot>ICABase</defaultSnapshot>
+        <email>
+            <recipients>
+                <to>myself@mycompany.com</to>
+            </recipients>
+            <sender>myself@mycompany.com</sender>
+            <subject>LIS_Production_Checkpoint_tests_WS2016</subject>
+            <smtpServer>mysmtphost.mycompany.com</smtpServer>
+        </email>
+    </global>
+
+    <testSuites>
+        <suite>
+            <suiteName>Production_Checkpoint</suiteName>
+            <suiteTests>
+                <suiteTest>ProductionCheckpoint</suiteTest>   
+                <suiteTest>ProductionCheckpoint_Failback</suiteTest>
+                <suiteTest>ProductionCheckpoint_ext3</suiteTest>
+                <suiteTest>ProductionCheckpoint_ext4</suiteTest>
+                <suiteTest>ProductionCheckpoint_btrfs</suiteTest>
+                <suiteTest>ProductionCheckpoint_IDE_SCSI</suiteTest>
+                <suiteTest>ProductionCheckpoint_SCSI_vhdx</suiteTest>
+                <suiteTest>ProductionCheckpoint_ISO_NoNetwork</suiteTest> 
+                <suiteTest>ProductionCheckpoint_3Chain_VHD</suiteTest>
+                <suiteTest>ProductionCheckpoint_iSCSI</suiteTest>
+            </suiteTests>
+        </suite>
+    </testSuites>
+
+    <testCases>
+        <test>
+            <testName>ProductionCheckpoint</testName>
+            <testScript>setupscripts\Production_checkpoint.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-01</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_Failback</testName>
+            <testScript>setupscripts\Production_checkpoint_failback.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-02</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_ext3</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\AddHardDisk.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Production_checkpoint_partition.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-03</param>
+                <param>IDE=0,1,Dynamic</param>
+                <param>FILESYS=ext3</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_ext4</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\AddHardDisk.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Production_checkpoint_partition.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-04</param>
+                <param>IDE=0,1,Dynamic</param>
+                <param>FILESYS=ext4</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_btrfs</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\AddHardDisk.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Production_checkpoint_partition.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-05</param>
+                <param>IDE=0,1,Dynamic</param>
+                <param>FILESYS=btrfs</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_IDE_SCSI</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\AddHardDisk.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Production_checkpoint_partition.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-06</param>
+                <param>IDE=0,1,Dynamic</param>
+                <param>SCSI=0,1,Dynamic</param>
+                <param>FILESYS=ext4</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_SCSI_vhdx</testName>
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\AddHardDisk.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Production_checkpoint_partition.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-07</param>
+                <param>SCSI=0,1,Dynamic</param>
+                <param>FILESYS=ext4</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_ISO_NoNetwork</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\Production_checkpoint_ISO_NoNetwork.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-08</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_3Chain_VHD</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\Production_checkpoint_3Chain_VHD.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-09</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
+        <test>
+            <testName>ProductionCheckpoint_iSCSI</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\Production_checkpoint_iSCSI.ps1</testScript> 
+            <testParams>
+                <param>TC_COVERED=PC-10</param>
+                <param>TargetIP=TARGET_IP</param>
+                <param>IQN=TARGET_IQN</param>
+                <param>FILESYS=ext4</param>
+                <param>snapshotName=ICABase</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+    </testCases>
+
+    <VMs>
+        <vm>
+            <hvServer>localhost</hvServer>
+            <vmName>VMNAME</vmName>
+            <os>Linux</os>
+            <ipv4></ipv4>
+            <sshKey>id_key.ppk</sshKey>
+            <suite>Production_Checkpoint</suite>
+        </vm>
+    </VMs>
+</config>


### PR DESCRIPTION
This test suite will check Production Checkpoint feature in WS2016. Test
list:
1. ProductionCheckpoint - basic test: Create a file on the VM; take
checkpoint; create second file; revert to the checkpoint & check for the
first file created
2. ProductionCheckpoint_Failback - VSS daemon is stopped inside VM and
then a Production checkpoint is taken. Test passes if a standard
checkpoint is taken instead
3. ProductionCheckpoint_ext3 - attach a vhd on IDE, format it in
ext3 & mount it.
4. ProductionCheckpoint_ext4 - attach a vhd on IDE, format it in
ext4 & mount it.
5. ProductionCheckpoint_btrfs - attach a vhd on IDE, format it in
btrfs & mount it.
6. ProductionCheckpoint_IDE_SCSI - attach 2 vhds on IDE and SCSI,
format them in ext4 & mount.
7. ProductionCheckpoint_SCSI_vhdx - attach a vhdx on SCSI, format it
in ext4 & mount it.
8. ProductionCheckpoint_iSCSI - connect to a iSCSI Target,
format disk in ext4 & mount it.
NOTE: For tests 3-8, the validation is:
     - Create a file on the mounting point
     - Take checkpoint then create second file
     - Revert to the checkpoint
     - Check for the first file created
9. ProductionCheckpoint_ISO_NoNetwork - attach an ISO file and
stop network connectivity. Take Production Checkpoint.
Revert the checkpoint and verify if ISO is still present.
10. ProductionCheckpoint_3Chain_VHD - create a new VM with a
3-chained differencing disk attached based on the source vm vhd.
After that, verify Production Checkpoint feature on the new VM