### PR TITLE
Refactor CheckGateway method

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NET_MAX_NIC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_MAX_NIC.sh
@@ -26,7 +26,13 @@ function CheckGateway
 	# Get interfaces that have default gateway set
 	gw_interf=($(route -n | grep 'UG[ \t]' | awk '{print $8}'))
 
-	[[ ${gw_interf[*]} =~ ${1} ]]
+	for if_gw in ${gw_interf[@]}; do
+		if [[ ${if_gw} == ${1} ]]; then
+			return 0
+		fi
+	done
+
+	return 1
 }
 
 function AddGateway


### PR DESCRIPTION
On some cases the partial comparison that was previously
present in the function did not work properly ('eth1' ~= 'eth11')
The comparison was removed in favour of a strict match between
interface names.