### PR TITLE
Add log parser to upload results for NTTTCP and FIO performance test cases

### DIFF
--- a/WS2012R2/lisa/Infrastructure/lisa-parser/file_parser.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/file_parser.py
@@ -176,7 +176,7 @@ def parse_ica_log(log_path):
 
         # Get timestamp
         parsed_ica['timestamp'] = re.search('([0-9/]+) ([0-9:]+)',
-            log_file.next()).group(0)
+                                            log_file.next()).group(0)
 
         vm_name = ""
         for line in log_file:
@@ -399,7 +399,7 @@ class NTTTCPLogsReader(BaseLogsReader):
                                 log_dict[key] = throughput.group(1).strip()
                 elif 'latency' in key:
                     lat_file = os.path.join(self.log_path,
-                                            'tcping-ntttcp-p{}.log'
+                                            'lagscope-ntttcp-p{}.log'
                                             .format(f_match.group(1)))
                     with open(lat_file, 'r') as f:
                         lines = f.readlines()

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/file_parser.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/file_parser.py
@@ -348,16 +348,16 @@ class FIOLogsReader(BaseLogsReader):
             for key in log_dict:
                 if not log_dict[key]:
                     for x in range(0, len(f_lines)):
-                        if all(markers in lines[x] for markers in
+                        if all(markers in f_lines[x] for markers in
                                [key.split(':')[0], 'pid=']):
                             if 'latency' in key:
                                 lat = re.match('.+lat \(.+avg=([0-9. ]+)',
-                                               lines[x + 4])
+                                               f_lines[x + 4])
                                 if lat:
                                     log_dict[key] = lat.group(1).strip()
                             else:
                                 iops = re.match('.+iops=([0-9. ]+)',
-                                                lines[x + 1])
+                                                f_lines[x + 1])
                                 if iops:
                                     log_dict[key] = iops.group(1).strip()
         return log_dict
@@ -407,7 +407,7 @@ class NTTTCPLogsReader(BaseLogsReader):
                         f_lines = fl.readlines()
                         for x in range(0, len(f_lines)):
                             r_latency = re.match('.+Average = ([0-9.]+)',
-                                                 lines[x])
+                                                 f_lines[x])
                             if r_latency:
                                 log_dict[key] = r_latency.group(1).strip()
                 elif 'packet_size' in key:

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser.py
@@ -70,7 +70,8 @@ def main(args):
     test_run.update_from_xml(parsed_arguments.xml_file_path)
 
     logger.info('Parsing log file - %s', parsed_arguments.log_file_path)
-    test_run.update_from_ica(parsed_arguments.log_file_path)
+    if not parsed_arguments.perf:
+        test_run.update_from_ica(parsed_arguments.log_file_path)
 
     if not parsed_arguments.skipkvp:
         logger.info('Getting KVP values from VM')

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser.py
@@ -70,8 +70,7 @@ def main(args):
     test_run.update_from_xml(parsed_arguments.xml_file_path)
 
     logger.info('Parsing log file - %s', parsed_arguments.log_file_path)
-    if not parsed_arguments.perf:
-        test_run.update_from_ica(parsed_arguments.log_file_path)
+    test_run.update_from_ica(parsed_arguments.log_file_path)
 
     if not parsed_arguments.skipkvp:
         logger.info('Getting KVP values from VM')

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/test_run.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/test_run.py
@@ -22,7 +22,8 @@ permissions and limitations under the License.
 from __future__ import print_function
 from file_parser import ParseXML
 from file_parser import parse_ica_log
-from file_parser import parse_from_csv
+from file_parser import FIOLogsReader
+from file_parser import NTTTCPLogsReader
 from virtual_machine import VirtualMachine
 from copy import deepcopy
 import logging
@@ -196,7 +197,11 @@ class PerfTestRun(TestRun):
 
     def update_from_ica(self, log_path):
         super(PerfTestRun, self).update_from_ica(log_path)
-        parsed_perf_log = parse_from_csv(self.perf_path)
+        parsed_perf_log = None
+        if self.suite.lower() == 'fio':
+            parsed_perf_log = FIOLogsReader(self.perf_path).process_logs()
+        elif self.suite.lower() == 'ntttcp':
+            parsed_perf_log = NTTTCPLogsReader(self.perf_path).process_logs()
 
         tests_cases = dict()
         test_index = 0
@@ -255,6 +260,17 @@ class PerfTestRun(TestRun):
         table_dict['Latency_SeqRead'] = float(test_case_obj.perf_dict[
             'seq-read: latency'])
         table_dict['Iodepth'] = float(test_case_obj.perf_dict['BlockSize'][1:])
+
+    @staticmethod
+    def prep_for_ntttcp(table_dict, test_case_obj):
+        table_dict['NumberOfConnections'] = int(test_case_obj.perf_dict[
+                                                    '#test_connections'])
+        table_dict['Throughput_Gbps'] = float(test_case_obj.perf_dict[
+                                                   'throughput_gbps'])
+        table_dict['Latency_ms'] = float(test_case_obj.perf_dict[
+                                             'average_tcp_latency'])
+        table_dict['PacketSize_KBytes'] = float(test_case_obj.perf_dict[
+                                                    'average_packet_size'])
 
 
 class TestCase(object):

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/test_run.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/test_run.py
@@ -237,7 +237,6 @@ class PerfTestRun(TestRun):
             test_case_obj = self.test_cases[table_dict['TestCaseName']]
             if self.suite.lower() == 'fio':
                 self.prep_for_fio(table_dict, test_case_obj)
-                table_dict['BlockSize'] = '8k'
             elif self.suite.lower() == 'ntttcp':
                 self.prep_for_ntttcp(table_dict, test_case_obj)
 
@@ -271,6 +270,8 @@ class PerfTestRun(TestRun):
                                              'average_tcp_latency'])
         table_dict['PacketSize_KBytes'] = float(test_case_obj.perf_dict[
                                                     'average_packet_size'])
+        table_dict['IPVersion'] = test_case_obj.perf_dict['IPVersion']
+        table_dict['ProtocolType'] = test_case_obj.perf_dict['Protocol']
 
 
 class TestCase(object):

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/test_run.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/test_run.py
@@ -233,13 +233,13 @@ class PerfTestRun(TestRun):
 
             # TODO - Find fix for hardcoded values
             table_dict['GuestSize'] = '8VP8G40G'
-            table_dict['BlockSize'] = '8k'
 
             test_case_obj = self.test_cases[table_dict['TestCaseName']]
             if self.suite.lower() == 'fio':
                 self.prep_for_fio(table_dict, test_case_obj)
+                table_dict['BlockSize'] = '8k'
             elif self.suite.lower() == 'ntttcp':
-                pass
+                self.prep_for_ntttcp(table_dict, test_case_obj)
 
             table_dict['TestCaseName'] = table_dict['TestCaseName'][:-1]
 


### PR DESCRIPTION
Tested manually on an NTTTCP generated zipped log results with the following command:
python lisa_parser.py <lisa_xml_testcase> <ica_log> -p <full_path_zipped_log> -c <db_config>