### PR TITLE
Fixed Omping issue for Ubuntu

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_Utils.sh
@@ -518,23 +518,6 @@ InstallDependencies()
 	            fi
 	        fi
 
-	        # Check omping
-	        omping -V > /dev/null 2>&1
-			if [ $? -ne 0 ]; then
-	            wget https://fedorahosted.org/releases/o/m/omping/omping-0.0.4.tar.gz
-	            tar -xzf omping-0.0.4.tar.gz
-	            cd omping-0.0.4/
-	            make
-	            make install
-	            if [ $? -ne 0 ]; then
-	                msg="ERROR: Failed to install omping"
-	                LogMsg "$msg"
-	                UpdateSummary "$msg"
-	                SetTestStateFailed
-	                return 1
-	            fi
-	            cd ~
-			fi
             ;;
 
         redhat*|centos*)

--- a/WS2012R2/lisa/xml/NET_Tests.xml
+++ b/WS2012R2/lisa/xml/NET_Tests.xml
@@ -555,7 +555,7 @@ permissions and limitations under the License.
             </setupScript>
             <testScript>NET_Multicast.sh</testScript>
             <files>remote-scripts/ica/utils.sh,remote-scripts/ica/NET_set_static_ip.sh,
-                remote-scripts/ica/NET_Multicast.sh</files>
+                remote-scripts/ica/NET_Multicast.sh,tools/omping-0.0.4.tar.gz</files>
             <testparams>
                 <param>NIC=NetworkAdapter,Private,Private</param>
                 <param>TC_COVERED=NET-25</param>

--- a/WS2012R2/lisa/xml/SR-IOV.xml
+++ b/WS2012R2/lisa/xml/SR-IOV.xml
@@ -111,7 +111,7 @@
         <test>
             <testName>Multicast</testName>
             <testScript>SR-IOV_Multicast.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_Multicast.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/SR-IOV_Multicast.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,tools/omping-0.0.4.tar.gz</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>


### PR DESCRIPTION
Download link for Omping is now broken for Ubuntu. We will use the
omping archive in tools folder instead of the web download from now