### PR TITLE
Kdump improvements

### DIFF
--- a/WS2012R2/lisa/setupscripts/Kdump.ps1
+++ b/WS2012R2/lisa/setupscripts/Kdump.ps1
@@ -187,7 +187,7 @@ if ($nmi -eq 1){
     Debug-VM -Name $vmName -InjectNonMaskableInterrupt -ComputerName $hvServer -Force
 }
 else {
-    $retVal = SendCommandToVM $ipv4 $sshKey "echo 'echo c > /proc/sysrq-trigger' | at now + 1 minutes"
+    $retVal = SendCommandToVM $ipv4 $sshKey "echo c > /proc/sysrq-trigger 2>/dev/null &"
 }
 
 #
@@ -202,38 +202,31 @@ if ((Get-VMIntegrationService -VMName $vmName -ComputerName $hvServer | ?{$_.nam
 }
 
 Write-Output "VM Heartbeat is OK."
-#
+
 # Waiting the VM to have a connection
 Write-Output "Checking the VM connection after kernel panic..."
-$temporar = 60
-do {
-    sleep 5
-    $temporar -= 5
-    if ($temporar -eq 0)
-    {
-        Write-Output "Error: Cannont connect to VM in time, maybe kernel panic occured again after reboot. Check summary.log for configuration problems."
-        Stop-VM -Name $vmName -ComputerName $hvServer -Force
-        return $False   
-    } 
-} until(Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue | ? { $_.TcpTestSucceeded } )
+
+$sts = WaitForVMToStartSSH $ipv4 100
+if (-not $sts[-1]){
+    Write-Output "Error: $vmName didn't restart after triggering the crash"
+    return $false
+}
 
 #
 # Verifying if the kernel panic process creates a vmcore file of size 10M+
 #
 Write-Output "Connection to VM is good. Checking the results..."
-if ((Get-VM -ComputerName $hvServer -Name $vmName).State -eq "Running") {
-    $retVal = SendFileToVM $ipv4 $sshKey ".\remote-scripts\ica\kdump_results.sh" "/root/kdump_results.sh"
+$retVal = SendFileToVM $ipv4 $sshKey ".\remote-scripts\ica\kdump_results.sh" "/root/kdump_results.sh"
 
-    # check the return Value of SendFileToVM
-    if (-not $retVal)
-    {
-        Write-Output "Error: Failed to send kdump_results.sh to VM."
-        return $false
-    }
-    Write-Output "Success: send kdump_results.sh to VM."
-
-    $retVal = SendCommandToVM $ipv4 $sshKey "cd /root && dos2unix kdump_results.sh && chmod u+x kdump_results.sh && ./kdump_results.sh"
+# check the return Value of SendFileToVM
+if (-not $retVal)
+{
+    Write-Output "Error: Failed to send kdump_results.sh to VM."
+    return $false
 }
+Write-Output "Success: sent kdump_results.sh to VM."
+
+$retVal = SendCommandToVM $ipv4 $sshKey "cd /root && dos2unix kdump_results.sh && chmod u+x kdump_results.sh && ./kdump_results.sh"
 
 $retVal = CheckResults $sshKey $ipv4
 return $retVal

--- a/WS2012R2/lisa/setupscripts/Kdump.ps1
+++ b/WS2012R2/lisa/setupscripts/Kdump.ps1
@@ -187,7 +187,13 @@ if ($nmi -eq 1){
     Debug-VM -Name $vmName -InjectNonMaskableInterrupt -ComputerName $hvServer -Force
 }
 else {
-    $retVal = SendCommandToVM $ipv4 $sshKey "echo c > /proc/sysrq-trigger 2>/dev/null &"
+    if ($vcpu -eq 4){
+        "Kdump will be triggered on VCPU 3 of 4"
+        $retVal = SendCommandToVM $ipv4 $sshKey "taskset -c 2 echo c > /proc/sysrq-trigger 2>/dev/null &"    
+    } 
+    else {
+        $retVal = SendCommandToVM $ipv4 $sshKey "echo c > /proc/sysrq-trigger 2>/dev/null &"
+    }
 }
 
 #

--- a/WS2012R2/lisa/xml/Kdump_Tests.xml
+++ b/WS2012R2/lisa/xml/Kdump_Tests.xml
@@ -37,6 +37,7 @@
                 <suiteTest>Crash_single_core</suiteTest>
                 <suiteTest>Crash_SMP</suiteTest>
                 <suiteTest>Crash_NMI</suiteTest>
+                <suiteTest>Crash_differentVCPU</suiteTest>
                 <!-- Only for REDHAT. Test with crashkernel=auto -->
                 <suiteTest>Crash_Auto_size</suiteTest>
             </suiteTests>
@@ -108,6 +109,23 @@
                 <param>crashkernel=auto</param>
                 <param>TC_COVERED=KDUMP-04</param>
                 <param>VCPU=2</param>
+                <param>VMMemory=2GB</param>
+            </testParams>
+            <timeout>600</timeout>
+        </test>
+
+        <test>
+            <testName>Crash_DifferentVCPU</testName>
+            <setupScript>
+                <file>setupscripts\ChangeCPU.ps1</file>
+                <file>setupScripts\SetVMMemory.ps1</file>
+            </setupScript>
+            <testScript>setupScripts\kdump.ps1</testScript>
+            <testParams>
+                <!-- Minimum RAM=2GB -->
+                <param>crashkernel=256M@128M</param>
+                <param>TC_COVERED=KDUMP-05</param>
+                <param>VCPU=4</param>
                 <param>VMMemory=2GB</param>
             </testParams>
             <timeout>600</timeout>


### PR DESCRIPTION
1. 'at' usage was removed, instead we will use stderr to avoid plink
freezing. This should make crash triggering more stable. Also,
Test-NetConnection was removed, instead, an existing function will be
used to verify the VM status.

2. Crash_DifferentVCPU testcase was added. This will start the VM with 4
vcpus and trigger a kdump on VCPU 2 of (0-3). Usually, by default kdump
is triggered on VCPU 0 or 1