### PR TITLE
Added minimum Hyper-V host version for features

### DIFF
--- a/WS2012R2/lisa/xml/FCOPY_Tests.xml
+++ b/WS2012R2/lisa/xml/FCOPY_Tests.xml
@@ -21,7 +21,7 @@
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
         <dependency>
-            <!-- Only Windows Server 2012 R2 supports this suite -->
+            <!-- Only Windows Server 2012 R2 and newer supports this feature -->
             <hostVersion>6.3.9600</hostVersion>
         </dependency>
         <email>

--- a/WS2012R2/lisa/xml/NMI_Tests.xml
+++ b/WS2012R2/lisa/xml/NMI_Tests.xml
@@ -24,6 +24,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2012 R2 and newer supports this feature -->
+            <hostVersion>6.3.9600</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myboss@mycompany.com</to>

--- a/WS2012R2/lisa/xml/Production_Checkpoint.xml
+++ b/WS2012R2/lisa/xml/Production_Checkpoint.xml
@@ -26,6 +26,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2016 supports this feature -->
+            <hostVersion>10.0.14393</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myself@mycompany.com</to>

--- a/WS2012R2/lisa/xml/Runtime_Memory_Resize_Tests.xml
+++ b/WS2012R2/lisa/xml/Runtime_Memory_Resize_Tests.xml
@@ -24,6 +24,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2016 supports this feature -->
+            <hostVersion>10.0.14393</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myboss@mycompany.com</to>

--- a/WS2012R2/lisa/xml/SR-IOV.xml
+++ b/WS2012R2/lisa/xml/SR-IOV.xml
@@ -23,6 +23,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2016 supports this feature -->
+            <hostVersion>10.0.14393</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myboss@mycompany.com</to>

--- a/WS2012R2/lisa/xml/STOR_VHDX.xml
+++ b/WS2012R2/lisa/xml/STOR_VHDX.xml
@@ -4,6 +4,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2012 and newer supports this feature -->
+            <hostVersion>6.2.9200</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myself@mycompany.com</to>

--- a/WS2012R2/lisa/xml/STOR_VHDXResize.xml
+++ b/WS2012R2/lisa/xml/STOR_VHDXResize.xml
@@ -23,6 +23,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2012 R2 and newer supports this feature -->
+            <hostVersion>6.3.9600</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myself@mail.com</to>

--- a/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
+++ b/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
@@ -26,6 +26,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
+        <dependency>
+            <!-- Only Windows Server 2012 R2 and newer supports this feature -->
+            <hostVersion>6.3.9600</hostVersion>
+        </dependency>
         <email>
             <recipients>
                 <to>myself@mycompany.com</to>


### PR DESCRIPTION
We can tag feature's test areas to define the minimum host side build ID from which the feature is supported.
We use build ID's to make them SKU names independent.