### PR TITLE
Dynamic Memory refactoring

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
@@ -68,55 +68,6 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 
 Set-PSDebug -Strict
 
-function checkStressapptest([String]$conIpv4, [String]$sshKey)
-{
-
-
-    $cmdToVM = @"
-#!/bin/bash
-        command -v stress-ng
-        sts=`$?
-        if [ 0 -ne `$sts ]; then
-            echo "Stressapptest is not installed! Please install it before running the memory stress tests." >> /root/HotAdd.log 2>&1
-        else
-            echo "Stressapptest is installed! Will begin running memory stress tests shortly." >> /root/HotAdd.log 2>&1
-        fi
-        echo "CheckStressappreturned `$sts"
-        exit `$sts
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "CheckStressapp.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal)
-    {
-        return $false
-    }
-
-    # execute command
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-}
-
 # we need a scriptblock in order to pass this function to start-job
 $scriptBlock = {
   # function which $memMB MB of memory on VM with IP $conIpv4 with stresstestapp
@@ -424,18 +375,18 @@ if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "
 }
 
 
-# Check if stressapptest is installed
-"Checking if Stressapptest is installed"
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
 
-$retVal = checkStressapptest $ipv4 $sshKey
+$retVal = check_app "stress-ng"
 
 if (-not $retVal)
 {
-    "Stressapptest is not installed on $vm1Name! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests."
     return $false
 }
 
-"Stressapptest is installed on $vm1Name! Will begin running memory stress tests shortly."
+"stress-ng is installed! Will begin running memory stress tests shortly."
 
 # Check kernel version
 $sts = check_kernel
@@ -445,7 +396,7 @@ if (-not $sts) {
   $retVal = $False
 }
 elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stressapp processes."
+  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
   $timeoutStress = 8
 }
 else {
@@ -490,16 +441,18 @@ if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm2BeforeAssigned -
 # get vm2 IP
 $vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
-# Check if stressapptest is installed on 2nd VM
-$retVal = checkStressapptest $vm2ipv4 $sshKey
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = check_app "stress-ng" $vm2ipv4
 
 if (-not $retVal)
 {
-    "Stressapptest is not installed on $vm2Name! Please install it before running the memory stress tests."
+    "stress-ng is not installed on $vm2Name! Please install it before running the memory stress tests."
     return $false
 }
 
-"Stressapptest is installed on $vm2Name! Will begin running memory stress tests shortly."
+"stress-ng is installed on $vm2Name! Will begin running memory stress tests shortly."
 
 # wait for ssh to start on vm2
 $timeout = 30 #seconds

--- a/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
@@ -129,7 +129,7 @@ $scriptBlock = {
           timeout=4000000
           duration=`$((5*__threads))
         else
