### PR TITLE
SR-IOV - Added 11 new Test Cases

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Broadcast.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Broadcast.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+# Description:
+#   Basic SR-IOV test that checks if VF can send and receive broadcast packets
+# Steps:
+#    Use ping for testing & tcpdump to check if the packets were received
+#    On the 2nd VM – tcpdump -i bond0 -c 10 ip proto \\icmp > out.client
+#    On the TEST VM – ping -b $broadcastAddress -c 13 &
+#    On the 2nd VM – cat out.client | grep $broadcastAddress
+#    If $?=0 test passed!
+##############################################################################
+
+# Convert eol
+dos2unix SR-IOV_Utils.sh
+
+# Source SR-IOV_Utils.sh. This is the script that contains all the 
+# SR-IOV basic functions (checking drivers, making de bonds, assigning IPs)
+. SR-IOV_Utils.sh || {
+    echo "ERROR: unable to source SR-IOV_Utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Check the parameters in constants.sh
+Check_SRIOV_Parameters
+if [ $? -ne 0 ]; then
+    msg="ERROR: The necessary parameters are not present in constants.sh. Please check the xml test file"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Check if the SR-IOV driver is in use
+VerifyVF
+if [ $? -ne 0 ]; then
+    msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Run the bonding script. Make sure you have this already on the system
+# Note: The location of the bonding script may change in the future
+RunBondingScript
+bondCount=$?
+if [ $bondCount -eq 99 ]; then
+    msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+
+else
+    LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"   
+fi
+
+# Set static IP to the bond
+ConfigureBond
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not set a static IP to the bond!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Install dependencies needed for testing
+InstallDependencies
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not install dependencies!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+
+else
+    LogMsg "INFO: All configuration completed successfully. Will proceed with the testing"   
+fi
+
+# Broadcast testing
+broadcastAddress=$(ip a s dev bond0 | awk '/inet / {print $4}')
+ping -b $broadcastAddress -c 13 &
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not ping to broadcast address on VM1 (BOND_IP: ${BOND_IP1})"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+ssh -i "$HOME"/.ssh/"$sshKey" -o StrictHostKeyChecking=no "$REMOTE_USER"@"$BOND_IP2" 'tcpdump -i bond0 -c 10 ip proto \\icmp > out.client'
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not start tcpdump on VM2 (BOND_IP: ${BOND_IP2})"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+else
+    LogMsg "INFO: Ping on VM1 and tcpdump on VM2 were successfully started"
+    sleep 20
+fi
+
+ssh -i "$HOME"/.ssh/"$sshKey" -o StrictHostKeyChecking=no "$REMOTE_USER"@"$BOND_IP2" cat out.client | grep $broadcastAddress
+if [ $? -ne 0 ]; then
+    msg="ERROR: VM2 didn't receive any packets from the broadcast address"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+
+else
+    sleep 10
+    msg="VM2 successfully received the packets sent to the broadcast address"
+    LogMsg $msg
+    UpdateSummary "$msg"
+    SetTestStateCompleted   
+fi

--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_MaxNIC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_MaxNIC.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+# Description:
+#   Limit test – one VM with max NICs, max SR-IOV devices - 7
+#
+# Steps:
+#   Create a Linux VM and configure it with the MAX number of synthetic NICs (7 NICs).
+#   Configure SR-IOV on each NIC.
+#   Verify network connectivity over each SR-IOV device.
+# Acceptance Criteria:
+#   The max number of SR-IOV devices can be created.
+#   Each SR-IOV device has network connectivity.
+################################################################################
+
+# Convert eol
+dos2unix SR-IOV_Utils.sh
+
+# Adding IPs for all bonds (VM1 and VM2) in constants.sh
+maxBondIterator=14
+__iterator=0
+__ipIterator1=1
+__ipIterator2=1
+while [ $__iterator -lt $maxBondIterator ]; do
+    echo -e "BOND_IP${__ipIterator2}=10.1${__ipIterator1}.12.${__ipIterator2}" >> constants.sh
+
+    if [ $((__iterator%2)) -eq 1 ]; then
+        __ipIterator1=$(($__ipIterator1 + 1))    
+    fi
+
+    __ipIterator2=$(($__ipIterator2 + 1))
+    : $((__iterator++))   
+done
+sleep 5
+
+# Source SR-IOV_Utils.sh. This is the script that contains all the 
+# SR-IOV basic functions (checking drivers, making de bonds, assigning IPs)
+. SR-IOV_Utils.sh || {
+    echo "ERROR: unable to source SR-IOV_Utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Check the parameters in constants.sh
+Check_SRIOV_Parameters
+if [ $? -ne 0 ]; then
+    msg="ERROR: The necessary parameters are not present in constants.sh. Please check the xml test file"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Check if the SR-IOV driver is in use
+VerifyVF
+if [ $? -ne 0 ]; then
+    msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Run the bonding script. Make sure you have this already on the system
+# Note: The location of the bonding script may change in the future
+RunBondingScript
+bondCount=$?
+if [ $bondCount -eq 99 ]; then
+    msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+
+else
+    LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"   
+fi
+
+# Set static IPs to the bond
+ConfigureBond
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not set a static IP to the bond!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Pinging
+__iterator=0
+__ipIterator=2
+while [ $__iterator -lt $bondCount ]; do
+    staticIP=$(cat constants.sh | grep IP$__ipIterator | tr = " " | awk '{print $2}')
+
+    # Ping the remote host
+    ping -I "bond$__iterator" -c 10 "$staticIP" >/dev/null 2>&1
+    if [ 0 -eq $? ]; then
+        msg="Successfully pinged $staticIP through bond$__iterator"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+    else
+        msg="ERROR: Unable to ping $staticIP through bond$__iterator"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+    fi
+    __ipIterator=$(($__ipIterator + 2))
+    : $((__iterator++))
+done
+
+msg="Pinging was successful through all bonds"
+LogMsg $msg
+UpdateSummary "$msg"
+sleep 5
+
+SetTestStateCompleted

--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Multicast.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Multicast.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+# Description:
+#   Basic SR-IOV test that checks if VF can send and receive multicast packets
+#
+# Steps:
+#   Use Omping (yum install omping -y)
+#   On the 2nd VM: omping $BOND_IP1 $BOND_IP2 -m 239.255.254.24 -c 11 > out.client &
+#   On the TEST VM: omping $BOND_IP1 $BOND_IP2 -m 239.255.254.24 -c 11 > out.client
+#   Check results:
+#   On the TEST VM: cat out.client | grep multicast | grep /0%
+#   On the 2nd VM: cat out.client | grep multicast | grep /0%
+#   If both have 0% packet loss, test passed
+################################################################################
+
+# Convert eol
+dos2unix SR-IOV_Utils.sh
+
+# Source SR-IOV_Utils.sh. This is the script that contains all the 
+# SR-IOV basic functions (checking drivers, making de bonds, assigning IPs)
+. SR-IOV_Utils.sh || {
+    echo "ERROR: unable to source SR-IOV_Utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Check the parameters in constants.sh
+Check_SRIOV_Parameters
+if [ $? -ne 0 ]; then
+    msg="ERROR: The necessary parameters are not present in constants.sh. Please check the xml test file"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Check if the SR-IOV driver is in use
+VerifyVF
+if [ $? -ne 0 ]; then
+    msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+UpdateSummary "VF is present on VM!"
+
+# Run the bonding script. Make sure you have this already on the system
+# Note: The location of the bonding script may change in the future
+RunBondingScript
+bondCount=$?
+if [ $bondCount -eq 99 ]; then
+    msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"
+
+# Set static IP to the bond
+ConfigureBond
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not set a static IP to the bond!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Install dependencies needed for testing
+InstallDependencies
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not install dependencies!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+LogMsg "INFO: All configuration completed successfully. Will proceed with the testing"
+
+# Multicast testing
+ssh -i "$HOME"/.ssh/"$sshKey" -o StrictHostKeyChecking=no "$REMOTE_USER"@"$BOND_IP2" "omping $BOND_IP1 $BOND_IP2 -m 239.255.254.24 -c 11 > out.client &"
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not start omping on VM2 (BOND_IP: ${BOND_IP2})"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+omping $BOND_IP1 $BOND_IP2 -m 239.255.254.24 -c 11 > out.client
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not start omping on VM1 (BOND_IP: ${BOND_IP1})"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+LogMsg "INFO: Omping was started on both VMs. Results will be checked in a few seconds"
+sleep 5
+ 
+# Check results - Summary must show a 0% loss of packets
+multicastSummary=$(cat out.client | grep multicast | grep /0%)
+if [ $? -ne 0 ]; then
+    msg="ERROR: VM1 shows that packets were lost!"
+    LogMsg "$msg"
+    LogMsg "${multicastSummary}"
+    UpdateSummary "$msg"
+    UpdateSummary "${multicastSummary}"
+    SetTestStateFailed
+fi
+LogMsg "Multicast summary"
+LogMsg "${multicastSummary}"
+
+ssh -i "$HOME"/.ssh/"$sshKey" -o StrictHostKeyChecking=no "$REMOTE_USER"@"$BOND_IP2" "cat out.client | grep multicast | grep /0%"
+if [ $? -ne 0 ]; then
+    msg="ERROR: VM2 shows that packets were lost!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+msg="Multicast packets were successfully sent, 0% loss"
+LogMsg $msg
+UpdateSummary "$msg"
+SetTestStateCompleted

--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Utils.sh
@@ -1,0 +1,604 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+########################################################################
+#
+# Description:
+#
+# This script contains all SR-IOV related functions that are often used
+# in the SR-IOV test suite.
+#
+########################################################################
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+# In case of error
+case $? in
+    0)
+        # Do nothing
+        ;;
+    1)
+        LogMsg "ERROR: Unable to cd to $LIS_HOME. Aborting..."
+        UpdateSummary "ERROR: Unable to cd to $LIS_HOME. Aborting..."
+        SetTestStateAborted
+        exit 3
+        ;;
+    2)
+        LogMsg "ERROR: Unable to use test state file. Aborting..."
+        UpdateSummary "ERROR: Unable to use test state file. Aborting..."
+        # Need to wait for test timeout to kick in
+        sleep 60
+        echo "TestAborted" > state.txt
+        exit 4
+        ;;
+    3)
+        LogMsg "ERROR: unable to source constants file. Aborting..."
+        UpdateSummary "ERROR: unable to source constants file"
+        SetTestStateAborted
+        exit 5
+        ;;
+    *)
+        # Should not happen
+        LogMsg "ERROR: UtilsInit returned an unknown error. Aborting..."
+        UpdateSummary "ERROR: UtilsInit returned an unknown error. Aborting..."
+        SetTestStateAborted
+        exit 6
+        ;;
+esac
+
+# Declare global variables
+declare -i bondCount
+
+#
+# VerifyVF - check if the VF driver is use
+#
+VerifyVF()
+{
+	# Check for pciutils. If it's not on the system, install it
+	lspci --version
+	if [ $? -ne 0 ]; then
+	    msg="INFO: pciutils not found. Trying to install it"
+	    LogMsg "$msg"
+
+	    GetDistro
+	    case "$DISTRO" in
+	        suse*)
+	            zypper --non-interactive in pciutils
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install pciutils"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+	            ;;
+	        ubuntu*)
+	            apt-get install pciutils -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install pciutils"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+	            ;;
+	        redhat*|centos*)
+	            yum install pciutils -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install pciutils"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+	            ;;
+	            *)
+	                msg="ERROR: OS Version not supported"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            ;;
+	    esac
+	fi
+
+	# Using lsmod command, verify if driver is loaded
+	lsmod | grep ixgbevf
+	if [ $? -ne 0 ]; then
+	    msg="ERROR: ixgbevf driver not loaded!"
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+	    SetTestStateFailed
+	    return 1
+	fi
+
+	# Using the lspci command, verify if NIC has SR-IOV support
+	lspci -vvv | grep ixgbevf
+	if [ $? -ne 0 ]; then
+	    msg="ERROR: No NIC with SR-IOV support found!"
+	    LogMsg "$msg"                                                             
+	    UpdateSummary "$msg"
+	    SetTestStateFailed
+	    return 1
+	fi
+
+	return 0
+}
+
+#
+# Check_SRIOV_Parameters - check if the needed parameters for SR-IOV 
+# testing are present in constants.sh
+#
+Check_SRIOV_Parameters()
+{
+	# Parameter provided in constants file
+	declare -a STATIC_IPS=()
+
+	if [ "${BOND_IP1:-UNDEFINED}" = "UNDEFINED" ]; then
+	    msg="ERROR: The test parameter BOND_IP1 is not defined in constants file. Will try to set addresses via dhcp"
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+	    SetTestStateAborted
+	    return 1
+	fi
+
+	if [ "${BOND_IP2:-UNDEFINED}" = "UNDEFINED" ]; then
+	    msg="ERROR: The test parameter BOND_IP2 is not defined in constants file. No network connectivity test will be performed."
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+        SetTestStateAborted
+        return 1
+	fi
+
+	IFS=',' read -a networkType <<< "$NIC"
+	if [ "${NETMASK:-UNDEFINED}" = "UNDEFINED" ]; then
+	    msg="ERROR: The test parameter NETMASK is not defined in constants file . Defaulting to 255.255.255.0"
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+        SetTestStateAborted
+        return 1
+	fi
+
+	if [ "${sshKey:-UNDEFINED}" = "UNDEFINED" ]; then
+	    msg="ERROR: The test parameter sshKey is not defined in ${LIS_CONSTANTS_FILE}"
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+        SetTestStateAborted
+        return 1
+	fi
+
+	if [ "${REMOTE_USER:-UNDEFINED}" = "UNDEFINED" ]; then
+	    msg="ERROR: The test parameter REMOTE_USER is not defined in ${LIS_CONSTANTS_FILE}"
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+        SetTestStateAborted
+        return 1
+	fi
+	
+    return 0
+}
+
+#
+# Create1Gfile - it creates a 1GB file that will be sent between VMs as part of testing
+#
+Create1Gfile()
+{
+	# Create file locally with PID appended
+	output_file=large_file
+	if [ -d "$HOME"/"$output_file" ]; then
+	    rm -rf "$HOME"/"$output_file"
+	fi
+
+	if [ -e "$HOME"/"$output_file" ]; then
+	    rm -f "$HOME"/"$output_file"
+	fi
+
+	dd if=$file_source of="$HOME"/"$output_file" bs=1 count=0 seek=1G
+	if [ 0 -ne $? ]; then
+	    msg="ERROR: Unable to create file $output_file in $HOME"
+	    LogMsg "$msg"
+	    UpdateSummary "$msg"
+	    SetTestStateFailed
+	    return 1
+	fi
+
+	LogMsg "Successfully created $output_file"
+	return 0
+}
+
+#
+# RunBondingScript - it will run the bonding script. Acceptance criteria is the
+# presence of the bond between VF and eth after the bonding script ran.
+# NOTE: function returns the number of bonds present on VM, not "0"
+#
+RunBondingScript()
+{
+	if is_ubuntu ; then
+	    bash /usr/src/linux-headers-*/tools/hv/bondvf.sh
+
+	    # Verify if bond0 was created
+	    bondCount=$(cat /etc/network/interfaces | grep "auto bond" | wc -l)
+	    if [ 0 -eq $bondCount ]; then
+	        msg="ERROR: Bonding script failed. No bond was created"
+		    LogMsg "$msg"
+		    UpdateSummary "$msg"
+		    SetTestStateFailed
+		    return 99
+	    fi
+
+	elif is_suse ; then
+	    bash /usr/src/linux-*/tools/hv/bondvf.sh
+
+	    # Verify if bond0 was created
+	    bondCount=$(ls -d /etc/sysconfig/network/ifcfg-bond* | wc -l)
+	    if [ 0 -eq $bondCount ]; then
+	        msg="ERROR: Bonding script failed. No bond was created"
+		    LogMsg "$msg"
+		    UpdateSummary "$msg"
+		    SetTestStateFailed
+		    return 99
+	    fi
+
+	elif is_fedora ; then
+	    ./bondvf.sh
+
+	    # Verify if bond0 was created
+	    bondCount=$(ls -d /etc/sysconfig/network-scripts/ifcfg-bond* | wc -l)
+	    if [ 0 -eq $bondCount ]; then
+	        msg="ERROR: Bonding script failed. No bond was created"
+		    LogMsg "$msg"
+		    UpdateSummary "$msg"
+		    SetTestStateFailed
+		    return 99
+	    fi
+	fi
+
+	LogMsg "Successfully ran the bonding script"
+	return $bondCount
+}
+
+#
+# ConfigureBond - will set the given BOND_IP(s) (from constants file) 
+# for each bond present 
+#
+ConfigureBond()
+{
+	__iterator=0
+	__ipIterator=1
+	LogMsg "Iterator: $__iterator"
+	LogMsg "BondCount: $bondCount"
+
+	# Set static IPs for each bond created
+	while [ $__iterator -lt $bondCount ]; do
+	    LogMsg "Network config will start"
+
+        # Extract bondIP value from constants.sh
+		staticIP=$(cat constants.sh | grep IP$__ipIterator | head -1 | tr = " " | awk '{print $2}')
+
+	    if is_ubuntu ; then
+	        __file_path="/etc/network/interfaces"
+	        # Change /etc/network/interfaces 
+	        sed -i "s/bond$__iterator inet dhcp/bond$__iterator inet static/g" $__file_path
+	        sed -i "/bond$__iterator inet static/a address $staticIP" $__file_path
+	        sed -i "/address ${staticIP}/a netmask $NETMASK" $__file_path
+
+	    elif is_suse ; then
+	        __file_path="/etc/sysconfig/network/ifcfg-bond$__iterator"
+	        # Replace the BOOTPROTO, IPADDR and NETMASK values found in ifcfg file 
+	        sed -i "/\b\(BOOTPROTO\|IPADDR\|\NETMASK\)\b/d" $__file_path
+	        cat <<-EOF >> $__file_path
+	        BOOTPROTO=static
+	        IPADDR=$staticIP
+	        NETMASK=$NETMASK
+	EOF
+
+	    elif is_fedora ; then
+	        __file_path="/etc/sysconfig/network-scripts/ifcfg-bond$__iterator"
+	        # Replace the BOOTPROTO, IPADDR and NETMASK values found in ifcfg file 
+	        sed -i "/\b\(BOOTPROTO\|IPADDR\|\NETMASK\)\b/d" $__file_path
+	        cat <<-EOF >> $__file_path
+	        BOOTPROTO=static
+	        IPADDR=$staticIP
+	        NETMASK=$NETMASK
+	EOF
+	    fi
+	    LogMsg "Network config file path: $__file_path"
+
+	    # Add some interface output
+	    LogMsg "$(ip -o addr show bond$__iterator | grep -vi inet6)"
+
+		__ipIterator=$(($__ipIterator + 2))
+	    : $((__iterator++))
+	done
+
+    # Get everything up & running
+    if is_ubuntu ; then
+        service networking restart
+
+    elif is_suse ; then
+        service network restart
+
+    elif is_fedora ; then
+        service network restart
+    fi
+
+	return 0
+}
+
+#
+# InstallDependencies - will install iperf, omping, netcat, etc
+#
+InstallDependencies()
+{
+	# Enable broadcast listening
+	echo 0 >/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts
+
+    GetDistro
+    case "$DISTRO" in
+        suse*)
+			# Disable firewall
+			rcSuSEfirewall2 stop
+
+			# Check wget 
+			wget -V > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				zypper --non-interactive in wget
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install wget"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+
+			# Check iPerf3
+			iperf3 -v > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				wget http://download.opensuse.org/repositories/home:/aeneas_jaissle:/sewikom/SLE_12/x86_64/libiperf0-3.1.3-50.1.x86_64.rpm
+				if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to download libiperf (this an iperf3 dependency)"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+
+	            wget http://download.opensuse.org/repositories/home:/aeneas_jaissle:/sewikom/SLE_12/x86_64/iperf-3.1.3-50.1.x86_64.rpm
+				if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to download iperf"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+
+	            rpm -i libiperf*
+	            rpm -i iperf*
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install iperf"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+
+			# Check netcat
+			nc -help > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            zypper --non-interactive in netcat
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install netcat"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+	        fi
+
+	        # Check omping
+	        omping -V > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            zypper addrepo http://download.opensuse.org/repositories/home:emendonca/SLE_12_SP2/home:emendonca.repo
+	            zypper --gpg-auto-import-keys refresh
+	            zypper --non-interactive in omping
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install omping"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+            ;;
+
+        ubuntu*)
+			# Disable firewall
+			ufw disable
+
+			# Check wget 
+			wget -V > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				apt-get install wget -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install wget"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+
+			# Check iPerf3
+			iperf3 -v > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				wget https://iperf.fr/download/ubuntu/libiperf0_3.1.3-1_amd64.deb
+				if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to download libiperf (this an iperf3 dependency)"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+
+	            wget https://iperf.fr/download/ubuntu/iperf3_3.1.3-1_amd64.deb
+				if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to download iperf"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+
+	            dpkg -i libiperf*
+	            dpkg -i iperf3*
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install iperf"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+
+			# Check netcat
+			nc -help > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            apt-get install netcat -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install netcat"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+	        fi
+
+	        # Check omping
+	        omping -V > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            wget https://fedorahosted.org/releases/o/m/omping/omping-0.0.4.tar.gz
+	            tar -xzf omping-0.0.4.tar.gz
+	            cd omping-0.0.4/
+	            make
+	            make install
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install omping"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+	            cd ~
+			fi
+            ;;
+
+        redhat*|centos*)
+			# Disable firewall
+			service firewalld stop
+
+			# Check wget 
+			wget -V > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				yum install wget -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install wget"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+
+			# Check iPerf3
+			iperf3 -v > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            wget https://iperf.fr/download/fedora/iperf3-3.1.3-1.fc24.x86_64.rpm
+				if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to download iperf"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+
+	            rpm -i iperf3*
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install iperf"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+			fi
+
+			# Check netcat
+			nc -help > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            yum install nc -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install netcat"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi
+            fi
+
+	        # Check omping
+	        omping -V > /dev/null 2>&1
+			if [ $? -ne 0 ]; then
+	            yum install omping -y
+	            if [ $? -ne 0 ]; then
+	                msg="ERROR: Failed to install omping"
+	                LogMsg "$msg"
+	                UpdateSummary "$msg"
+	                SetTestStateFailed
+	                return 1
+	            fi	
+			fi
+
+        ;;
+        *)
+            msg="ERROR: OS Version not supported"
+            LogMsg "$msg"
+            UpdateSummary "$msg"
+            SetTestStateFailed
+            return 1
+        ;;
+    esac
+
+    return 0
+}

