### PR TITLE
Add save xml report and time duration for test case by migrating comm…

### DIFF
--- a/WS2012R2/lisa/OSAbstractions.ps1
+++ b/WS2012R2/lisa/OSAbstractions.ps1
@@ -3,11 +3,11 @@
 # Linux on Hyper-V and Azure Test Code, ver. 1.0.0
 # Copyright (c) Microsoft Corporation
 #
-# All rights reserved. 
+# All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the ""License"");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0  
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
 # OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
@@ -27,7 +27,7 @@
 .Description
     This file contains functions that are intended to hide
     differences in the OS platforms.  The hope is to hide
-    differences in Linux distros and FreeBSD when the 
+    differences in Linux distros and FreeBSD when the
     Integrated Services are released.
 
     Currently supported OS platforms:
@@ -65,7 +65,7 @@ function GetOSDateTimeCmd ([System.Xml.XmlElement] $vm)
         Return a OS specific date/time command
         Linux:   "date mmddhhMMyyyy"
         FreeBSD: "date -n ccyymmddhhMM"
-	#> 
+	#>
 
     $dateTimeCmd = $null
 
@@ -117,13 +117,13 @@ function GetOSDos2unixCmd ([System.Xml.XmlElement] $vm, [String] $filename)
         Return a OS specific dos2unix command string
         Linux:   dos2unix -q filename
         FreeBSD: dos2unix filename
-	#> 
+	#>
 
     if (-not $vm)
     {
         return $null
     }
-    
+
     if (-not $filename)
     {
         return $null
@@ -138,7 +138,7 @@ function GetOSDos2unixCmd ([System.Xml.XmlElement] $vm, [String] $filename)
         # We use the -q with Linux
         #
         $LinuxOS    { $cmdString = "dos2unix -q ${filename}" }
-        
+
         #
         # No options with FreeBSD
         #
@@ -172,13 +172,13 @@ function StartOSAtDaemon ([System.Xml.XmlElement] $vm)
     .Description
         Start the daemon that handles batch jobs for the OS running on
         the VM.  Linux has the atd daemon.  FreeBSD uses crond.
-	#> 
+	#>
 
     if (-not $vm)
     {
         return $False
     }
-    
+
     $daemonStarted = $False
 
     if ($vm.os)
@@ -232,8 +232,8 @@ function GetOSType ([System.Xml.XmlElement] $vm)
     .Description
         Use SSH to send a uname command to the VM.  Use the
         returned name as OSType.
-	#> 
-    
+	#>
+
     # plink will pending at waiting password if sshkey failed auth, so
     # pipe a 'y' to response
     $os = echo y | bin\plink -i ssh\${sshKey} root@${hostname} "uname -s"
@@ -244,8 +244,57 @@ function GetOSType ([System.Xml.XmlElement] $vm)
         $FreeBSDOS {}
         default    { $os = "unknown" }
     }
-    
+
     return $os
+}
+
+#####################################################################
+#
+# GetKernelVersion()
+#
+#####################################################################
+function GetKernelVersion ()
+{
+	<#
+	.Synopsis
+        Ask the OS to provide Kernel version.
+    .Description
+        Use SSH to send a uname command to the VM.  Use the
+        returned name as Kernel version.
+	#>
+
+    # plink will pending at waiting password if sshkey failed auth, so
+    # pipe a 'y' to response
+    $ver = echo y | bin\plink -i ssh\${sshKey} root@${hostname} "uname -r"
+
+    return $ver
+}
+
+#####################################################################
+#
+# GetFirmwareVersion()
+#
+#####################################################################
+function GetFirmwareVersion ()
+{
+	<#
+	.Synopsis
+        Ask the OS to provide firmware version.
+    .Description
+        Use SSH to send a uname command to the VM.  The firmware is
+        based on shell command result.
+	#>
+
+    # plink will pending at waiting password if sshkey failed auth, so
+    # pipe a 'y' to response
+    $cmdResult = echo y | bin\plink -i ssh\${sshKey} root@${hostname} "[ -d /sys/firmware/efi ] && echo 0"
+
+    $firmware = "BIOS"
+    if ($cmdResult -eq "0")
+    {
+        $firmware = "EFI"
+    }
+    return $firmware
 }
 
 