-          timeout=8000000
+          timeout=10000000
           duration=`$((9*__threads))
         fi
         echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd.ps1
@@ -72,7 +72,7 @@ function checkStressapptest([String]$conIpv4, [String]$sshKey)
 
     $cmdToVM = @"
 #!/bin/bash
-        command -v stressapptest
+        command -v stress-ng
         sts=`$?
         if [ 0 -ne `$sts ]; then
             echo "Stressapptest is not installed! Please install it before running the memory stress tests." >> /root/HotAdd.log 2>&1

--- a/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
@@ -128,7 +128,7 @@ $scriptBlock = {
           timeout=4000000
           duration=`$((5*__threads))
         else
-          timeout=8000000
+          timeout=10000000
           duration=`$((9*__threads))
         fi
         echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1

--- a/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
@@ -67,55 +67,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-function checkStressapptest([String]$conIpv4, [String]$sshKey)
-{
-
-
-    $cmdToVM = @"
-#!/bin/bash
-        command -v stress-ng >> /root/HotAdd.log 2>&1
-        sts=`$?
-        if [ 0 -ne `$sts ]; then
-            echo "Stressapptest is not installed! Please install it before running the memory stress tests." >> /root/HotAdd.log 2>&1
-        else
-            echo "Stressapptest is installed! Will begin running memory stress tests shortly." >> /root/HotAdd.log 2>&1
-        fi
-        echo "CheckStressappreturned `$sts"
-        exit `$sts
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "CheckStressapp.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal)
-    {
-        return $false
-    }
-
-    # execute command
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-}
-
 # we need a scriptblock in order to pass this function to start-job
 $scriptBlock = {
   # function for starting stresstestapp
@@ -422,18 +373,18 @@ if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "
   return $false
 }
 
-# Check if stressapptest is installed
-"Checking if Stressapptest is installed"
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
 
-$retVal = checkStressapptest $ipv4 $sshKey
+$retVal = check_app "stress-ng"
 
 if (-not $retVal)
 {
-    "Stressapptest is not installed! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests."
     return $false
 }
 
-"Stressapptest is installed! Will begin running memory stress tests shortly."
+"stress-ng is installed! Will begin running memory stress tests shortly."
 
 # Check kernel version
 $sts = check_kernel
@@ -443,7 +394,7 @@ if (-not $sts) {
   $retVal = $False
 }
 elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stressapp processes."
+  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
   $timeoutStress = 8
 }
 else {

--- a/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
@@ -464,7 +464,7 @@ if (-not $?)
 }
 
 # sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 180
+start-sleep -s 120
 # get memory stats for vm1 after stresstestapp starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
@@ -373,7 +373,7 @@ if (-not $?)
 }
 
 # sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
-start-sleep -s 180
+start-sleep -s 120
 # get memory stats for vm1 after stress-ng starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
@@ -66,53 +66,10 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-function checkStressNg([String]$conIpv4, [String]$sshKey)
-{
-
-
-    $cmdToVM = @"
-#!/bin/bash
-        command -v stress-ng
-        sts=`$?
-        exit `$sts
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "CheckStress-ng.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal)
-    {
-        return $false
-    }
-
-    # execute command
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-}
-
 # we need a scriptblock in order to pass this function to start-job
 $scriptBlock = {
-  # function for starting stress-ng
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir)
+  # function for starting stresstestapp
+  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir, [int]$timeoutStress, [int64]$memMB)
   {
 
   # because function is called as job, setup rootDir and source TCUtils again
@@ -156,14 +113,26 @@ $scriptBlock = {
         dos2unix check_traces.sh
         chmod +x check_traces.sh
         ./check_traces.sh &
-        
+
         __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
         __totalMem=`$((__totalMem/1024))
         echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
-        __threads=16
+        declare -i __chunks
+        declare -i __threads
+        declare -i duration
+        declare -i timeout
         __chunks=128
-        echo "Going to start `$__threads instance(s) of stress-ng every 2 seconds, each consuming 128MB memory" >> /root/HotAdd.log 2>&1
-        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t 60 --backoff 2000000
+        __threads=`$(($memMB/__chunks))
+        if [ $timeoutStress -eq 1 ]; then
+          timeout=4000000
+          duration=`$((5*__threads))
+        else
+          timeout=10000000
+          duration=`$((9*__threads))
+        fi
+        echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1
+        echo "Other info: chunks: `$__chunks , memory: $memMB" >> /root/HotAdd.log 2>&1
+        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
         echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
         wait
         exit 0
@@ -330,15 +299,31 @@ if (-not $vm1)
 # Check if stress-ng is installed
 "Checking if stress-ng is installed"
 
-$retVal = checkStressNg $ipv4 $sshKey
+$retVal = check_app "stress-ng"
 
 if (-not $retVal)
 {
-    "Stress-ng is not installed! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests."
     return $false
 }
 
-"Stress-ng is installed! Will begin running memory stress tests shortly."
+"stress-ng is installed! Will begin running memory stress tests shortly."
+
+# Check kernel version
+$sts = check_kernel
+
+if (-not $sts) {
+  "ERROR: Could not check kernel version"
+  $retVal = $False
+}
+elseif ($sts -like '2.6*') {
+  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
+  $timeoutStress = 8
+}
+else {
+  "Kernel version: ${sts}"
+  $timeoutStress = 1
+}
 
 # get memory stats from vm1
 # wait up to 2 min for it
@@ -372,8 +357,14 @@ if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 "Memory stats after $vm1Name started reporting "
 "  ${vm1Name}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
 
+# Calculate the amount of memory to be consumed on VM1 and VM2 with stresstestapp
+[int64]$vm1ConsumeMem = (Get-VMMemory -VM $vm1).Maximum
+
+# transform to MB
+$vm1ConsumeMem /= 1MB
+
 # Send Command to consume
-$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir) ConsumeMemory $ip $sshKey $rootDir } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir)
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem} -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem)
 if (-not $?)
 {
   "Error: Unable to start job for creating pressure on $vm1Name"
@@ -382,7 +373,7 @@ if (-not $?)
 }
 
 # sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
