### PR TITLE
Add support for specific port addresses on FC tests

### DIFF
--- a/WS2012R2/lisa/xml/FC_Tests.xml
+++ b/WS2012R2/lisa/xml/FC_Tests.xml
@@ -56,7 +56,6 @@
 			<timeout>3600</timeout>
 			<testParams>
 				<param>TC_COVERED=FC-01,FC-02</param>
-				<param>vSANName=FC_NAME</param>
 			</testParams>
 		</test>
 
@@ -70,7 +69,6 @@
             <timeout>7200</timeout>
             <testParams>
                 <param>TC_COVERED=FC-04</param>
-                <param>vSANName=FC_NAME</param>
                 <param>FILE_NAME=iozone3_420.tar</param>
             </testParams>
         </test>
@@ -85,7 +83,6 @@
 			<timeout>7200</timeout>
 			<testParams>
 				<param>TC_COVERED=FC-07</param>
-				<param>vSANName=FC_NAME</param>
 			</testParams>
 		</test>
 
@@ -97,10 +94,9 @@
 			<timeout>3600</timeout>
 			<testParams>
 				<param>TC_COVERED=FC-08</param>
-				<param>vSANName=FC_NAME</param>
 			</testParams>
 		</test>
-		
+
 		<test>
 			<testName>FC_WWN_basic</testName>
 			<testScript>setupScripts\FC_WWN.ps1</testScript>
@@ -110,7 +106,6 @@
 			<timeout>800</timeout>
 			<testParams>
 				<param>TC_COVERED=FC-09</param>
-				<param>vSANName=FC_NAME</param>
 			</testParams>
 		</test>
 	</testCases>
@@ -123,6 +118,11 @@
             <ipv4></ipv4>
             <sshKey>PKI_id_rsa.ppk</sshKey>
             <suite>FC</suite>
+            <testParams>
+				<!-- <param>WWNN=portA,portB</param> -->
+                <!-- <param>WWPN=portA,portB</param> -->
+                <param>vSANName=FC_NAME</param>
+            </testParams>
         </vm>
     </VMs>
 </config>


### PR DESCRIPTION
Now you can specify different port addresses for fibre channel tests
through parameters in an xml file - WWNN=portA,portB - WWPN=portA,portB

If the specific addresses are already in use by some other local VM
the test will fail.