@@ -262,10 +311,10 @@ function GetOSRunTestCaseCmd ([String] $os, [String] $testFilename, [String] $lo
     .Description
         Create a command string that will run the test case and
         also redirect STDOUT and STDERR to the logfile.
-	#> 
+	#>
 
     $runCmd = $null
-    
+
     switch ($os)
     {
         $LinuxOS
@@ -280,7 +329,7 @@ function GetOSRunTestCaseCmd ([String] $os, [String] $testFilename, [String] $lo
 
         default
             {
-        
+
                 $runCmd = $null
             }
     }

--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -238,6 +238,11 @@ New-Variable TestFailed          -value "TestFailed"          -option ReadOnly
 New-Variable LinuxOS             -value "Linux"               -option ReadOnly
 New-Variable FreeBSDOS           -value "FreeBSD"             -option ReadOnly
 
+#
+# Generate JUnit formated XML object to store case results.
+#
+$testResult = GetJUnitXML
+
 ########################################################################
 #
 # RunICTests()
@@ -320,7 +325,7 @@ function RunICTests([XML] $xmlConfig, [string] $collect)
         #
         # Add the state related xml elements to each VM xml node
         #
-        $xmlElementsToAdd = @("currentTest", "stateTimeStamp", "state", "emailSummary", "jobID", "testCaseResults", "iteration")
+        $xmlElementsToAdd = @("currentTest", "stateTimeStamp", "caseStartTime", "state", "emailSummary", "jobID", "testCaseResults", "iteration", "isRebooted")
         foreach($element in $xmlElementsToAdd)
         {
             if (-not $vm.${element})
@@ -341,6 +346,12 @@ function RunICTests([XML] $xmlConfig, [string] $collect)
         $vm.iteration = "-1"
 
         #
+        # Add test suite and test date time into test result XML
+        #
+        SetTimeStamp $testStartTime.toString()
+        SetResultSuite $vm.suite
+
+        #
         # Add VM specific information to the email summary text
         #
         $vm.emailSummary = "VM: $($vm.vmName)<br />"
@@ -353,6 +364,11 @@ function RunICTests([XML] $xmlConfig, [string] $collect)
         }
         $vm.emailSummary += " build $($OSInfo.BuildNumber)<br />"
         $vm.emailSummary += "<br /><br />"
+
+        #
+        # Add Hyper-V host version into result XML
+        #
+        SetHypervVersion "$($OSInfo.Version)"
 
         #
         # Make sure the VM actually exists on the specific HyperV server
@@ -516,6 +532,15 @@ function ResetVM([System.Xml.XmlElement] $vm, [XML] $xmlData)
             $snapshotFound = $true
             break
         }
+    }
+    if ($snaps)
+    {
+        $snapshotFound = $true
+    }
+    else
+    {
+        Checkpoint-VM -Name $vm.vmName -SnapshotName $snapshotName -ComputerName $vm.hvServer
+        $snapshotFound = $true
     }
 
     #
@@ -721,7 +746,7 @@ function DoStateMachine([XML] $xmlConfig, [string] $collect)
 
             $Finished
                 {
-                    # Nothing to do in the Finished state
+                    DoFinished $vm $xmlConfig
                 }
 
             $Disabled
@@ -803,12 +828,19 @@ function DoSystemDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
         #
         UpdateCurrentTest $vm $xmlData
 
+        #
+        # Mark current test the first case or after rebooted
+        #
+        $vm.isRebooted = $true.ToString()
+
         $iterationMsg = $null
         if ($vm.iteration -ne "-1")
         {
             $iterationMsg = " (iteration $($vm.iteration))"
         }
         LogMsg 0 "Info : $($vm.vmName) currentTest updated to $($vm.currentTest) ${iterationMsg}"