-start-sleep -s 50
+start-sleep -s 180
 # get memory stats for vm1 after stress-ng starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_stressapptest.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_stressapptest.ps1
@@ -66,55 +66,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-function checkStressapptest([String]$conIpv4, [String]$sshKey)
-{
-
-
-    $cmdToVM = @"
-#!/bin/bash
-        command -v stress-ng
-        sts=`$?
-        if [ 0 -ne `$sts ]; then
-            echo "Stressapptest is not installed! Please install it before running the memory stress tests." >> /root/HotAdd.log 2>&1
-        else
-            echo "Stressapptest is installed! Will begin running memory stress tests shortly." >> /root/HotAdd.log 2>&1
-        fi
-        echo "CheckStressappreturned `$sts"
-        exit `$sts
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "CheckStressapp.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal)
-    {
-        return $false
-    }
-
-    # execute command
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-}
-
 # we need a scriptblock in order to pass this function to start-job
 $scriptBlock = {
   # function for starting stresstestapp
@@ -346,7 +297,7 @@ if (-not $vm1)
 # Check if stressapptest is installed
 "Checking if Stressapptest is installed"
 
-$retVal = checkStressapptest $ipv4 $sshKey
+$retVal = check_app "stressapptest"
 
 if (-not $retVal)
 {

--- a/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
@@ -128,7 +128,7 @@ $scriptBlock = {
           timeout=4000000
           duration=`$((5*__threads))
         else
-          timeout=8000000
+          timeout=10000000
           duration=`$((9*__threads))
         fi
         echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1

--- a/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
@@ -373,6 +373,19 @@ if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "
   return $false
 }
 
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = check_app "stress-ng"
+
+if (-not $retVal)
+{
+    "stress-ng is not installed! Please install it before running the memory stress tests."
+    return $false
+}
+
+"stress-ng is installed! Will begin running memory stress tests shortly."
+
 # Check kernel version
 $sts = check_kernel
 
@@ -381,7 +394,7 @@ if (-not $sts) {
   $retVal = $False
 }
 elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stressapp processes."
+  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
   $timeoutStress = 8
 }
 else {

--- a/WS2012R2/lisa/setupscripts/DM_PressureChangesDemand.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_PressureChangesDemand.ps1
@@ -129,7 +129,7 @@ $scriptBlock = {
           timeout=4000000
         else
           duration=180
-          timeout=8000000
+          timeout=10000000
         fi
         echo "Going to start `$__iterations instance(s) of stresstestapp with a duration of `$duration and a timeout of $timeoutStress each consuming 128MB memory" >> /root/HotAdd.log 2>&1
         stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout

--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -565,7 +565,7 @@ if (-not $?)
 }
 
 # sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 180
+start-sleep -s 120
 # get memory stats for vm1 and vm2 just before vm3 starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/[int64]1048576)
 [int64]$vm1Demand = ($vm1.MemoryDemand/[int64]1048576)

--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -131,7 +131,7 @@ $scriptBlock = {
           timeout=4000000
           duration=`$((3*__threads))
         else
