### PR TITLE
SR-IOV: Various fixes and tweaks in automation

### DIFF
--- a/WS2012R2/lisa/setupscripts/SR-IOV_ChangeRSS.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_ChangeRSS.ps1
@@ -163,7 +163,9 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
-# Get VM2 ipv4
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
 $vm2ipv4 = GetIPv4 $vm2Name $remoteServer
 "${vm2Name} IPADDRESS: ${vm2ipv4}"
 
@@ -239,7 +241,7 @@ if (-not $status) {
 
 # Read the throughput with RSS profile changed
 Start-Sleep -s 60
-[decimal]$vfBeforeThroughput = $vfBeforeThroughput / 2
+[decimal]$vfBeforeThroughput = $vfBeforeThroughput * 0.7
 [decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
 
 "The throughput after changing RSS profile is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog

--- a/WS2012R2/lisa/setupscripts/SR-IOV_DisableVMQ.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_DisableVMQ.ps1
@@ -164,7 +164,9 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
-# Get VM2 ipv4
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
 $vm2ipv4 = GetIPv4 $vm2Name $remoteServer
 "${vm2Name} IPADDRESS: ${vm2ipv4}"
 
@@ -241,7 +243,7 @@ if (-not $status) {
 
 # Read the throughput with VMQ disabled
 Start-Sleep -s 60
-[decimal]$vfBeforeThroughput = $vfBeforeThroughput / 2
+[decimal]$vfBeforeThroughput = $vfBeforeThroughput * 0.7
 [decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
 
 "The throughput after disabling VMQ is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog

--- a/WS2012R2/lisa/setupscripts/SR-IOV_MeasureDisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_MeasureDisableVF.ps1
@@ -160,7 +160,9 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
-# Get VM2 ipv4
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
 $vm2ipv4 = GetIPv4 $vm2Name $remoteServer
 "${vm2Name} IPADDRESS: ${vm2ipv4}"
 
@@ -191,7 +193,7 @@ if (-not $initialRTT){
 "The RTT before disabling VF is $initialRTT ms" | Tee-Object -Append -file $summaryLog
 
 # We add 0.4 ms to the initial RTT to future determine if the data is transmitted through VF or netvsc
-[decimal]$initialRTT = $initialRTT + 0.05
+[decimal]$initialRTT = $initialRTT + 0.03
 #
 # Disable SR-IOV on test VM
 #
@@ -273,7 +275,7 @@ while ($hasSwitched -eq $false){
 
 [int]$timetoSwitch = $enabled_icmpSeq - $initial_icmpSeq_2 
 if ($timetoSwitch -gt 10) {
-    "ERROR: After disabling VF, $timetoSwitch seconds passed until Ping worked again. Time is too big" | Tee-Object -Append -file $summaryLog
+    "ERROR: After enabling VF, $timetoSwitch seconds passed until Ping worked again. Time is too big" | Tee-Object -Append -file $summaryLog
     return $false
 }
 

--- a/WS2012R2/lisa/setupscripts/SR-IOV_Ping_DisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_Ping_DisableVF.ps1
@@ -159,6 +159,10 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
+
 #
 # Configure the bond on test VM
 #
@@ -237,11 +241,6 @@ if (-not $?) {
     "ERROR: Failed to enable SR-IOV on $vm2Name!" | Tee-Object -Append -file $summaryLog
     return $false 
 }
-
-# Restart VF on both VMs
-Start-Sleep -s 20
-RestartVF $ipv4 $sshKey
-RestartVF $vm2ipv4 $sshKey
 Start-Sleep -s 80
 
 # Read the RTT again, it should be lower than before

--- a/WS2012R2/lisa/setupscripts/SR-IOV_SavePauseVM.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_SavePauseVM.ps1
@@ -163,6 +163,9 @@ foreach ($p in $params)
 $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
 
 #
 # Configure the bond on test VM

--- a/WS2012R2/lisa/setupscripts/SR-IOV_UpgradeKernel.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_UpgradeKernel.ps1
@@ -167,7 +167,9 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
-# Get VM2 ipv4
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
 $vm2ipv4 = GetIPv4 $vm2Name $remoteServer
 "${vm2Name} IPADDRESS: ${vm2ipv4}"
 

--- a/WS2012R2/lisa/setupscripts/SR-IOV_UpgradePF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_UpgradePF.ps1
@@ -173,6 +173,10 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
+
 # Get default Hyper-V VHD path; The drivers will be copied here
 $hostInfo = Get-VMHost -ComputerName $hvServer
 $defaultVhdPath = $hostInfo.VirtualHardDiskPath
@@ -284,7 +288,7 @@ if (-not $pfFinalRTT){
 "The RTT after upgrading the firmware: $pfFinalRTT ms" | Tee-Object -Append -file $summaryLog
 
 # Last, check if the RTT values are worse in the end
-[decimal]$pfInitialRTT = $pfInitialRTT + 0.08
+[decimal]$pfInitialRTT = $pfInitialRTT + 0.05
 if ($pfFinalRTT -gt $pfInitialRTT ) {
     "ERROR: After upgrading & downgrading, the RTT value is too high
     Please check if the VF was successfully restarted" | Tee-Object -Append -file $summaryLog

--- a/WS2012R2/lisa/setupscripts/SR-IOV_iPerf.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_iPerf.ps1
@@ -167,6 +167,12 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
+# Get IPs
+$ipv4 = GetIPv4 $vmName $hvServer
+"${vmName} IPADDRESS: ${ipv4}"
+$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
+"${vm2Name} IPADDRESS: ${vm2ipv4}"
+
 #
 # Configure the bond on test VM
 #
@@ -187,10 +193,6 @@ if (-not $retVal)
     "ERROR: Failed to install iPerf3 on vm $vmName (IP: ${ipv4})"
     return $false
 }
-
-# Get ipv4 from VM2
-$vm2ipv4 = GetIPv4 $vm2Name $remoteServer
-"$vm2Name IPADDRESS: $vm2ipv4"
 
 $retVal = iPerfInstall $vm2ipv4 $sshKey $netmask
 if (-not $retVal)

--- a/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_Reboot.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_Reboot.ps1
@@ -271,9 +271,10 @@ Start-Sleep -s 5
 .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "bash ~/runIperf.sh > ~/iPerf.log 2>&1"
 
 # Read the throughput again, it should be higher than before
-# We should see a significant imporvement, we'll check for at least 1gpbs improvement
+# We should see a a similar throughput as before. If the throughput after reboot
+# is lower than 80% of the first recorded throughput, the test is considered failed
 Start-Sleep -s 30
-[decimal]$vfBeforeThroughput = $vfBeforeThroughput - 1
+[decimal]$vfBeforeThroughput = $vfBeforeThroughput * 0.8
 [decimal]$vfFinalThroughput = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "tail -2 PerfResults.log | head -1 | awk '{print `$7}'"
 
 "The throughput after rebooting the VM is $vfFinalThroughput Gbits/sec" | Tee-Object -Append -file $summaryLog


### PR DESCRIPTION
1. Get the test VMs ipv4 again during testing, to make sure that the
bash scripts are sent to the correct VM

2. Tweak the accepted variations in RTT or throughput for more
precise results

3. Removed RestartVF function. The VF should automatically restart,
so there is no need for a forced restart