### PR TITLE
Check state for VMs that are using same ports

### DIFF
--- a/WS2012R2/lisa/setupscripts/FC_AddFibreChannelHba.ps1
+++ b/WS2012R2/lisa/setupscripts/FC_AddFibreChannelHba.ps1
@@ -141,9 +141,15 @@ if (($WWNN -ne $null) -and ($WWPN -ne $null)) {
     $FCList = Get-VMFibreChannelHba -VMName (Get-VM).name -ComputerName $hvServer
     foreach ($fcNIC in $FCList) {
         if ($WWPN -contains $fcNIC.WorldWidePortNameSetA) {
-    		$usedVM = $fcNIC.VMName
-    		"Error: Specified WWPN is being used on $usedVM"
-    		return $retVal
+            $usedVM = $fcNIC.VMName
+			$state = (Get-VM -name $usedVM -ComputerName $hvServer).State
+
+			if ($state -ne "off") {
+				Write-Host "Error: Specified WWPN is being used on $usedVM" -foregroundcolor "red"
+ 				return $retVal
+			} else {
+				Write-Host "Warning: Specified WWPN is being used on $usedVM which is currently in an off state." -foregroundcolor "yellow"
+			}
     	}
     }
     if ($WWPN.Count -eq 2) {


### PR DESCRIPTION
When checking if a FC port value is used by another VM
another step was added so that the test can continue if
the other VMs are in an off state