+
+        $vm.caseStartTime = [DateTime]::Now.ToString()
 
         if ($($vm.currentTest) -eq "done")
         {
@@ -1423,6 +1455,7 @@ function DoSlowSystemStarting([System.Xml.XmlElement] $vm, [XML] $xmlData)
     }
     else
     {
+        LogMsg 9 "=================The  VMs IP address to $($vm.ipv4)======================"
         $sts = TestPort $vm.ipv4 -port 22 -timeout 5
         if ($sts)
         {
@@ -1523,6 +1556,10 @@ function DoSystemUp([System.Xml.XmlElement] $vm, [XML] $xmlData)
         UpdateState $vm $ForceShutdown
     }
 
+    if (-not [bool]$vm.isRebooted)
+    {
+         $vm.caseStartTime = [DateTime]::Now.ToString()
+    }
     $hostname = $vm.ipv4
     $sshKey = $vm.sshKey
 
@@ -1549,6 +1586,14 @@ function DoSystemUp([System.Xml.XmlElement] $vm, [XML] $xmlData)
     #
     $os = (GetOSType $vm).ToString()
     LogMsg 9 "INFO : The OS type is $os"
+
+    #
+    # Add guest kernel version and firmware info int result XML
+    #
+    $kernelVer = GetKernelVersion
+    $firmwareVer = GetFirmwareVersion
+
+    SetOSInfo $kernelVer $firmwareVer
 
     If ($vm.role.ToLower().StartsWith("sut"))
     {
@@ -2388,6 +2433,8 @@ function DoCollectLogFiles([System.Xml.XmlElement] $vm, [XML] $xmlData, [string]
         $iterationMsg = "($($vm.iteration))"
     }
 
+    SetTestResult $currentTest $completionCode
+
     $vm.emailSummary += ("    Test {0,-25} : {2}<br />" -f $($vm.currentTest), $iterationMsg, $completionCode)
 
     #
@@ -2693,6 +2740,12 @@ function DoDetermineReboot([System.Xml.XmlElement] $vm, [XML] $xmlData)
             }
             else
             {
+                SetRunningTime $vm.currentTest $vm
+                #
+                # Mark next test not rebooted
+                #
+                $vm.isRebooted = $false.ToString()
+
                 UpdateState $vm $SystemUp
 
                 $nextTestData = GetTestData $nextTest $xmlData
@@ -2826,6 +2879,7 @@ function DoShuttingDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
         }
         else
         {
+            SetRunningTime $vm.currentTest $vm
             UpdateState $vm $SystemDown
         }
     }
@@ -2922,6 +2976,7 @@ function DoRunCleanUpScript($vm, $xmlData)
         $vm.emailSummary += "Entered RunCleanupScript but test does not have a cleanup script<br />"
     }
 
+    SetRunningTime $vm.currentTest $vm
     UpdateState $vm $SystemDown
 }
 
@@ -2979,6 +3034,7 @@ function DoForceShutDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
     $v = Get-VM $vm.vmName -ComputerName $vm.hvServer
     if ( $($v.State) -eq "Off" )
     {
+        SetRunningTime $vm.currentTest $vm
         UpdateState $vm $nextState
     }
     else
@@ -2995,6 +3051,7 @@ function DoForceShutDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
             $v = Get-VM $vm.vmName -ComputerName $vm.hvServer
             if ( $($v.State) -eq "Off" )
             {
+                SetRunningTime $vm.currentTest $vm
                 UpdateState $vm $nextState
                 break
             }
@@ -3040,8 +3097,7 @@ function DoFinished([System.Xml.XmlElement] $vm, [XML] $xmlData)
     LogMsg 11 "Info : DoFinished( $($vm.vmName), xmlData )"
     LogMsg 11 "Info :   timestamp = $($vm.stateTimestamp))"
     LogMsg 11 "Info :   Test      = $($vm.currentTest))"
-
-    # Currently, nothing to do...
+    SaveResultToXML $testDir
 }
 
 ########################################################################
@@ -3367,6 +3423,7 @@ function DoPS1TestCompleted ([System.Xml.XmlElement] $vm, [XML] $xmlData)
 
     LogMsg 0 "Info : ${vmName} Status for test $($vm.currentTest) = ${completionCode}"
 
+    SetTestResult $currentTest $completionCode
     #
     # Update e-mail summary
     #

--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -533,15 +533,6 @@ function ResetVM([System.Xml.XmlElement] $vm, [XML] $xmlData)
             break
         }
     }
-    if ($snaps)
-    {
-        $snapshotFound = $true
-    }
-    else
-    {
-        Checkpoint-VM -Name $vm.vmName -SnapshotName $snapshotName -ComputerName $vm.hvServer
-        $snapshotFound = $true
-    }
 
     #
     # Make sure the snapshot left the VM in a stopped state.


### PR DESCRIPTION
…it from xiaofeng


   1.  Add JUnit XML result file support.
        there'll be a new Report-.xml file in the case result folder.
        result xml file follows JUnit rules and is acceptable by Jenkins and other CI applications.
    2.  Add case running time support.
        this feature finds how long the test case will last.
        the running time will be included in result XML file for each test case.
        the running time will be calculated from system down to system down if case needs reboot, or from system up to determinreboot if case doesn't need reboot.
