### PR TITLE
add extra kdump parameters for rhel 5.x, 6.0, 6.1, 6.2

### DIFF
--- a/WS2012R2/lisa/xml/Kdump_Tests.xml
+++ b/WS2012R2/lisa/xml/Kdump_Tests.xml
@@ -52,6 +52,7 @@
                 <file>setupScripts\SetVMMemory.ps1</file>
             </setupScript>
             <testScript>setupScripts\kdump.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
             <testParams>
                 <!-- for Ubuntu use min 384M -->
                 <param>crashkernel=256M@128M</param>
@@ -69,6 +70,7 @@
                 <file>setupScripts\SetVMMemory.ps1</file>
             </setupScript>
             <testScript>setupscripts\kdump.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
             <testParams>
                 <!-- for Ubuntu use min 384M -->
                 <param>crashkernel=256M@128M</param>
@@ -86,6 +88,7 @@
                 <file>setupScripts\SetVMMemory.ps1</file>
             </setupScript>
             <testScript>setupscripts\kdump.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
             <testParams>
                 <!-- for Ubuntu use min 384M -->
                 <param>crashkernel=384M</param>
@@ -104,6 +107,7 @@
                 <file>setupScripts\SetVMMemory.ps1</file>
             </setupScript>
             <testScript>setupScripts\kdump.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
             <testParams>
                 <!-- Minimum RAM=2GB -->
                 <param>crashkernel=auto</param>
@@ -121,6 +125,7 @@
                 <file>setupScripts\SetVMMemory.ps1</file>
             </setupScript>
             <testScript>setupScripts\kdump.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
             <testParams>
                 <!-- Minimum RAM=2GB -->
                 <param>crashkernel=256M@128M</param>


### PR DESCRIPTION
add following kdump extra parameters to for RHEL 5.x, 6.0-6.2

-- kdump.conf
core_collector makedumpfile -c --message-level 1 -d 31
disk_timeout 100
blacklist hv_vmbus hv_storvsc hv_utils hv_netvsc hid-hyperv hyperv_fb hyperv-keyboard
extra_modules ata_piix sr_mod sd_mod

-- /etc/sysconfig/kdump
- append to KDUMP_COMMANDLINE_APPEND
"irqpoll maxcpus=1 reset_devices ide_core.prefer_ms_hyperv=1"