### PR TITLE
Catch RuntimeError when trying to restore snapshot

### DIFF
--- a/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser/sql_utils.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser/sql_utils.py
@@ -142,7 +142,7 @@ def select_row(cursor, row_dict):
         if type(col_value) == str:
             filters = ' '.join([filters, col_name, '=', "'" + col_value + "'"])
         else:
-            filters = ' '.join([filters, '=', "'" + col_value + "'"])
+            filters = ' '.join([filters, '=', str(col_value)])
         filters = ' '.join([filters, 'AND'])
 
     table_name = '"' + env.str('TableName') + '"'

--- a/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser/virtual_machine.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser/virtual_machine.py
@@ -65,7 +65,10 @@ class VirtualMachine(object):
 
     def update_from_kvp(self, kvp_fields, stop_vm):
         if not self.get_status():
-            self.revert_snapshot()
+            try:
+                self.revert_snapshot()
+            except RuntimeError:
+                logger.warning("Unable to restore VM snapshot")
             self.start()
             logger.info('Starting %s - Waiting for it to boot', self.vm_name)
             if not self.has_booted():


### PR DESCRIPTION
In some cases VMs don not have snasphots available
so we have to catch errors that appear when calling
revert_snapshot