### PR TITLE
SR-IOV: 4 TCs added

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_UpgradeKernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_UpgradeKernel.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved. 
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0  
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+# Description:
+# This script install the latest kernel on RHEL, SLES or Ubuntu
+#
+########################################################################
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+if is_fedora ; then
+	yum install kernel -y
+
+elif is_ubuntu ; then
+	DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+
+elif is_suse ; then
+	zypper --non-interactive dist-upgrade
+fi
+
+if [ $? -ne 0 ]; then
+	LogMsg "ERROR: Failed to install kernel"
+    SetTestStateFailed
+    exit 1
+else
+	LogMsg "Kernel was installed successfully"
+	SetTestStateCompleted
+fi

--- a/WS2012R2/lisa/setupscripts/SR-IOV_MeasureDisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_MeasureDisableVF.ps1
@@ -1,0 +1,283 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Continuous iPerf, disable SR-IOV, enable SR-IOV and measure time to switch
+
+.Description
+    Disable SR-IOV while transferring data of the device, then enable SR-IOV. 
+    For both operations, measure time between the switch.
+    If the time is bigger than 10 seconds, fail the test
+   
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Measure_DisableVF</testName>
+        <testScript>setupscripts\SR-IOV_MeasureDisableVF.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
+            <param>TC_COVERED=SRIOV-7</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHost</param>
+        </testParams>
+        <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
+        <timeout>2400</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get VM2 ipv4
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Start ping
+#
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && ping -c 1200 -I bond0 `$BOND_IP2 > PingResults.log &' > runPing.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runPing.sh > ~/Ping.log 2>&1"
+Start-Sleep -s 10
+
+[decimal]$initialRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $initialRTT){
+    "ERROR: No result was logged! Check if bond is up!" | Tee-Object -Append -file $summaryLog
+    .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "ifconfig"
+    return $false
+}
+"The RTT before disabling VF is $initialRTT ms" | Tee-Object -Append -file $summaryLog
+
+# We add 0.4 ms to the initial RTT to future determine if the data is transmitted through VF or netvsc
+[decimal]$initialRTT = $initialRTT + 0.05
+#
+# Disable SR-IOV on test VM
+#
+"Disabling VF on vm1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IovWeight 0
+if (-not $?) {
+    "ERROR: Failed to disable SR-IOV on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+# icmp seq
+[int]$initial_icmpSeq = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -1 PingResults.log | head -1 | awk '{print `$5}' | sed 's/=/ /' | awk '{print `$2}'"
+
+# Read the throughput with SR-IOV disabled; it should be lower
+$timeToRun = 0
+$hasSwitched = $false
+while ($hasSwitched -eq $false){ 
+    [decimal]$disabledRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -1 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+    [int]$disabled_icmpSeq = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -1 PingResults.log | head -1 | awk '{print `$5}' | sed 's/=/ /' | awk '{print `$2}'"
+    if (($disabledRTT -ge $initialRTT) -and ($disabled_icmpSeq -ne $initial_icmpSeq)) {
+        $hasSwitched = $true
+    }
+
+    $timeToRun++
+    if ($timeToRun -ge 100) {
+        "ERROR: The switch beteen VF and netvsc was not made. RTT values show that traffic goes through VF!" | Tee-Object -Append -file $summaryLog
+        return $false 
+    }
+
+    if ($hasSwitched -eq $false){
+        Start-Sleep -s 1
+    }
+}
+[int]$timetoSwitch = $disabled_icmpSeq - $initial_icmpSeq
+if ($timetoSwitch -gt 10) {
+    "ERROR: After disabling VF, $timetoSwitch seconds passed until Ping worked again. Time is too big" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+Start-Sleep -s 5
+"After disabling VF, $timetoSwitch seconds passed until Ping worked again. RTT value is $disabledRTT" | Tee-Object -Append -file $summaryLog
+
+#
+# Read icmp seq value & enable SR-IOV on test VM
+#
+Start-Sleep -s 10
+
+"Enable VF on vm1"
+Set-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer -IovWeight 1
+if (-not $?) {
+    "ERROR: Failed to enable SR-IOV on $vmName!" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+# icmp seq
+[int]$initial_icmpSeq_2 = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -1 PingResults.log | head -1 | awk '{print `$5}' | sed 's/=/ /' | awk '{print `$2}'"
+
+# Read the throughput with SR-IOV disabled; it should be lower
+$timeToRun = 0
+$hasSwitched = $false
+while ($hasSwitched -eq $false){ 
+    [decimal]$enabledRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -1 PingResults.log | head -2 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+    [int]$enabled_icmpSeq = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -1 PingResults.log | head -2 | awk '{print `$5}' | sed 's/=/ /' | awk '{print `$2}'"
+    if (($enabledRTT -le $initialRTT) -and ($enabled_icmpSeq -ne $initial_icmpSeq_2)){
+        $hasSwitched = $true
+        $timetoSwitch = $enabled_icmpSeq - $initial_icmpSeq_2
+        "After enabling VF, $timetoSwitch seconds passed until Ping worked again. RTT value is $enabledRTT ms " | Tee-Object -Append -file $summaryLog
+    }
+
+    $timeToRun++
+    if ($timeToRun -ge 100) {
+        $hasSwitched = $true
+    }
+
+    if ($hasSwitched -eq $false){
+        Start-Sleep -s 1
+    }
+}
+
+[int]$timetoSwitch = $enabled_icmpSeq - $initial_icmpSeq_2 
+if ($timetoSwitch -gt 10) {
+    "ERROR: After disabling VF, $timetoSwitch seconds passed until Ping worked again. Time is too big" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+Start-Sleep -s 3
+"After enabling VF, $timetoSwitch seconds passed until Ping worked again. RTT value is $enabledRTT" | Tee-Object -Append -file $summaryLog
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_MoveVHD.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_MoveVHD.ps1
@@ -1,0 +1,372 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Move the VHD to another host, and build a new VM based on this VHD. The SR-IOV should work.
+
+.Description
+    Description:  
+    Create a new Linux VM from an existing VHDX file that has SR-IOV configured.  
+    SR-IOV should be configured correctly and should work when the new VM is booted.
+    Steps:
+        1.  Configure SR-IOV on a Linux VM and confirm SR-IOV is working.
+        2.  Shutdown the VM.
+        3.  Make a copy of the VHDX file from this VM.
+        4.  Create a second Linux VM using the VHDX file from step 3.
+        5.  Boot the second Linux VM.
+        6.  Test SR-IOV functionality on the second VM.
+
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Move_VHD</testName>
+        <testScript>setupscripts\SR-IOV_MoveVHD.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
+            <param>TC_COVERED=SRIOV-7</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHost/param>
+        </testParams>
+        <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
+        <timeout>2400</timeout>
+    </test>
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+# To Get Parent VHD from VM.
+#######################################################################
+function GetParentVHD($vmName, $hvServer)
+{
+    $ParentVHD = $null
+
+    $VmInfo = Get-VM -Name $vmName -ComputerName $hvServer
+    if (-not $VmInfo) {
+       Write-Error -Message "Error: Unable to collect VM settings for ${vmName}" -ErrorAction SilentlyContinue
+       return $False
+    }
+
+    if ( $VmInfo.Generation -eq "" -or $VmInfo.Generation -eq 1  ) {
+        $Disks = $VmInfo.HardDrives
+        foreach ($VHD in $Disks) {
+            if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "IDE"  )) {
+                $Path = Get-VHD $VHD.Path -ComputerName $hvServer
+                if ([string]::IsNullOrEmpty($Path.ParentPath)) {
+                    $ParentVHD = $VHD.Path
+                }
+                else {
+                    $ParentVHD =  $Path.ParentPath
+                }
+
+                Write-Host "Parent VHD Found: $ParentVHD "
+            }
+        }
+    }
+    if ( $VmInfo.Generation -eq 2 ) {
+        $Disks = $VmInfo.HardDrives
+        foreach ($VHD in $Disks) {
+            if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "SCSI"  )) {
+                $Path = Get-VHD $VHD.Path -ComputerName $hvServer
+                if ([string]::IsNullOrEmpty($Path.ParentPath)) {
+                    $ParentVHD = $VHD.Path
+                }
+                else {
+                    $ParentVHD =  $Path.ParentPath
+                }
+
+                Write-Host "Parent VHD Found: $ParentVHD "
+            }
+        }
+    }
+
+    if ( -not ($ParentVHD.EndsWith(".vhd") -xor $ParentVHD.EndsWith(".vhdx") )) {
+        Write-Error -Message " Parent VHD is Not correct please check VHD, Parent VHD is: $ParentVHD " -ErrorAction SilentlyContinue
+        return $False
+    }
+
+    return $ParentVHD
+}
+
+
+function CreateChildVHD($ParentVHD, $defaultpath)
+{
+    $ChildVHD  = $null
+    $hostInfo = Get-VMHost -ComputerName $remoteHost
+    if (-not $hostInfo) {
+        Write-Error -Message "Error: Unable to collect Hyper-V settings for $remoteHost" -ErrorAction SilentlyContinue
+        return $False
+    }
+
+    # Create Child VHD
+    if ($ParentVHD.EndsWith("x") ) {
+        $ChildVHD = $defaultpath + ".vhdx"
+    }
+    else {
+        $ChildVHD = $defaultpath + ".vhd"
+    }
+
+    if ( Test-Path $ChildVHD ) {
+        Write-Host "Deleting existing VHD $ChildVHD"
+        del $ChildVHD
+    }
+
+    # Copy Child VHD
+    Copy-Item $ParentVHD $ChildVHD
+    if (-not $?) {
+        Write-Error -Message "Error: Unable to create child VHD"  -ErrorAction SilentlyContinue
+        return $False
+    }
+
+    return $ChildVHD
+}
+
+function Cleanup($childVMName)
+{
+    # Clean up
+    $sts = Stop-VM -Name $childVMName -ComputerName $remoteHost -TurnOff
+
+    # Delete New VM created
+    $sts = Remove-VM -Name $childVMName -ComputerName $remoteHost -Confirm:$false -Force
+}
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+#
+# Check the required input args are present
+#
+$netmask = "255.255.255.0"
+
+# Write out test Params
+$testParams
+
+if ($hvServer -eq $null) {
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null) {
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?) {
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+
+$rootDir = $Matches[1]
+if (Test-Path $rootDir) {
+    Set-Location -Path $rootDir
+    if (-not $?) {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else {
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+    . .\setupScripts\TCUtils.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1") {
+    . .\setupScripts\NET_UTILS.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteHost = $fields[1].Trim() }
+        "REMOTE_USER" { $remoteUser = $fields[1].Trim() }
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim()}
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim()}
+        "NIC"
+        {
+            $temp = $p.Trim().Split('=')
+            if ($temp[0].Trim() -eq "NIC")
+            {
+                $nicArgs = $temp[1].Split(',')
+
+                $networkName = $nicArgs[2].Trim()
+            }
+        }
+        default   {}  # unknown param - just ignore it
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Check if there are running old child VMs and stop them
+Cleanup "SRIOV_Child_Remote"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Start creating the VM on the remote host
+#
+# Get default Hyper-V VHD path; The VHD will be copied there
+$hostInfo = Get-VMHost -ComputerName $remoteHost
+$defaultVhdPath = $hostInfo.VirtualHardDiskPath
+if (-not $defaultVhdPath.EndsWith("\")) {
+    $defaultVhdPath += "\"
+}
+$vhd_path_formatted = $defaultVhdPath.Replace(':','$')
+$final_vhd_path="\\${remoteHost}\${vhd_path_formatted}SRIOV_ChildRemote"
+
+# Stop main VM to get the parent VHD
+# Shutdown gracefully so we dont corrupt VHD.
+Stop-VM -Name $vmName -ComputerName $hvServer
+if (-not $?) {
+    Write-Output "Error: Unable to Shut Down VM" | Tee-Object -Append -file $summaryLog
+    return $False
+}
+
+Start-Sleep -s 10
+# Get Parent VHD
+$ParentVHD = GetParentVHD $vmName $hvServer
+if(-not $ParentVHD) {
+    Write-Output "Error getting Parent VHD of VM $vmName" | Tee-Object -Append -file $summaryLog
+    return $False
+}
+
+# Get information about the main VM
+$vm = Get-VM -Name $vmName -ComputerName $hvServer
+# Get VM Generation
+$vm_gen = $vm.Generation
+
+$VMNetAdapter = Get-VMNetworkAdapter $vmName -ComputerName $hvServer
+if (-not $?) {
+    Write-Output "Error: Get-VMNetworkAdapter for $vmName failed" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+# Create Child vhd
+$ChildVHD = CreateChildVHD $ParentVHD $final_vhd_path
+
+# Check if SR-IOV Switch is present on remote host
+Get-VMSwitch $networkName -ComputerName $remoteHost
+if (-not $?) {
+    Write-Output "Error: The vSwitch named $networkName is not present on $remoteHost" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+# Create the new VM
+$newVm = New-VM -Name "SRIOV_Child_Remote" -ComputerName $remoteHost -VHDPath "${defaultVhdPath}\SRIOV_ChildRemote.vhdx" -MemoryStartupBytes 4096MB -SwitchName "External" -Generation $vm_gen
+
+if (-not $?) {
+    Write-Output "Error: Creating New VM SRIOV_Child_Remote on $remoteHost" | Tee-Object -Append -file $summaryLog
+    return $False
+} 
+
+# Disable secure boot if Gen2
+if ($vm_gen -eq 2) {
+    Set-VMFirmware -VMName "SRIOV_Child_Remote" -ComputerName $remoteHost -EnableSecureBoot Off
+    if(-not $?) {
+        Write-Output "Error: Unable to disable secure boot" | Tee-Object -Append -file $summaryLog
+        Cleanup "SRIOV_Child_Remote"
+        return $false
+    }
+}
+
+ConfigureVMandBond "SRIOV_Child_Remote" $remoteHost $sshKey $vmBondIP1 $netmask
+Write-Output "Child VM Configured and started" | Tee-Object -Append -file $summaryLog
+
+$ipv4_child = GetIPv4 "SRIOV_Child_Remote" $remoteHost 
+Write-Output "SRIOV_Child_Remote IP Address: $ipv4_child"
+Start-Sleep -s 5
+
+# Run ping from child VM to dependency
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4_child} "echo ' ping -c 20 -I bond0 $vmBondIP2 > PingResults.log &' > runPing.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4_child} "bash ~/runPing.sh > ~/Ping.log 2>&1"
+Start-Sleep -s 5
+[decimal]$vfEnabledRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4_child} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+
+if (-not $vfEnabledRTT){
+    Write-Output "ERROR: No result was logged on the Child VM!" | Tee-Object -Append -file $summaryLog
+    Cleanup "SRIOV_Child_Remote"
+    return $false   
+}
+
+if ($vfEnabledRTT -le 0.11) {
+    Write-Output "VF is up & running, RTT is $vfEnabledRTT ms" | Tee-Object -Append -file $summaryLog
+    Cleanup "SRIOV_Child_Remote"
+    return $True    
+} 
+else {
+    Write-Output "ERROR: RTT value is too high, $vfEnabledRTT ms!" | Tee-Object -Append -file $summaryLog
+    Cleanup "SRIOV_Child_Remote"
+    return $false
+}

--- a/WS2012R2/lisa/setupscripts/SR-IOV_UpgradeKernel.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_UpgradeKernel.ps1
@@ -1,0 +1,253 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Guest kernel update, SR-IOV should work without any interrupts
+
+.Description
+    Description:
+    Perform a Linux kernel update. After the kernel update, SR-IOV should continue to work correctly.
+    Steps:
+        1. Configure SR-IOV on a Linux VM and confirm SR-IOV is working.
+        2. Upgrade the Linux kernel.
+        3. Reboot the VM
+        3. Test SR-IOV functionality.
+
+    Acceptance Criteria:
+        After the upgrade, the SR-IOV device works correctly.
+ 
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Upgrade_Linux_Kernel</testName>
+        <testScript>setupscripts\SR-IOV_UpgradeKernel.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/SR-IOV_UpgradeKernel.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
+            <param>TC_COVERED=SRIOV-7</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHost</param>
+        </testParams>
+        <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
+        <timeout>2400</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get VM2 ipv4
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+$kernelVersionOld = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "uname -r"
+"Kernel version before upgrade: $kernelVersionOld" | Tee-Object -Append -file $summaryLog
+
+#
+# Test ping before upgrading the kernel
+#
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && ping -c 30 -I bond0 `$BOND_IP2 > PingResults.log &' > runPing.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runPing.sh > ~/Ping.log 2>&1"
+Start-Sleep -s 10
+
+[decimal]$beforeUpgradeRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $beforeUpgradeRTT){
+    "ERROR: No result was logged before installing the kernel!" | Tee-Object -Append -file $summaryLog
+    .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "ifconfig"
+    return $false
+}
+
+"The RTT before upgrading the kernel is $beforeUpgradeRTT ms" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+#
+# Upgrade the kernel and reboot the VM after
+#
+$sts = RunRemoteScript "SR-IOV_UpgradeKernel.sh"
+if (-not $sts[-1])
+{
+    "ERROR executing SR-IOV_UpgradeKernel.sh on VM. Exiting test case!" | Tee-Object -Append -file $summaryLog
+    "ERROR: Running SR-IOV_UpgradeKernel.sh script failed on VM!"
+    return $False
+}
+"Kernel was installed"
+
+# Reboot VM
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "reboot"
+
+Start-Sleep -s 30
+$timeout = 200 # seconds
+if (-not (WaitForVMToStartKVP $vmName $hvServer $timeout))
+{
+    "ERROR: $vmName never started KVP after reboot" | Tee-Object -Append -file $summaryLog
+    return $False
+}
+
+# Check if the kernel was indeed upgraded
+$kernelVersionNew = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "uname -r"
+"Kernel version after upgrade: $kernelVersionNew" | Tee-Object -Append -file $summaryLog
+
+if ($kernelVersionOld -eq $kernelVersionNew) {
+    "ERROR: Kernel wasn't upgraded" | Tee-Object -Append -file $summaryLog
+    return $False    
+}
+
+#
+# Test ping after upgrading the kernel
+#
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && ping -c 30 -I bond0 `$BOND_IP2 > PingResults.log &' > runPing.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runPing.sh > ~/Ping.log 2>&1"
+Start-Sleep -s 10
+
+[decimal]$afterUpgradeRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $afterUpgradeRTT){
+    "ERROR: No result was logged! Check if Ping was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The RTT after upgrading the kernel is $afterUpgradeRTT ms" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_UpgradePF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_UpgradePF.ps1
@@ -1,0 +1,294 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    NOTE: This is a Mellanox specific TC
+    Host PF driver update/downgrade, SR-IOV in guest should work without any interrupts
+
+.Description
+    Perform a Physical Function (PF) driver upgrade and down grade.  
+    Upgrading or downgrading the driver should not affect SR-IOV functionality.
+    Steps:
+        Configure SR-IOV on a Linux VM and confirm SR-IOV is working.
+        Upgrade the PF driver.
+        Test SR-IOV functionality.
+        Downgrade the PF driver.
+        Test SR-IOV functionality.
+
+    Acceptance Criteria:
+        SR-IOV continues to work correctly after upgrading the PF driver.
+        SR-IOV continues to work correctly after downgrading the PF driver.
+    
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>Upgrade_Downgrade_PF</testName>
+        <testScript>setupscripts\SR-IOV_UpgradePF.ps1</testScript>
+        <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript> 
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+            <param>TC_COVERED=SRIOV-18</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_SERVER=remoteHost</param>
+            <param>OLDER_DRIVER_FOLDER_PATH=\\network\path\to\old\drivers</param>
+            <param>NEWER_DRIVER_FOLDER_PATH=\\network\path\to\new\drivers</param>
+        </testParams>
+        <timeout>1800</timeout>
+    </test>
+#>
+
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+$leaveTrail = "no"
+
+#
+# Check the required input args are present
+#
+
+# Write out test Params
+$testParams
+
+
+if ($hvServer -eq $null)
+{
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null)
+{
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?)
+{
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir)
+{
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else
+{
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1")
+{
+    . .\setupScripts\NET_UTILS.ps1
+}
+else
+{
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+# Process the test params
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+    switch ($fields[0].Trim())
+    {
+        "SshKey" { $sshKey = $fields[1].Trim() }
+        "ipv4" { $ipv4 = $fields[1].Trim() }   
+        "BOND_IP1" { $vmBondIP1 = $fields[1].Trim() }
+        "BOND_IP2" { $vmBondIP2 = $fields[1].Trim() }
+        "NETMASK" { $netmask = $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
+        "REMOTE_SERVER" { $remoteServer = $fields[1].Trim()}
+        "OLDER_DRIVER_FOLDER_PATH" { $olderDriverPath = $fields[1].Trim()}
+        "NEWER_DRIVER_FOLDER_PATH" { $newerDriverPath = $fields[1].Trim()}
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    }
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Get default Hyper-V VHD path; The drivers will be copied here
+$hostInfo = Get-VMHost -ComputerName $hvServer
+$defaultVhdPath = $hostInfo.VirtualHardDiskPath
+if (-not $defaultVhdPath.EndsWith("\")) {
+    $defaultVhdPath += "\"
+}
+
+# Copy the drivers to local vhd path
+Copy-Item -Path $olderDriverPath -Destination $defaultVhdPath -Force -Recurse
+Start-Sleep -s 5
+Copy-Item -Path $newerDriverPath -Destination $defaultVhdPath -Force -Recurse
+
+# Get file names from each folder
+$newerDriverPath =  Get-ChildItem $defaultVhdPath -Directory -Recurse | Sort-Object LastAccessTime -Descending | Select-Object -First 1
+$olderDriverPath =  Get-ChildItem $defaultVhdPath -Directory -Recurse | Select-Object -First 1
+
+$olderFirmware = Get-ChildItem $olderDriverPath.FullName | Where-Object {$_.Name -like '*mlxfw*'}
+$olderDriver = Get-ChildItem $olderDriverPath.FullName | Where-Object {$_.Name -like '*Azure_Compute_*'}
+
+$newerFirmware = Get-ChildItem $newerDriverPath.FullName | Where-Object {$_.Name -like '*mlxfw*'}
+$newerDriver = Get-ChildItem $newerDriverPath.FullName | Where-Object {$_.Name -like '*Azure_Compute_*'}
+
+# Unblock files
+Unblock-File -Path $olderFirmware.FullName
+Unblock-File -Path $olderDriver.FullName
+Unblock-File -Path $newerFirmware.FullName
+Unblock-File -Path $newerDriver.FullName
+
+#
+# Configure the bond on test VM
+#
+$retVal = ConfigureBond $ipv4 $sshKey $netmask
+if (-not $retVal)
+{
+    "ERROR: Failed to configure bond on vm $vmName (IP: ${ipv4}), by setting a static IP of $vmBondIP1 , netmask $netmask"
+    return $false
+}
+
+#
+# Run Ping
+#
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "echo 'source constants.sh && ping -c 1200 -I bond0 `$BOND_IP2 > PingResults.log &' > runPing.sh"
+Start-Sleep -s 5
+.\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runPing.sh > ~/Ping.log 2>&1"
+
+# Wait 60 seconds and read the RTT
+"Get Logs"
+Start-Sleep -s 60
+[decimal]$pfInitialRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $pfInitialRTT){
+    "ERROR: No result was logged! Check if Ping was executed!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The RTT before starting upgrading and downgrading: $pfInitialRTT ms" | Tee-Object -Append -file $summaryLog
+Start-Sleep -s 10
+
+#
+# Upgrade the firmware & driver
+#
+# Install the newest driver & firmware
+Start-Process -FilePath $newerDriver.FullName -ArgumentList "/R /S /v/qn" -Wait
+Start-Sleep -s 150
+Start-Process -FilePath $newerFirmware.FullName -ArgumentList "-f -y --sfx-no-pause" -Wait
+
+# Restart VF
+Start-Sleep -s 20
+RestartVF $ipv4 $sshKey
+
+# Read the RTT after upgrading
+Start-Sleep -s 20
+[decimal]$pfUpgradedRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $pfUpgradedRTT){
+    "ERROR: No result was logged after SR-IOV was disabled!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The RTT after upgrading the driver & firmware: $pfUpgradedRTT ms" | Tee-Object -Append -file $summaryLog
+
+#
+# Downgrade the firmware; driver can't be downgraded
+#
+# Install older firmware
+Start-Process -FilePath $olderFirmware.FullName -ArgumentList "-f -y --sfx-no-pause" -Wait
+
+# Read the RTT after upgrading
+Start-Sleep -s 20
+[decimal]$pfDowngradedRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $pfDowngradedRTT){
+    "ERROR: No result was logged after firwmare was downgraded!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+"The RTT after downgrading the firmware: $pfDowngradedRTT ms" | Tee-Object -Append -file $summaryLog
+
+#
+# Upgrade the firmware again
+#
+# Install older firmware
+Start-Process -FilePath $newerFirmware.FullName -ArgumentList "-f -y --sfx-no-pause" -Wait
+
+# Read the RTT after upgrading
+Start-Sleep -s 20
+[decimal]$pfFinalRTT = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PingResults.log | head -1 | awk '{print `$7}' | sed 's/=/ /' | awk '{print `$2}'"
+if (-not $pfFinalRTT){
+    "ERROR: No result was logged after the firmware was upgraded again!" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+"The RTT after upgrading the firmware: $pfFinalRTT ms" | Tee-Object -Append -file $summaryLog
+
+# Last, check if the RTT values are worse in the end
+[decimal]$pfInitialRTT = $pfInitialRTT + 0.08
+if ($pfFinalRTT -gt $pfInitialRTT ) {
+    "ERROR: After upgrading & downgrading, the RTT value is too high
+    Please check if the VF was successfully restarted" | Tee-Object -Append -file $summaryLog
+    return $false 
+}
+
+return $true

--- a/WS2012R2/lisa/xml/SR-IOV.xml
+++ b/WS2012R2/lisa/xml/SR-IOV.xml
@@ -51,6 +51,11 @@
                 <suiteTest>Change_RSS</suiteTest>
                 <suiteTest>CompareRTT</suiteTest>
                 <suiteTest>Compare_iPerf</suiteTest>
+                <suiteTest>Upgrade_Linux_kernel</suiteTest>
+                <suiteTest>Measure_DisableVF</suiteTest>
+                <suiteTest>Move_VHD</suiteTest>
+                <!-- Mellanox specific -->
+                <suiteTest>Upgrade_Downgrade_PF</suiteTest>
                 
                 <!-- Multiple NIC Bonding tests -->
                 <suiteTest>Multiple_basic</suiteTest>
@@ -94,7 +99,6 @@
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1000</timeout>
@@ -115,7 +119,6 @@
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1000</timeout>
@@ -136,7 +139,6 @@
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1000</timeout>
@@ -157,7 +159,6 @@
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1000</timeout>
@@ -241,7 +242,6 @@
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <param>REMOTE_SERVER=remoteHostName</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
@@ -308,7 +308,6 @@
                 <param>STATIC_IP1=192.168.0.10</param>
                 <param>STATIC_IP2=192.168.0.20</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1800</timeout>
@@ -335,6 +334,90 @@
             <timeout>1800</timeout>
         </test>
 
+        <test>
+            <testName>Upgrade_Linux_Kernel</testName>
+            <testScript>setupscripts\SR-IOV_UpgradeKernel.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/SR-IOV_UpgradeKernel.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
+                <param>TC_COVERED=SRIOV-15</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=lis-f2323</param>
+            </testParams>
+            <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
+            <timeout>2400</timeout>
+        </test>
+
+        <test>
+            <testName>Measure_DisableVF</testName>
+            <testScript>setupscripts\SR-IOV_MeasureDisableVF.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
+                <param>TC_COVERED=SRIOV-16</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHost</param>
+            </testParams>
+            <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
+            <timeout>2400</timeout>
+        </test>
+
+        <test>
+            <testName>Move_VHD</testName>
+            <testScript>setupscripts\SR-IOV_MoveVHD.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
+                <param>TC_COVERED=SRIOV-17</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHost</param>
+            </testParams>
+            <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
+            <timeout>2400</timeout>
+        </test>
+
+        <test>
+            <testName>Upgrade_Downgrade_PF</testName>
+            <testScript>setupscripts\SR-IOV_UpgradePF.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
+                <param>TC_COVERED=SRIOV-18</param>
+                <param>BOND_IP1=10.11.12.31</param>
+                <param>BOND_IP2=10.11.12.32</param>
+                <param>NETMASK=255.255.255.0</param>
+                <param>REMOTE_SERVER=remoteHost</param>
+                <param>OLDER_DRIVER_FOLDER_PATH=\\network\path\to\old\drivers</param>
+                <param>NEWER_DRIVER_FOLDER_PATH=\\network\path\to\new\drivers</param>
+            </testParams>
+            <timeout>1800</timeout>
+        </test>
 
         <test>
             <testName>Multiple_basic</testName>
@@ -348,13 +431,12 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112801</param>
-                <param>TC_COVERED=SRIOV-15</param>
+                <param>TC_COVERED=SRIOV-19</param>
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
                 <param>BOND_IP4=10.12.12.34</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1000</timeout>
@@ -372,13 +454,12 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112801</param>
-                <param>TC_COVERED=SRIOV-16</param>
+                <param>TC_COVERED=SRIOV-20</param>
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
                 <param>BOND_IP4=10.12.12.34</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
             <timeout>1000</timeout>
@@ -394,9 +475,8 @@
             </setupScript> 
             <noReboot>False</noReboot>
             <testParams>
-                <param>TC_COVERED=SRIOV-17</param>
+                <param>TC_COVERED=SRIOV-21</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <param>MAX_NICS=yes</param>
             </testParams>
             <cleanupScript>setupscripts\SR-IOV_ShutDown_Dependency.ps1</cleanupScript>
@@ -414,11 +494,10 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
-                <param>TC_COVERED=SRIOV-18</param>                                   
+                <param>TC_COVERED=SRIOV-22</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <!-- VM_STATE has to be 'pause' or 'save' -->
                 <param>VM_STATE=pause</param>
             </testParams>
@@ -438,13 +517,12 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112801</param>
-                <param>TC_COVERED=SRIOV-19</param>                                   
+                <param>TC_COVERED=SRIOV-23</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
             	<param>BOND_IP3=10.12.12.33</param>
                 <param>BOND_IP4=10.12.12.34</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <!-- VM_STATE has to be 'pause' or 'save' -->
                 <param>VM_STATE=pause</param>
             </testParams>
@@ -463,11 +541,10 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
-                <param>TC_COVERED=SRIOV-20</param>                                   
+                <param>TC_COVERED=SRIOV-24</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <!-- VM_STATE has to be 'pause' or 'save' -->
                 <param>VM_STATE=save</param>
             </testParams>
@@ -487,13 +564,12 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112801</param>
-                <param>TC_COVERED=SRIOV-21</param>                                   
+                <param>TC_COVERED=SRIOV-25</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
                 <param>BOND_IP4=10.12.12.34</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <!-- VM_STATE has to be 'pause' or 'save' -->
                 <param>VM_STATE=save</param>
             </testParams>
@@ -510,8 +586,7 @@
             </setupScript> 
             <noReboot>False</noReboot>
             <testParams>
-                <param>TC_COVERED=SRIOV-22</param>
-                <param>REMOTE_USER=root</param>
+                <param>TC_COVERED=SRIOV-26</param>
                 <param>VM_NUMBER=4</param>
             </testParams>
             <timeout>10800</timeout>
@@ -528,7 +603,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
-                <param>TC_COVERED=SRIOV-23</param>
+                <param>TC_COVERED=SRIOV-27</param>
                 <param>BOND_IP1=10.11.12.61</param>
                 <param>BOND_IP2=10.11.12.62</param>
                 <param>VM3BOND_IP=10.11.12.63</param>
@@ -553,7 +628,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
-                <param>TC_COVERED=SRIOV-24</param>
+                <param>TC_COVERED=SRIOV-28</param>
                 <param>BOND_IP1=10.11.12.61</param>
                 <param>BOND_IP2=10.11.12.62</param>
                 <param>VM3BOND_IP=10.11.12.63</param>
@@ -578,11 +653,10 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
-                <param>TC_COVERED=SRIOV-25</param>                                   
+                <param>TC_COVERED=SRIOV-29</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <param>ReplicationServer=ReplicaServer</param>
                 <param>ReplicationPort=8080</param>
                 <param>enableVF=yes</param>
@@ -605,12 +679,11 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112801</param>
-                <param>TC_COVERED=SRIOV-26</param>
+                <param>TC_COVERED=SRIOV-30</param>
                 <param>leaveTrail=no</param>                                 
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <param>ReplicationServer=ReplicaServer</param>
                 <param>ReplicationPort=80</param>
                 <param>enableVF=no</param>
@@ -632,13 +705,12 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
-                <param>TC_COVERED=SRIOV-27</param>                                   
+                <param>TC_COVERED=SRIOV-31</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
                 <param>BOND_IP4=10.12.12.34</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <param>ReplicationServer=ReplicaServer</param>
                 <param>ReplicationPort=80</param>
                 <param>enableVF=yes</param>
@@ -661,13 +733,12 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112800</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112801</param>
-                <param>TC_COVERED=SRIOV-28</param>                                   
+                <param>TC_COVERED=SRIOV-32</param>                                   
                 <param>BOND_IP1=10.11.12.31</param>
                 <param>BOND_IP2=10.11.12.32</param>
                 <param>BOND_IP3=10.12.12.33</param>
                 <param>BOND_IP4=10.12.12.34</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>REMOTE_USER=root</param>
                 <param>ReplicationServer=ReplicaServer</param>
                 <param>ReplicationPort=80</param>
                 <param>enableVF=no</param>
@@ -681,7 +752,7 @@
 
     <VMs>
         <vm>
-            <hvServer>lis-f2322</hvServer>
+            <hvServer>localhost</hvServer>
             <vmName>vm1</vmName>
             <os>Linux</os>
             <ipv4></ipv4>
@@ -690,6 +761,7 @@
                 <param>VM2NAME=vm2</param>
                 <param>SnapshotName=ICABase</param>
                 <param>sshKey=id_rsa</param>
+                <param>REMOTE_USER=root</param>
             </testParams>
             <suite>SR-IOV</suite>
         </vm>

--- a/WS2012R2/lisa/xml/SR-IOV_LM.xml
+++ b/WS2012R2/lisa/xml/SR-IOV_LM.xml
@@ -91,7 +91,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-29</param>                                   
+                <param>TC_COVERED=SRIOV-33</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -111,7 +111,7 @@
             <noReboot>False</noReboot>
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
-                <param>TC_COVERED=SRIOV-30</param>                                   
+                <param>TC_COVERED=SRIOV-34</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>NETMASK=255.255.255.0</param>
@@ -133,7 +133,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-31</param>                                   
+                <param>TC_COVERED=SRIOV-35</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>BOND_IP3=10.11.12.53</param>
@@ -156,7 +156,7 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112200</param>
                 <param>NIC=NetworkAdapter,External,SRIOV,001600112201</param>
-                <param>TC_COVERED=SRIOV-32</param>                                   
+                <param>TC_COVERED=SRIOV-36</param>                                   
                 <param>BOND_IP1=10.11.12.51</param>
                 <param>BOND_IP2=10.11.12.52</param>
                 <param>BOND_IP3=10.11.12.53</param>


### PR DESCRIPTION
1. Added 4 TCs:
- Host PF driver update/downgrade, SR-IOV in guest should work without
any interrupts
- Guest kernel update, SR-IOV should work without any interrupts
- Switch network between SR-IOV and netvsc synthetic data path back and
forth, the switch should happen immediately
- Switch network between SR-IOV and netvsc synthetic data path back and
forth, the switch should happen immediately
- Move the VHD to another host, and build a new VM based on this VHD.
The SR-IOV should work.

2. Make A change to existing TC - iPerfReboot to check the ifconfig
bytes/packets stats (should zeroed out those counters)

3. Changed Save/Pause TC to check if RTT values are lower (consistent
with VF in use)

4. Changed SR-IOV TC numbers to accommodate the new TCs