### PR TITLE
Update 50 Reboot test script

### DIFF
--- a/WS2012R2/lisa/xml/StressTests.xml
+++ b/WS2012R2/lisa/xml/StressTests.xml
@@ -18,7 +18,7 @@
         <suite>
             <suiteName>Stress</suiteName>
             <suiteTests>
-                <suiteTest>Test50TimesReboot</suiteTest>
+                <suiteTest>MultipleReboot</suiteTest>
                 <suiteTest>Stress_IOzone</suiteTest>
                 <suiteTest>Sysbench</suiteTest>
                 <!-- Obsolete test cases
@@ -31,11 +31,12 @@
 
     <testCases>
         <test>
-            <testName>Test50TimesReboot</testName>
-            <testScript>setupScripts\Test50TimesReboot.ps1</testScript>
+            <testName>MultipleReboot</testName>
+            <testScript>setupScripts\MultipleReboot.ps1</testScript>
             <timeout>3600</timeout>
             <testParams>
                 <param>TC_COVERED=Stress-01</param>
+                <param>count=50</param>
             </testParams>
             <onError>Continue</onError>
             <noReboot>False</noReboot>


### PR DESCRIPTION
There was an issue with this script because it formerly tried to reboot
the VM both using the "Restart-VM" cmdlet and the ctrl-alt-del keystroke
from the VM's keyboard. This led to the occasional situation where the VM
would get stuck in the GRUB menu, failing the test this way.

In order to fix this, I removed the "ctrl-alt-del" reboot from the main
loop (Why was the VM being restarted twice with just a "sleep 5" between those
reboots?) alongside the VM keyboard variable (which only needs to be
initialized once). I also left a "ctrl-alt-del" reboot outside of the
loop, in case we need to test if rebooting with that method works aswell.

Also the boot count parameter is defined in the stress tests xml now,
therefore the script has been renamed to "MultipleReboot.ps1"

Also added indentation to the main loop so it may be easier to understand
for future modifications.