### PR TITLE
DM: switched to stress-ng as memory pressure tool

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_HotAdd.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd.ps1
@@ -72,7 +72,7 @@ function checkStressapptest([String]$conIpv4, [String]$sshKey)
 
     $cmdToVM = @"
 #!/bin/bash
-        command -v stressapptest
+        command -v stress-ng
         sts=`$?
         if [ 0 -ne `$sts ]; then
             echo "Stressapptest is not installed! Please install it before running the memory stress tests." >> /root/HotAdd.log 2>&1

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -124,15 +124,15 @@
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
-				<param>maxMem=6GB</param>
+				<param>maxMem=30%</param>
 				<param>startupMem=1024MB</param>
 				<param>memWeight=100</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=512MB</param>
-				<param>maxMem=70%</param>
-				<param>startupMem=70%</param>
+				<param>maxMem=68%</param>
+				<param>startupMem=68%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 			</testParams>
@@ -254,14 +254,14 @@
 				<param>enableDM=yes</param>
 				<param>minMem=50%</param>
 				<param>maxMem=80%</param>
-				<param>startupMem=80%</param>
+				<param>startupMem=75%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=512MB</param>
 				<param>maxMem=50%</param>
-				<param>startupMem=50%</param>
+				<param>startupMem=45%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 			</testParams>


### PR DESCRIPTION
- Switched to stress-ng as memory pressure tool from stresapptest
- The only remaining test using stressapptest is HotAdd. It can be used for a while to double check the validity of stress-ng
- Changed the way stress tests handle memory and pressure calculations
- Tested on SLES 12 and partially on RHEL 7.2. Should work well with kernels 3.x and 4.x

Please report any issues or misbehavior as these are not only guest, but host dependent as well.