-          timeout=8000000
+          timeout=10000000
           duration=`$((7*__threads))
         fi
         echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1

--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -70,55 +70,6 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 
 Set-PSDebug -Strict
 
-function checkStressapptest([String]$conIpv4, [String]$sshKey)
-{
-
-
-    $cmdToVM = @"
-#!/bin/bash
-        command -v stress-ng
-        sts=`$?
-        if [ 0 -ne `$sts ]; then
-            echo "Stressapptest is not installed! Please install it before running the memory stress tests." >> /root/HotAdd.log 2>&1
-        else
-            echo "Stressapptest is installed! Will begin running memory stress tests shortly." >> /root/HotAdd.log 2>&1
-        fi
-        echo "CheckStressappreturned `$sts"
-        exit `$sts
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "CheckStressapp.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-        Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal)
-    {
-        return $false
-    }
-
-    # execute command
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-}
-
 # we need a scriptblock in order to pass this function to start-job
 $scriptBlock = {
   # function which $memMB MB of memory on VM with IP $conIpv4 with stresstestapp
@@ -489,18 +440,18 @@ if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "
 }
 
 
-# Check if stressapptest is installed
-"Checking if Stressapptest is installed"
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
 
-$retVal = checkStressapptest $ipv4 $sshKey
+$retVal = check_app "stress-ng"
 
 if (-not $retVal)
 {
-    "Stressapptest is not installed on $vm1Name! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests."
     return $false
 }
 
-"Stressapptest is installed on $vm1Name! Will begin running memory stress tests shortly."
+"stress-ng is installed! Will begin running memory stress tests shortly."
 
 # Check kernel version
 $sts = check_kernel
@@ -510,7 +461,7 @@ if (-not $sts) {
   $retVal = $False
 }
 elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stressapp processes."
+  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
   $timeoutStress = 8
 }
 else {
@@ -556,16 +507,18 @@ if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 # get vm2 IP
 $vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
-# Check if stressapptest is installed on 2nd VM
-$retVal = checkStressapptest $vm2ipv4 $sshKey
+# Check if stress-ng is installed
+"Checking if stress-ng is installed"
+
+$retVal = check_app "stress-ng" $vm2ipv4
 
 if (-not $retVal)
 {
-    "Stressapptest is not installed on $vm2Name! Please install it before running the memory stress tests."
+    "stress-ng is not installed on $vm2Name! Please install it before running the memory stress tests."
     return $false
 }
 
-"Stressapptest is installed on $vm2Name! Will begin running memory stress tests shortly."
+"stress-ng is installed on $vm2Name! Will begin running memory stress tests shortly."
 
 # wait for ssh to start on vm2
 $timeout = 30 #seconds

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -980,7 +980,7 @@ function WaitForVMToStartSSH([String] $ipv4addr, [int] $timeout)
 # WaiForVMToStop()
 #
 #######################################################################
-function  WaitForVMToStop ([string] $vmName ,[string]  $hvServer, [int] $timeout)
+function  WaitForVMToStop ([string] $vmName, [string] $hvServer, [int] $timeout)
 {
     <#
     .Synopsis
@@ -1190,6 +1190,26 @@ function check_kernel
     .\bin\plink -i ssh\${sshKey} root@${ipv4} "uname -r"
     if (-not $?) {
         Write-Output "ERROR: Unable check kernel version" -ErrorAction SilentlyContinue
+        return $False
+    }
+}
+
+#######################################################################
+#
+# Check for application on VM
+#
+#######################################################################
+function check_app([string]$app_name, [string]$custom_ip)
+{
+    IF([string]::IsNullOrWhiteSpace($custom_ip)) {
+        $target_ip = $ipv4
+    }
+    else {
+        $target_ip = $custom_ip
+    }
+    .\bin\plink -i ssh\${sshKey} root@${target_ip} "command -v ${app_name}"
+    if (-not $?) {
+        Write-Output "ERROR: ${app_name} is not installed on the VM" -ErrorAction SilentlyContinue
         return $False
     }
 }

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -66,7 +66,7 @@
 			<testParams>
 				<param>TC_COVERED=DM-02</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=2GB</param>
 				<param>startupMem=1024MB</param>
 				<param>memWeight=20</param>
@@ -130,7 +130,7 @@
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=70%</param>
 				<param>startupMem=65%</param>
 				<param>memWeight=0</param>
@@ -149,18 +149,18 @@
 				<param>TC_COVERED=DM-06</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
-				<param>startupMem=79%</param>
+				<param>startupMem=80%</param>
 				<param>memWeight=0</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
-				<param>startupMem=19%</param>
+				<param>startupMem=20%</param>
 				<param>memWeight=0</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 			</testParams>
 			<testScript>setupScripts\DM_StartupLowCompete.ps1</testScript>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
@@ -174,25 +174,25 @@
 				<param>TC_COVERED=DM-07</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=60%</param>
 				<param>startupMem=60%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=40%</param>
 				<param>startupMem=40%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=512MB</param>
 				<param>vmName=VM3Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=25%</param>
 				<param>startupMem=25%</param>
 				<param>memWeight=100</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 			</testParams>
 			<testScript>setupScripts\DM_RemoveUnderPressure.ps1</testScript>
 			<files>remote-scripts/ica/check_traces.sh</files>
@@ -207,11 +207,11 @@
 				<param>TC_COVERED=DM-08</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
 				<param>startupMem=20%</param>
 				<param>memWeight=0</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 			</testParams>
 			<testScript>setupScripts\DM_PressureChangesDemand.ps1</testScript>
 			<files>remote-scripts/ica/check_traces.sh</files>
@@ -226,16 +226,16 @@
 				<param>TC_COVERED=DM-09</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
-				<param>startupMem=50%</param>
+				<param>startupMem=45%</param>
 				<param>memWeight=100</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
-				<param>startupMem=50%</param>
+				<param>startupMem=45%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 			</testParams>
@@ -254,12 +254,12 @@
 				<param>enableDM=yes</param>
 				<param>minMem=50%</param>
 				<param>maxMem=80%</param>
-				<param>startupMem=75%</param>
+				<param>startupMem=65%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
 				<param>startupMem=45%</param>
 				<param>memWeight=0</param>
@@ -277,14 +277,14 @@
 				<param>TC_COVERED=DM-11</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=80%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=40%</param>
 				<param>startupMem=40%</param>
 				<param>memWeight=100</param>
@@ -302,18 +302,18 @@
 				<param>TC_COVERED=DM-12</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=80%</param>
 				<param>memWeight=0</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
 				<param>startupMem=20%</param>
 				<param>memWeight=0</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 			</testParams>
 			<testScript>setupScripts\DM_SaveRestore.ps1</testScript>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
@@ -327,18 +327,18 @@
 				<param>TC_COVERED=DM-13</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
 				<param>startupMem=20%</param>
 				<param>memWeight=0</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
-				<param>minMem=512MB</param>
+				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=80%</param>
 				<param>memWeight=100</param>
-				<param>staticMem=512MB</param>
+				<param>staticMem=1024MB</param>
 			</testParams>
 			<testScript>setupScripts\DM_CleanShutdown.ps1</testScript>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -24,7 +24,7 @@
 
 				<!-- Dynamic Memory – Hot Add -->
 				<suiteTest>HotAdd</suiteTest>
-				<suiteTest>HotAddStressNg</suiteTest>
+				<suiteTest>HotAddStressapptest</suiteTest>
 				<suiteTest>HotRemove</suiteTest>
 				<suiteTest>StartupHighCompete</suiteTest>
 				<suiteTest>DemandPressure</suiteTest>
@@ -79,7 +79,7 @@
 		</test>
 
 		<test>
-			<testName>HotAdd</testName>
+			<testName>HotAddStressapptest</testName>
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-03</param>
@@ -91,14 +91,14 @@
 				<param>memWeight=100</param>
 				<param>staticMem=512MB</param>
 			</testParams>
-			<testScript>setupScripts\DM_HotAdd.ps1</testScript>
+			<testScript>setupScripts\DM_HotAdd_stressapptest.ps1</testScript>
 			<files>remote-scripts/ica/check_traces.sh</files>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
 			<timeout>1200</timeout>
 		</test>
 
 		<test>
-			<testName>HotAddStressNg</testName>
+			<testName>HotAdd</testName>
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-04</param>

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -124,15 +124,15 @@
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
-				<param>maxMem=6GB</param>
+				<param>maxMem=30%</param>
 				<param>startupMem=1024MB</param>
 				<param>memWeight=100</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=512MB</param>
-				<param>maxMem=70%</param>
-				<param>startupMem=70%</param>
+				<param>maxMem=68%</param>
+				<param>startupMem=68%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 			</testParams>
@@ -254,14 +254,14 @@
 				<param>enableDM=yes</param>
 				<param>minMem=50%</param>
 				<param>maxMem=80%</param>
-				<param>startupMem=80%</param>
+				<param>startupMem=75%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=512MB</param>
 				<param>maxMem=50%</param>
-				<param>startupMem=50%</param>
+				<param>startupMem=45%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 			</testParams>

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -131,8 +131,8 @@
 				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=512MB</param>
-				<param>maxMem=68%</param>
-				<param>startupMem=68%</param>
+				<param>maxMem=70%</param>
+				<param>startupMem=65%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
 			</testParams>


### PR DESCRIPTION
- Switch to stress-ng as memory stress test app (HotAddStressapptest remains the only one using stressapptest as reference)
- Created an application checking function in TCUtils. This is now used to check if stress-ng/stressapptest is present.
- Changed the way memory is calculated and how pressure is applied.
- Adjusted a few memory setting in the XML.

Tested successfully on: Centos 6.8, RHEL 7.2 (gen 1 and gen 2), Ubuntu 16 and SLES 12 sp 2