### PR TITLE
Adding perf_utils.sh sourcing possibility without code execution

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/perf_utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_utils.sh
@@ -72,18 +72,21 @@ function setup_io_scheduler {
     sleep 5
 }
 
-echo "###Setting sysctl params###"
-setup_sysctl
-if [[ $? -ne 0 ]]
-then
-    echo "ERROR: Unable to set sysctl params"
-    exit 1
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    echo "###Setting sysctl params###"
+    setup_sysctl
+    if [[ $? -ne 0 ]]
+    then
+        echo "ERROR: Unable to set sysctl params"
+        exit 1
+    fi
+    echo "###Setting elevator to noop###"
+    setup_io_scheduler
+    if [[ $? -ne 0 ]]
+    then
+        echo "ERROR: Unable to set elevator to noop."
+        exit 1
+    fi
+    echo "Done."
 fi
-echo "###Setting elevator to noop###"
-setup_io_scheduler
-if [[ $? -ne 0 ]]
-then
-    echo "ERROR: Unable to set elevator to noop."
-    exit 1
-fi
-echo "Done."
+


### PR DESCRIPTION
Wrapping script function calls to allow sourcing without code execution. Tested on Centos, Sles and Ubuntu.