--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_iPerfStress.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_iPerfStress.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+# Description:
+#   This SR-IOV test will run iPerf3 for 30 minutes and checks
+# if network connectivity is lost at any point
+#
+################################################################################
+
+# Convert eol
+dos2unix SR-IOV_Utils.sh
+
+# Source SR-IOV_Utils.sh. This is the script that contains all the 
+# SR-IOV basic functions (checking drivers, making de bonds, assigning IPs)
+. SR-IOV_Utils.sh || {
+    echo "ERROR: unable to source SR-IOV_Utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Check the parameters in constants.sh
+Check_SRIOV_Parameters
+if [ $? -ne 0 ]; then
+    msg="ERROR: The necessary parameters are not present in constants.sh. Please check the xml test file"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Check if the SR-IOV driver is in use
+VerifyVF
+if [ $? -ne 0 ]; then
+    msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Run the bonding script. Make sure you have this already on the system
+# Note: The location of the bonding script may change in the future
+RunBondingScript
+bondCount=$?
+if [ $bondCount -eq 99 ]; then
+    msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+
+else
+    LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"   
+fi
+
+# Set static IP to the bond
+ConfigureBond
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not set a static IP to the bond!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+# Install dependencies needed for testing
+InstallDependencies
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not install dependencies!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+
+else
+    LogMsg "INFO: All configuration completed successfully. Will proceed with the testing"   
+fi
+
+# iPerf3 Stress test
+ssh -i "$HOME"/.ssh/"$sshKey" -o StrictHostKeyChecking=no "$REMOTE_USER"@"$BOND_IP2" 'iperf3 -s > perfResults.log &'
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not start iPerf3 on VM2 (BOND_IP: ${BOND_IP2})"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+iperf3 -t 1800 -c ${BOND_IP2} > perfResults.log &
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not start iPerf3 on VM1 (BOND_IP: ${BOND_IP1})"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+else
+    LogMsg "INFO: iPerf3 was started on both VM. Please wait for stress test to finish"
+    sleep 1860
+fi
+
+cat perfResults.log | grep error 
+if [ $? -eq 0 ]; then
+    msg="ERROR: iPerf3 didn't run!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+sleep 10
+bandwidth=$(cat perfResults.log | grep sender | awk '{print $7}')
+LogMsg "The bandwidh reported by iPerf was ${bandwidth}"
+UpdateSummary "The bandwidh reported by iPerf was ${bandwidth} gbps"
+
+# Check the connection again
+LogMsg "Last step: Ping again from VM1 to VM2 to make sure the connection is still up"
+
+ping -I bond0 -c 5 ${BOND_IP2} > pingResults.log
+if [ $? -ne 0 ]; then
+    msg="ERROR: Could not ping from VM1 to VM2 after iPerf3 finished the run!"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed
+fi
+
+sleep 5
+cat pingResults.log | grep " 0%"
+if [ $? -ne 0 ]; then
+    msg="ERROR: Ping shows that packets were lost between VM1 and VM2"
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateFailed  
+else
+    sleep 3
+    msg="Ping was succesful between VM1 and VM2 after iPerf finished the run"
+    LogMsg $msg
+    UpdateSummary "$msg"
+    sleep 5
+    SetTestStateCompleted   
+fi

--- a/WS2012R2/lisa/setupscripts/SR-IOV_ChangeRSS.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_ChangeRSS.ps1
@@ -1,0 +1,264 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Change RSS settings during iPerf
+
+.Description
+    While a Linux VM is transferring data via iPerf, change on of the RSS settings 
+    for the vSwitch and confirm network traffic continues to flow.
+    Steps:
+        1.  Configure a Linux VM with SR-IOV, and a second VM with SR-IOV (Windows or Linux).
+        2.  Start iPerf in server mode on the second VM.
+        3.  On the Linux VM, start iPerf in client mode for about a 10 minute run.
+        4.  Using Hyper-V manager, or a PowerShell cmdlet, change one of the RSS settings for the vSwitch.
+
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Change_RSS</testName>
+        <testScript>setupscripts\SR-IOV_ChangeRSS.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=SRIOV-12</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHostName</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get VM2 ipv4
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Install iPerf3 on VM1
+#
+"Installing iPerf3 on ${vmName}"
+$retval = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "dos2unix SR-IOV_Utils.sh && source SR-IOV_Utils.sh && InstallDependencies"
+if (-not $retVal)
+{
+    "ERROR: Failed to install iPerf3 on vm $vmName (IP: ${ipv4})"
+    return $false
+}
+
+#
+# Run iPerf3 with SR-IOV enabled
+#
+# Start the client side
+"Start Client"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s > client.out &"
+
+"Start Server"
+# Start iPerf3 testing
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && iperf3 -t 600 -c `$BOND_IP2 --logfile PerfResults.log &' > runIperf.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+
+# Wait 30 seconds and read the throughput
+"Get Logs"
+Start-Sleep -s 60
+[decimal]$vfBeforeThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+if (-not $vfBeforeThroughput){
+    "ERROR: No result was logged! Check if iPerf was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The throughput before changing the RSS profile is $vfBeforeThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+#
+# Change RSS profile
+#
+# First, we'll save the current RSS profile
+$rssProfile = Get-NetAdapterRss -Name SRIOV
+$rssProfile = $rssProfile.Profile
+
+"Changing RSS profile on VM1"
+Set-NetAdapterRss -Name SRIOV -Profile ClosestStatic
+if (-not $?) {
+    "ERROR: Failed to change RSS profile for SRIOV interface!" | Tee-Object -Append -file $summaryLog
+    Set-NetAdapterRss -Name SRIOV -Profile $rssProfile
+    return $false 
+}
+
+# Check if bond is still up & running
+Start-Sleep -s 30
+$status = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "ifconfig | grep bond0"
+if (-not $status) {
+    "ERROR: The VF is down after changing RSS profile!" | Tee-Object -Append -file $summaryLog
+    Set-NetAdapterRss -Name SRIOV -Profile $rssProfile
+    return $false    
+}
+
+# Read the throughput with RSS profile changed
+Start-Sleep -s 60
+[decimal]$vfBeforeThroughput = $vfBeforeThroughput - 2
+[decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+
+"The throughput after changing RSS profile is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+if (-not $vfFinalThroughput) {
+    "ERROR: After changing RSS profile, the throughput is significantly lower
+    Please check if the VF is still running" | Tee-Object -Append -file $summaryLog
+    Set-NetAdapterRss -Name SRIOV -Profile $rssProfile
+    return $false 
+}
+
+# Check for Call Traces in VM system logs
+Start-Sleep -s 60
+$status = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "grep 'Call Trace' /var/log/* --exclude-dir=*"
+if ($status) {
+    "ERROR: System logs shows Call Traces. Please check the VM for further info" | Tee-Object -Append -file $summaryLog
+    Set-NetAdapterRss -Name SRIOV -Profile $rssProfile
+    return $false    
+}
+# Change back the RSS profile
+Set-NetAdapterRss -Name SRIOV -Profile $rssProfile
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_DisableVMQ.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_DisableVMQ.ps1
@@ -1,0 +1,254 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Tear down VMQ and fallback to synthetic NIC
+
+.Description
+    Description:  
+    While transferring data through a SR-IOV device, tear down the VMQ configuration 
+    and verify the configuration falls back to the synthetic NIC.
+    Steps:
+        1.  Configure a Linux VM with SR-IOV, and a second VM with SR-IOV (Windows or Linux).
+        2.  Start iPerf in server mode on the second VM.
+        3.  On the Linux VM, start iPerf in client mode for about a 10 minute run.
+        4.  Using the Hyper-V Manager, or PowerShell cmdlets, tear down the VMQ configuration.
+  
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Disable_VMQ</testName>
+        <testScript>setupscripts\SR-IOV_DisableVMQ.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=SRIOV-11</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHostName</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get VM2 ipv4
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Install iPerf3 on VM1
+#
+"Installing iPerf3 on ${vmName}"
+$retval = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "dos2unix SR-IOV_Utils.sh && source SR-IOV_Utils.sh && InstallDependencies"
+if (-not $retVal)
+{
+    "ERROR: Failed to install iPerf3 on vm $vmName (IP: ${ipv4})"
+    return $false
+}
+
+#
+# Run iPerf3 with SR-IOV enabled
+#
+# Start the client side
+"Start Client"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s > client.out &"
+
+"Start Server"
+# Start iPerf3 testing
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && iperf3 -t 200 -c `$BOND_IP2 --logfile PerfResults.log &' > runIperf.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+
+# Wait 30 seconds and read the throughput
+"Get Logs"
+Start-Sleep -s 30
+[decimal]$vfBeforeThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+if (-not $vfBeforeThroughput){
+    "ERROR: No result was logged! Check if iPerf was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The throughput before disabling VMQ is $vfBeforeThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+#
+# Disable VMQ on both VMs
+#
+"Disabling VMQ on VM1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -VmqWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable VMQ on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+"Disabling VMQ on VM2"
+Set-VMNetworkAdapter -VMName $vm2Name -ComputerName $remoteServer -VmqWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable VMQ on $vm2Name!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+# Check if bond is still up & running
+Start-Sleep -s 10
+$status = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "ifconfig | grep bond0" 
+if (-not $status) {
+    "ERROR: The bond is down after disabling VMQ!" | Tee-Object -Append -file $summaryLog
+    return $false    
+}
+
+# Read the throughput with VMQ disabled
+Start-Sleep -s 60
+[decimal]$vfBeforeThroughput = $vfBeforeThroughput - 2
+[decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+
+"The throughput after disabling VMQ is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+if ($vfBeforeThroughput -ge $vfFinalThroughput ) {
+    "ERROR: After disabling VMQ, the throughput is significantly lower
+    Please check if the VF is still running" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_MaxVMs.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_MaxVMs.ps1
@@ -1,0 +1,385 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Limit test – 32* VMs, one SR-IOV device each
+
+.Description
+    Description:  
+    Create 32 Linux VMs on a single Hyper-V host.  Configure each VM to have a single SR-IOV device.
+    Verify network connectivity for each VM.
+    Steps:
+        1.  Create 32 Linux VMs and configure each Linux VM to have a single SR-IOV device.
+        2.  Using one of the Linux VMs as the client, use a network file protocol (SCP, NFS, etc) 
+        to transfer a small file to each of the remaining VMs.
+ 
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Max_VMs</testName>
+        <testScript>setupscripts\SR-IOV_MaxVMs.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>TC_COVERED=SRIOV-22</param>
+            <param>REMOTE_USER=root</param>
+            <param>VM_NUMBER=32</param>
+        </testParams>
+        <timeout>10800</timeout>
+    </test>
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# To Get Parent VHD from VM.
+#######################################################################
+function GetParentVHD($vmName, $hvServer)
+{
+    $ParentVHD = $null
+
+    $VmInfo = Get-VM -Name $vmName -ComputerName $hvServer
+    if (-not $VmInfo) {
+       Write-Error -Message "Error: Unable to collect VM settings for ${vmName}" -ErrorAction SilentlyContinue
+       return $False
+    }
+
+    if ( $VmInfo.Generation -eq "" -or $VmInfo.Generation -eq 1  ) {
+        $Disks = $VmInfo.HardDrives
+        foreach ($VHD in $Disks) {
+            if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "IDE"  )) {
+                $Path = Get-VHD $VHD.Path -ComputerName $hvServer
+                if ([string]::IsNullOrEmpty($Path.ParentPath)) {
+                    $ParentVHD = $VHD.Path
+                }
+                else {
+                    $ParentVHD =  $Path.ParentPath
+                }
+
+                Write-Host "Parent VHD Found: $ParentVHD "
+            }
+        }
+    }
+    if ( $VmInfo.Generation -eq 2 ) {
+        $Disks = $VmInfo.HardDrives
+        foreach ($VHD in $Disks) {
+            if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "SCSI"  )) {
+                $Path = Get-VHD $VHD.Path -ComputerName $hvServer
+                if ([string]::IsNullOrEmpty($Path.ParentPath)) {
+                    $ParentVHD = $VHD.Path
+                }
+                else {
+                    $ParentVHD =  $Path.ParentPath
+                }
+
+                Write-Host "Parent VHD Found: $ParentVHD "
+            }
+        }
+    }
+
+    if ( -not ($ParentVHD.EndsWith(".vhd") -xor $ParentVHD.EndsWith(".vhdx") )) {
+        Write-Error -Message " Parent VHD is Not correct please check VHD, Parent VHD is: $ParentVHD " -ErrorAction SilentlyContinue
+        return $False
+    }
+
+    return $ParentVHD
+}
+
+
+function CreateChildVHD($ParentVHD, $defaultpath)
+{
+    $ChildVHD  = $null
+    $hostInfo = Get-VMHost -ComputerName $hvServer
+    if (-not $hostInfo) {
+        Write-Error -Message "Error: Unable to collect Hyper-V settings for ${hvServer}" -ErrorAction SilentlyContinue
+        return $False
+    }
+
+    # Create Child VHD
+    if ($ParentVHD.EndsWith("x") ) {
+        $ChildVHD = $defaultpath + ".vhdx"
+    }
+    else {
+        $ChildVHD = $defaultpath + ".vhd"
+    }
+
+    if ( Test-Path $ChildVHD ) {
+        Write-Host "Deleting existing VHD $ChildVHD"
+        del $ChildVHD
+    }
+
+    # Copy Child VHD
+    Copy-Item $ParentVHD $ChildVHD
+    if (-not $?) {
+        Write-Error -Message "Error: Unable to create child VHD"  -ErrorAction SilentlyContinue
+        return $False
+    }
+
+    return $ChildVHD
+}
+
+function Cleanup($childVMName)
+{
+    # Clean up
+    $sts = Stop-VM -Name $childVMName -ComputerName $hvServer -TurnOff
+
+    # Delete New VM created
+    $sts = Remove-VM -Name $childVMName -ComputerName $hvServer -Confirm:$false -Force
+}
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+#
+# Check the required input args are present
+#
+$netmask = "255.255.255.0"
+
+# Write out test Params
+$testParams
+
+if ($hvServer -eq $null) {
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null) {
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?) {
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+
+$rootDir = $Matches[1]
+if (Test-Path $rootDir) {
+    Set-Location -Path $rootDir
+    if (-not $?) {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else {
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+    . .\setupScripts\TCUtils.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1") {
+    . .\setupScripts\NET_UTILS.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+        "VM_NUMBER" { $vmNumber = $fields[1].Trim() }
+        "REMOTE_USER" { $remoteUser = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Check if there are running old child VMs and stop them
+for($i=0; $i -lt $vmNumber; $i++){
+    Cleanup "SRIOV_Child${i}"
+}
+
+#
+# Start creating the 32 child VMs
+#
+# First, we'll check for the partition with the most resources
+$biggestPartition = Get-Partition | Sort-Object "Size" -Descending | Select-Object -First 1
+$driveLetter = $biggestPartition.DriveLetter
+$folderPath = "${driveLetter}:\SRIOV_ChildVMs"
+
+# Make a new directory on the biggest partition. Here will be copied all child VHDs
+If (Test-Path $folderPath){
+    Remove-Item $folderPath -Force -Recurse
+}
+New-Item $folderPath -ItemType Directory
+
+# Stop main VM to get the parent VHD
+# Shutdown gracefully so we dont corrupt VHD.
+Stop-VM -Name $vmName -ComputerName $hvServer
+if (-not $?) {
+    Write-Output "Error: Unable to Shut Down VM" | Tee-Object -Append -file $summaryLog
+    return $False
+}
+
+Start-Sleep -s 10
+# Get Parent VHD
+$ParentVHD = GetParentVHD $vmName $hvServer
+if(-not $ParentVHD) {
+    Write-Output "Error getting Parent VHD of VM $vmName" | Tee-Object -Append -file $summaryLog
+    return $False
+}
+
+# Get information about the main VM
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+# Get VM Generation
+$vm_gen = $vm.Generation
+
+$VMNetAdapter = Get-VMNetworkAdapter $vmName -ComputerName $hvServer
+if (-not $?) {
+    Write-Output "Error: Get-VMNetworkAdapter for $vmName failed" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+# Make a specified number of childs from the parent VHD
+for($i=0; $i -lt $vmNumber; $i++) {
+    $childName = "${folderPath}\SR-IOV_Child_${i}"
+    $ChildVHD = CreateChildVHD $ParentVHD $childName
+    New-Variable -Name "ChildVHD${i}" -Value $ChildVHD
+
+    $childVMName = "SRIOV_Child${i}"
+    New-Variable -Name "ChildVM${i}" -Value $childVMName
+
+    $childBondIP = "10.11.12.1${i}"
+    New-Variable -Name "ChildBondIP${i}" -Value $childBondIP
+
+    $newVm = New-VM -Name $childVMName -ComputerName $hvServer -VHDPath $ChildVHD -MemoryStartupBytes 1024MB -SwitchName $VMNetAdapter[0].SwitchName -Generation $vm_gen
+    if (-not $?) {
+       Write-Output "Error: Creating New VM $childVMName" | Tee-Object -Append -file $summaryLog
+       return $False
+    }
+
+    # Disable secure boot if Gen2
+    if ($vm_gen -eq 2) {
+        Set-VMFirmware -VMName $childVMName -ComputerName $hvServer -EnableSecureBoot Off
+        if(-not $?) {
+            Write-Output "Error: Unable to disable secure boot" | Tee-Object -Append -file $summaryLog
+            Cleanup $childVMName
+            return $false
+        }
+    }
+
+    ConfigureVMandBond $childVMName $hvServer $sshKey $childBondIP $netmask
+}
+
+Write-Output "Child VMs were started and configured " | Tee-Object -Append -file $summaryLog
+
+# Start again main VM and configure it
+ConfigureVMandBond $vmName $hvServer $sshKey "10.11.12.1" $netmask
+
+$ipv4 = GetIPv4 $vmName $hvServer 
+Write-Output "$vmName IPADDRESS: $ipv4"
+
+#
+# Create an 128MB file on test VM
+#
+Start-Sleep -s 3
+$retVal = CreateFileOnVM $ipv4 $sshKey 128
+if (-not $retVal)
+{
+    Write-Output "ERROR: Failed to create a file on vm $vmName (IP: ${ipv4})" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+# For SRIOV_SendFile function to work, constants.sh needs to contain specific information
+# This info is appended to constants.sh from here
+SendCommandToVM "$ipv4" "$sshKey" "echo 'BOND_IP1=10.11.12.1' >> constants.sh"
+SendCommandToVM "$ipv4" "$sshKey" "echo 'sshKey=$sshKey' >> constants.sh"
+SendCommandToVM "$ipv4" "$sshKey" "sed -i 's/.ppk//' constants.sh"
+SendCommandToVM "$ipv4" "$sshKey" "echo 'REMOTE_USER=$remoteUser' >> constants.sh"
+
+# Send the file to all Child VMs
+Start-Sleep -s 10
+$failedToSendCount = 0
+for($i=0; $i -lt $vmNumber; $i++) {
+    $transferStatus = $null
+    $childBondIP = Get-Variable -Name "ChildBondIP${i}" -ValueOnly
+
+    SendCommandToVM "$ipv4" "$sshKey" "echo 'BOND_IP2=$childBondIP' >> constants.sh"
+    $retVal = SRIOV_SendFile $ipv4 $sshKey 1400
+    if (-not $retVal)
+    {
+        "ERROR: Failed to send the file from vm $vmName to SRIOV_Child${i} after changing state"
+        SendCommandToVM $ipv4 $sshKey "head -n -1 constants.sh > temp.txt ; mv temp.txt constants.sh"
+        $failedToSendCount++
+    }
+    else {
+        SendCommandToVM $ipv4 $sshKey "head -n -1 constants.sh > temp.txt ; mv temp.txt constants.sh -f"
+    }  
+}
+
+# Clean all Child VMs
+for($i=0; $i -lt $vmNumber; $i++){
+    Write-Output "Starting cleanup"
+    Cleanup "SRIOV_Child${i}"
+}
+Remove-Item $folderPath -Force -Recurse
+
+# Check results
+Start-Sleep -s 10
+if ($failedToSendCount -gt 0) {
+    Write-Output "File was not sent to ${failedToSendCount} VMs"
+    if ($failedToSendCount -eq $vmNumber){
+        Write-Output "ERROR: File was not sent to any of the $vmNumber Child VMs" | Tee-Object -Append -file $summaryLog  
+        return $false
+    }
+}
+else {
+    Write-Output "File was sent to all ${vmNumber} VMs" | Tee-Object -Append -file $summaryLog
+}
+
+return $True

--- a/WS2012R2/lisa/setupscripts/SR-IOV_Ping_DisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_Ping_DisableVF.ps1
@@ -1,0 +1,259 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Run continous Ping while disabling and enabling the SR-IOV feature
+
+.Description
+    Continuously ping a server, from a Linux client, over a SR-IOV connection. 
+    Disable SR-IOV on the Linux client and observe RTT increase.  
+    Re-enable SR-IOV and observe that RTT lowers. 
+      
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Ping_DisableVF</testName>
+        <testScript>setupscripts\SR-IOV_Ping_DisableVF.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=SRIOV-5A</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHostname</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Run Ping with SR-IOV enabled
+#
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && ping -c 600 -I bond0 `$BOND_IP2 > PingResults.log &' > runPing.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runPing.sh > ~/Ping.log 2>&1"
+
+# Wait 60 seconds and read the RTT
+"Get Logs"
+Start-Sleep -s 60
+[decimal]$vfEnabledRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $vfEnabledRTT){
+    "ERROR: No result was logged! Check if Ping was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The RTT before disabling SR-IOV is $vfEnabledRTT ms" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+#
+# Disable SR-IOV on both VMs
+#
+"Disabling VF on vm1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IovWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable SR-IOV on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+"Disabling VF on vm2"
+Set-VMNetworkAdapter -VMName $vm2Name -ComputerName $remoteServer -IovWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable SR-IOV on $vm2Name!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+
+# Read the RTT with SR-IOV disabled; it should be higher
+Start-Sleep -s 60
+[decimal]$vfDisabledRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $vfDisabledRTT){
+    "ERROR: No result was logged after SR-IOV was disabled!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The RTT with SR-IOV disabled is $vfDisabledRTT ms" | Tee-Object -Append -file $summaryLog
+if ($vfDisabledRTT -le $vfEnabledRTT) {
+    "ERROR: The RTT was lower with SR-IOV disabled, it should be higher" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+Start-Sleep -s 10
+
+#
+# Enable SR-IOV on both VMs
+#
+"Enable VF on vm1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IovWeight 1
+if (-not $?) {
+    "ERROR: Failed to enable SR-IOV on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+"Enable VF on vm2"
+Set-VMNetworkAdapter -VMName $vm2Name -ComputerName $remoteServer -IovWeight 1
+if (-not $?) {
+    "ERROR: Failed to enable SR-IOV on $vm2Name!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+# Restart VF on both VMs
+Start-Sleep -s 20
+RestartVF $ipv4 $sshKey
+RestartVF $vm2ipv4 $sshKey
+Start-Sleep -s 80
+
+# Read the RTT again, it should be lower than before
+# We should see a significant imporvement, we'll check for at least 0.1 ms improvement
+[decimal]$vfDisabledRTT = $vfDisabledRTT - 0.08
+[decimal]$vfFinalRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+
+"The RTT after re-enabling SR-IOV is $vfFinalRTT ms" | Tee-Object -Append -file $summaryLog
+if ($vfDisabledRTT -le $vfFinalRTT ) {
+    "ERROR: After re-enabling SR-IOV, the RTT value has not lowered enough
+    Please check if the VF was successfully restarted" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_DisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_DisableVF.ps1
@@ -1,0 +1,280 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Continuous iPerf, disable SR-IOV, enable SR-IOV
+
+.Description
+    Disable SR-IOV while transferring data of the device, then enable SR-IOV. 
+    While disabled, the traffic should fallback to the synthetic device and throughput should drop. 
+    Once SR-IOV is enabled again, traffic should handled by the SR-IOV device and throughput increase.
+   
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>iPerf_DisableVF</testName>
+        <testScript>setupscripts\SR-IOV_iPerf_DisableVF.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=SRIOV-8</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHostName</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get VM2 ipv4
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Install iPerf3 on VM1
+#
+"Installing iPerf3 on ${vmName}"
+$retval = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "dos2unix SR-IOV_Utils.sh && source SR-IOV_Utils.sh && InstallDependencies"
+if (-not $retVal)
+{
+    "ERROR: Failed to install iPerf3 on vm $vmName (IP: ${ipv4})"
+    return $false
+}
+
+#
+# Run iPerf3 with SR-IOV enabled
+#
+# Start the client side
+"Start Client"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s > client.out &"
+
+"Start Server"
+# Start iPerf3 testing
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && iperf3 -t 600 -c `$BOND_IP2 --logfile PerfResults.log &' > runIperf.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+
+# Wait 60 seconds and read the throughput
+"Get Logs"
+Start-Sleep -s 60
+[decimal]$vfEnabledThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+if (-not $vfEnabledThroughput){
+    "ERROR: No result was logged! Check if iPerf was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The throughput before disabling SR-IOV is $vfEnabledThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+#
+# Disable SR-IOV on both VMs
+#
+"Disabling VF on vm1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IovWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable SR-IOV on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+"Disabling VF on vm2"
+Set-VMNetworkAdapter -VMName $vm2Name -ComputerName $remoteServer -IovWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable SR-IOV on $vm2Name!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+
+# Read the throughput with SR-IOV disabled; it should be lower
+Start-Sleep -s 60
+[decimal]$vfDisabledThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+if (-not $vfDisabledThroughput){
+    "ERROR: No result was logged after SR-IOV was disabled!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The throughput with SR-IOV disabled is $vfDisabledThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+if ($vfDisabledThroughput -ge $vfEnabledThroughput) {
+    "ERROR: The throughput was higher with SR-IOV disabled, it should be lower" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+Start-Sleep -s 10
+
+#
+# Enable SR-IOV on both VMs
+#
+"Enable VF on vm1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IovWeight 1
+if (-not $?) {
+    "ERROR: Failed to enable SR-IOV on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+"Enable VF on vm2"
+Set-VMNetworkAdapter -VMName $vm2Name -ComputerName $remoteServer -IovWeight 1
+if (-not $?) {
+    "ERROR: Failed to enable SR-IOV on $vm2Name!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+# Restart VF on both VMs
+Start-Sleep -s 20
+RestartVF $ipv4 $sshKey
+RestartVF $vm2ipv4 $sshKey
+Start-Sleep -s 60
+
+# Read the throughput again, it should be higher than before
+# We should see a significant imporvement, we'll check for at least 1gpbs improvement
+[decimal]$vfDisabledThroughput = $vfDisabledThroughput + 1
+[decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+
+"The throughput after re-enabling SR-IOV is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+if ($vfDisabledThroughput -ge $vfFinalThroughput ) {
+    "ERROR: After re-enabling SR-IOV, the throughput has not increased enough 
+    Please check if the VF was successfully restarted" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_MultipleServers.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_MultipleServers.ps1
@@ -1,0 +1,319 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Multiple VM SR-IOV test
+
+.Description
+    a. Using two Hyper-V hosts, create Linux VMs, VM1 and VM2, on the first host,
+       and  VM3 and VM4 on the second Hyper-V host.
+    b. Configure each VM with a synthetic NIC with SR-IOV enabled on
+       the vSwitch and the VMs NIC.
+    c. On each Linux VM, run the bonding script to create the bond0 device.
+    d. Verify the bond0 device is working on each VM.
+    e. Run iPerf from VM1 to VM3 and from VM2 to VM4 simultaneously
+ Acceptance Criteria
+    a. iPerf completes.
+    b. Dropped packets does not exceed 3% of total packets.
+
+    
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Single_SaveVM</testName>
+        <testScript>setupScripts\SR-IOV_SavePauseVM.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=??</param>                                   
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_USER=root</param>
+            <!-- VM_STATE has to be 'pause' or 'save' -->
+            <param>VM_STATE=save</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+function StopVM ([String] $vmName, [String] $hvServer)
+{
+    # Make sure VM2 is shutdown
+    if (Get-VM -Name $vmName -ComputerName $hvServer |  Where { $_.State -like "Running" }) {
+        Stop-VM $vmName  -ComputerName $hvServer -force
+
+        if (-not $?)
+        {
+            "ERROR: Failed to shut $vm2Name down (in order to add a new network Adapter)"
+            return $false
+        }
+
+        # wait for VM to finish shutting down
+        $timeout = 60
+        while (Get-VM -Name $vmName -ComputerName $hvServer |  Where { $_.State -notlike "Off" })
+        {
+            if ($timeout -le 0) {
+                "ERROR: Failed to shutdown $vmName"
+                return $false
+            }
+
+            start-sleep -s 5
+            $timeout = $timeout - 5
+        }
+
+    }
+}
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+        "VM3NAME" { $vm3name = $fields[1].Trim() }
+        "VM4NAME" { $vm4name = $fields[1].Trim() }
+        "VM3BOND_IP" { $vm3bondIP = $fields[1].Trim() }
+        "VM4BOND_IP" { $vm4bondIP = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Start VM3 and VM4 and configure them
+#
+$retVal = ConfigureVMandBond $vm3Name $hvServer $sshKey $vm3bondIP $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure vm $vm3Name on $hvServer"
+    return $false
+}
+$retVal = ConfigureVMandBond $vm4Name $hvServer $sshKey $vm4bondIP $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure vm $vm4Name on $remoteServer"
+    return $false
+}
+
+# Get ipv4 from VM2
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer 
+"$vm2Name IPADDRESS: $vm2ipv4"
+
+# Get ipv4 from VM3
+$vm3ipv4 = GetIPv4 $vm3Name $hvServer
+"$vm3Name IPADDRESS: $vm3ipv4"
+
+# Get ipv4 from VM4
+$vm4ipv4 = GetIPv4 $vm4Name $hvServer
+"$vm4Name IPADDRESS: $vm4ipv4"
+
+# Send BOND_IP2 to VM3 and VM4. This ip will be used by iPerf
+$commandToSend = "echo -e BOND_IP2=${vmBondIP2} >> constants.sh"
+$retVal = SendCommandToVM "$vm3ipv4" "$sshKey" $commandToSend
+if (-not $retVal)
+{
+    "Failed appending $ipToSend to constants.sh on VM3"
+    return $False
+}
+
+$retVal = SendCommandToVM "$vm4ipv4" "$sshKey" $commandToSend
+if (-not $retVal)
+{
+    "Failed appending $ipToSend to constants.sh on VM4"
+    return $False
+}
+
+Start-Sleep -s 5
+"All 4 VMs were successfully configured"
+
+#
+# Run iPerf3 with SR-IOV enabled
+#
+# Start the client side on VM2 and VM4
+"Start Client"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s -p 5201 > client.out &"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s -p 5202 > client.out &"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s -p 5203 > client.out &"
+
+Start-Sleep -s 5
+# Start iPerf3 testing
+"Start Servers"
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && iperf3 -c `$BOND_IP2 -p 5201 -u -t 100 --logfile PerfResults.log &' > runIperf.sh"
+.\bin\plink.exe -i ssh\$sshKey root@${vm3ipv4} "echo 'source constants.sh && iperf3 -c `$BOND_IP2 -p 5202 -u -t 100 --logfile PerfResults.log &' > runIperf.sh"
+.\bin\plink.exe -i ssh\$sshKey root@${vm4ipv4} "echo 'source constants.sh && iperf3 -c `$BOND_IP2 -p 5203 -u -t 100 --logfile PerfResults.log &' > runIperf.sh"
+
+
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+.\bin\plink.exe -i ssh\$sshKey root@${vm3ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+.\bin\plink.exe -i ssh\$sshKey root@${vm4ipv4}  "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+
+# Get the logs
+"Get Logs"
+Start-Sleep -s 120
+$droppedPackets = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "cat PerfResults.log | grep % | sed 's/(/ /' | sed 's/%./ /' | awk '{print `$12}'"
+if (-not $droppedPackets){
+    "ERROR: No result was logged on VM1! Check if iPerf was executed on VM1!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The droppedPackets percentage on Server 1 is ${droppedPackets}%" | Tee-Object -Append -file $summaryLog
+
+$droppedPackets2 = .\bin\plink.exe -i ssh\$sshKey root@${vm3ipv4} "cat PerfResults.log | grep % | sed 's/(/ /' | sed 's/%./ /' | awk '{print `$12}'"
+if (-not $droppedPackets2){
+    "ERROR: No result was logged on VM3! Check if iPerf was executed on VM3!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The droppedPackets percentage on Server 2 is ${droppedPackets2}%" | Tee-Object -Append -file $summaryLog
+
+$droppedPackets3 = .\bin\plink.exe -i ssh\$sshKey root@${vm4ipv4} "cat PerfResults.log | grep % | sed 's/(/ /' | sed 's/%./ /' | awk '{print `$12}'"
+if (-not $droppedPackets3){
+    "ERROR: No result was logged on VM4! Check if iPerf was executed on VM4!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The droppedPackets percentage on Server 3 is ${droppedPackets3}%" | Tee-Object -Append -file $summaryLog
+
+if (($droppedPackets -ge 3) -or ($droppedPackets2 -ge 3) -or ($droppedPackets3 -ge 3)){
+    "ERROR: The dropped packets are more than 3%" | Tee-Object -Append -file $summaryLog
+    return $false  
+}
+
+#
+# Stop all dependenncy VMs
+#
+StopVM $vm2Name $remoteServer
+StopVM $vm3Name $hvServer
+StopVM $vm4Name $hvServer
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_Reboot.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_Reboot.ps1
@@ -1,0 +1,263 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    While iPerf is transferring data over a SR-IOV connection, reboot the VM.
+
+.Description
+    Description:
+    While iPerf is transferring data over a SR-IOV connection, reboot the VM.
+    Steps:
+        1.  Configure a Linux VM with SR-IOV, and a second VM with SR-IOV (Windows or Linux).
+        2.  Start iPerf in server mode on the second VM.
+        3.  On the Linux VM, start iPerf in client mode for about a 10 minute run.
+        4.  While the iPerf client is transferring data, reboot the Linux client VM.
+        5.  After reboot, start the iPerf client again.
+    Acceptance Criteria:
+        After the reboot, the SR-IOV device works correctly.
+ 
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>iPerf_Reboot</testName>
+        <testScript>setupscripts\SR-IOV_iPerf_Reboot.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=SRIOV-9</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHostName</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get VM2 ipv4
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Install iPerf3 on VM1
+#
+"Installing iPerf3 on ${vmName}"
+$retval = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "dos2unix SR-IOV_Utils.sh && source SR-IOV_Utils.sh && InstallDependencies"
+if (-not $retVal)
+{
+    "ERROR: Failed to install iPerf3 on vm $vmName (IP: ${ipv4})"
+    return $false
+}
+
+#
+# Run iPerf3 with SR-IOV enabled
+#
+# Start the client side
+"Start Client"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s > client.out &"
+
+"Start Server"
+# Start iPerf3 testing
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && iperf3 -t 600 -c `$BOND_IP2 --logfile PerfResults.log &' > runIperf.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+
+# Wait 60 seconds and read the throughput
+"Get Logs"
+Start-Sleep -s 20
+[decimal]$vfBeforeThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+if (-not $vfBeforeThroughput){
+    "ERROR: No result was logged! Check if iPerf was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The throughput before rebooting VM is $vfBeforeThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+
+#
+# Reboot VM1
+#
+Restart-VM -VMName $vmName -ComputerName $hvServer -Force
+$timeout = 100
+if (-not (WaitForVMToStartKVP $vmName $hvServer $timeout ))
+{
+    Write-Output "Error: ${vmName} failed to restart" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+Start-Sleep -s 5
+# Get the ipv4, maybe it may change after the reboot
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IP Address after reboot: ${ipv4}"
+
+# Check if bond is still up & running
+$status = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "ifconfig | grep bond0" 
+if (-not $status) {
+    "ERROR: The bond is down after reboot!" | Tee-Object -Append -file $summaryLog
+    return $false    
+}
+
+# Restart iPerf 3 on VM2
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4} "kill `$(ps aux | grep iperf | head -1 | awk '{print `$2}')"
+.\bin\plink.exe -i ssh\$sshKey root@${vm2ipv4}  "iperf3 -s > client.out &"
+
+# Start iPerf3 again
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && iperf3 -t 600 -c `$BOND_IP2 --logfile PerfResults.log &' > runIperf.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
+
+# Read the throughput again, it should be higher than before
+# We should see a significant imporvement, we'll check for at least 1gpbs improvement
+Start-Sleep -s 30
+[decimal]$vfBeforeThroughput = $vfBeforeThroughput - 1
+[decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
+
+"The throughput after rebooting the VM is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog
+if ($vfBeforeThroughput -ge $vfFinalThroughput ) {
+    "ERROR: After rebooting the VM, the throughput is significantly lower
+    Please check if the VF was successfully restarted" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+return $true

--- a/WS2012R2/lisa/xml/SR-IOV.xml
+++ b/WS2012R2/lisa/xml/SR-IOV.xml
@@ -40,24 +40,40 @@
             <suiteTests>
                 <!-- Basic SR-IOV tests -->
                 <suiteTest>VerifyVF_basic</suiteTest>
+                <suiteTest>Multicast</suiteTest>
+                <suiteTest>Broadcast</suiteTest>
+                <suiteTest>DisableVF</suiteTest>
+                <suiteTest>Ping_DisableVF</suiteTest>
+                <suiteTest>iPerf_DisableVF</suiteTest>
+                <suiteTest>iPerf_Reboot</suiteTest>
+                <suiteTest>iPerf_Stress</suiteTest>
+                <suiteTest>Disable_VMQ</suiteTest>
+                <suiteTest>Change_RSS</suiteTest>
                 <suiteTest>CompareRTT</suiteTest>
                 <suiteTest>Compare_iPerf</suiteTest>
-                <suiteTest>DisableVF</suiteTest>
+                
                 <!--Multiple NIC Bonding tests-->
                 <suiteTest>Multiple_basic</suiteTest>
                 <suiteTest>Multiple_fileCopy</suiteTest>
+                <suiteTest>MaxNICS</suiteTest>
+
                 <!--Pause/Save VM tests with Single/Multiple NICs-->
                 <suiteTest>Single_PauseVM</suiteTest>
                 <suiteTest>Multiple_PauseVM</suiteTest>
                 <suiteTest>Single_SaveVM</suiteTest>
                 <suiteTest>Multiple_SaveVM</suiteTest>
+
+                <!-- Multiple VMs-->
+                <suiteTest>Max_VMs</suiteTest>
+                <suiteTest>iPerf_MultipleServers</suiteTest> 
+                <suiteTest>MultipleLinuxVMs</suiteTest>
+
                 <!-- Replication Tests -->
                 <!-- Run this tests if you have a Replication Server set up -->
                 <!-- <suiteTest>Replication_Single_VF</suiteTest>  
                 <suiteTest>Replication_Single_FailoverVF</suiteTest> 
                 <suiteTest>Replication_Multiple_VF</suiteTest> 
                 <suiteTest>Replication_Multiple_FailoverVF</suiteTest>-->
-                <suiteTest>MultipleLinuxVMs</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -84,9 +100,9 @@
         </test>
 
         <test>
-            <testName>CompareRTT</testName>
-            <testScript>SR-IOV_compareRTT.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_compareRTT.sh,remote-scripts/ica/utils.sh</files> 
+            <testName>Multicast</testName>
+            <testScript>SR-IOV_Multicast.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_Multicast.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -94,12 +110,9 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>NIC=NetworkAdapter,Internal,Internal,001600112201</param>
-                <param>TC_COVERED=SRIOV-4</param>
+                <param>TC_COVERED=SRIOV-4</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
-                <param>STATIC_IP1=192.168.0.10</param>
-                <param>STATIC_IP2=192.168.0.20</param>
                 <param>NETMASK=255.255.255.0</param>
                 <param>REMOTE_USER=root</param>
             </testParams>
@@ -107,9 +120,9 @@
         </test>
 
         <test>
-            <testName>Compare_iPerf</testName>
-            <testScript>setupscripts\SR-IOV_iPerf.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files> 
+            <testName>Broadcast</testName>
+            <testScript>SR-IOV_Broadcast.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_Broadcast.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -117,11 +130,11 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-5</param>
+                <param>TC_COVERED=SRIOV-5</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_SERVER=HOST2</param>
+                <param>REMOTE_USER=root</param>
             </testParams>
             <timeout>1000</timeout>
         </test>
@@ -147,6 +160,171 @@
         </test>
 
         <test>
+            <testName>Ping_DisableVF</testName>
+            <testScript>setupscripts\SR-IOV_Ping_DisableVF.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-7</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>iPerf_DisableVF</testName>
+            <testScript>setupscripts\SR-IOV_iPerf_DisableVF.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-8</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>iPerf_Reboot</testName>
+            <testScript>setupscripts\SR-IOV_iPerf_Reboot.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-9</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>iPerf_Stress</testName>
+            <testScript>SR-IOV_iPerfStress.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_iPerfStress.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-10</param>                                   
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_USER=root</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>3600</timeout>
+        </test>
+
+        <test>
+            <testName>Disable_VMQ</testName>
+            <testScript>setupscripts\SR-IOV_DisableVMQ.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-11</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>Change_RSS</testName>
+            <testScript>setupscripts\SR-IOV_ChangeRSS.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-12</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>CompareRTT</testName>
+            <testScript>SR-IOV_compareRTT.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_compareRTT.sh,remote-scripts/ica/utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>NIC=NetworkAdapter,Internal,Internal,001600112201</param>
+                <param>TC_COVERED=SRIOV-13</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>STATIC_IP1=192.168.0.10</param>
+                <param>STATIC_IP2=192.168.0.20</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_USER=root</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>Compare_iPerf</testName>
+            <testScript>setupscripts\SR-IOV_iPerf.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-14</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+
+        <test>
             <testName>Multiple_basic</testName>
             <testScript>SR-IOV_Multiple_basic.sh</testScript>
             <files>remote-scripts/ica/SR-IOV_Multiple_basic.sh,remote-scripts/ica/utils.sh</files> 
@@ -158,7 +336,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-7</param>
+                <param>TC_COVERED=SRIOV-15</param>
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
@@ -171,8 +349,8 @@
 
         <test>
             <testName>Multiple_fileCopy</testName>
-            <testScript>SR-IOV_Multiple_fileCopy.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_Multiple_fileCopy.sh,remote-scripts/ica/utils.sh</files> 
+            <testScript>SR-IOV_Multiple_basic.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_Multiple_basic.sh,remote-scripts/ica/utils.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -181,7 +359,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-8</param>
+                <param>TC_COVERED=SRIOV-16</param>
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
@@ -190,6 +368,24 @@
                 <param>REMOTE_USER=root</param>
             </testParams>
             <timeout>1000</timeout>
+        </test>
+
+        <test>
+            <testName>MaxNICS</testName>
+            <testScript>SR-IOV_MaxNIC.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_MaxNIC.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>TC_COVERED=SRIOV-17</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_USER=root</param>
+                <param>MAX_NICS=yes</param>
+            </testParams>
+            <timeout>1600</timeout>
         </test>
 
         <test>
@@ -203,7 +399,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-9</param>                                   
+                <param>TC_COVERED=SRIOV-18</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -226,7 +422,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-10</param>                                   
+                <param>TC_COVERED=SRIOV-19</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
             	<param>BOND_IP3=10.12.12.33</param>
@@ -250,7 +446,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-11</param>                                   
+                <param>TC_COVERED=SRIOV-20</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -273,7 +469,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-12</param>                                   
+                <param>TC_COVERED=SRIOV-21</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
@@ -282,6 +478,70 @@
                 <param>REMOTE_USER=root</param>
                 <!-- VM_STATE has to be 'pause' or 'save' -->
                 <param>VM_STATE=save</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>Max_VMs</testName>
+            <testScript>setupscripts\SR-IOV_MaxVMs.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>TC_COVERED=SRIOV-22</param>
+                <param>REMOTE_USER=root</param>
+                <param>VM_NUMBER=32</param>
+            </testParams>
+            <timeout>10800</timeout>
+        </test>
+
+        <test>
+            <testName>iPerf_MultipleServers</testName>
+            <testScript>setupscripts\SR-IOV_iPerf_MultipleServers.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-23</param>
+                <param>BOND_IP1=10.11.12.61</param>
+                <param>BOND_IP2=10.11.12.62</param>
+                <param>VM3BOND_IP=10.11.12.63</param>
+                <param>VM4BOND_IP=10.11.12.64</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+                <param>VM3NAME=VM3_Name_HOST1</param>
+                <param>VM4NAME=VM4_NAME_HOST1</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
+
+        <test>
+            <testName>MultipleLinuxVMs</testName>
+            <testScript>setupscripts\SR-IOV_MultipleLinuxVMs.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-24</param>
+                <param>BOND_IP1=10.11.12.61</param>
+                <param>BOND_IP2=10.11.12.62</param>
+                <param>VM3BOND_IP=10.11.12.63</param>
+                <param>VM4BOND_IP=10.11.12.64</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHostName</param>
+                <param>VM3NAME=VM3_Name_HOST1</param>
+                <param>VM4NAME=VM4_Name_HOST2</param>
             </testParams>
             <timeout>1800</timeout>
         </test>
@@ -297,7 +557,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-17</param>                                   
+                <param>TC_COVERED=SRIOV-25</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -323,7 +583,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-18</param>
+                <param>TC_COVERED=SRIOV-26</param>
                 <param>leaveTrail=no</param>                                 
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
@@ -349,7 +609,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-19</param>                                   
+                <param>TC_COVERED=SRIOV-27</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
@@ -377,7 +637,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-20</param>                                   
+                <param>TC_COVERED=SRIOV-28</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
@@ -392,42 +652,18 @@
             </testParams>
             <timeout>2400</timeout>
         </test>
-
-        <test>
-            <testName>MultipleLinuxVMs</testName>
-            <testScript>setupscripts\SR-IOV_MultipleLinuxVMs.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files> 
-            <setupScript>
-                <file>setupscripts\RevertSnapshot.ps1</file>
-                <file>setupscripts\SR-IOV_enable.ps1</file>
-            </setupScript> 
-            <noReboot>False</noReboot>
-            <testParams>
-                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-21</param>
-                <param>BOND_IP1=10.11.12.61</param>
-                <param>BOND_IP2=10.11.12.62</param>
-                <param>VM3BOND_IP=10.11.12.63</param>
-                <param>VM4BOND_IP=10.11.12.64</param>
-                <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_SERVER=HOST2</param>
-                <param>VM3NAME=VM3</param>
-                <param>VM4NAME=VM4</param>
-            </testParams>
-            <timeout>1000</timeout>
-        </test>
     </testCases>
 
     <VMs>
         <vm>
             <hvServer>localhost</hvServer>
-            <vmName>VM1Name</vmName>
+            <vmName>vm1</vmName>
             <os>Linux</os>
             <ipv4></ipv4>
-            <sshKey>linux_id_rsa.ppk</sshKey>
+            <sshKey>id_rsa.ppk</sshKey>
             <testParams>
-                <param>VM2NAME=VM2Name</param>
-                <param>sshKey=ssh_key</param>
+                <param>VM2NAME=vm2</param>
+                <param>sshKey=id_rsa</param>
                 <param>SnapshotName=ICABase</param>
             </testParams>
             <suite>SR-IOV</suite>

--- a/WS2012R2/lisa/xml/SR-IOV_LM.xml
+++ b/WS2012R2/lisa/xml/SR-IOV_LM.xml
@@ -91,7 +91,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-13</param>                                   
+                <param>TC_COVERED=SRIOV-29</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -111,7 +111,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-14</param>                                   
+                <param>TC_COVERED=SRIOV-30</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -133,7 +133,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-15</param>                                   
+                <param>TC_COVERED=SRIOV-31</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>BOND_IP3=10.11.12.53</param>
@@ -156,7 +156,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-16</param>                                   
+                <param>TC_COVERED=SRIOV-32</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>BOND_IP3=10.11.12.53</param>


### PR DESCRIPTION
Added the following new TCs:

- Broadcast packet test
- Multicast packet test
- Multiple Linux sending TCP traffic to same host
- Continuous Ping, disable SR-IOV, enable SR-IOV
- iPerf, disable SR-IOV, enable SR-IOV
- Change RSS settings during iPerf
- Tear down VMQ and fallback to synthetic NIC
- Limit test – 32 VMs, one SR-IOV device each
- Limit test – one VM with max NICs, max SR-IOV devices
- Reboot during iPerf then connect successfully
- iPerf Stress test

For more detailed info, please check the FTM Automation spreadsheet

Important note: Also changed all SR-IOV TC_Covered codes to accommodate
the new TCs