### PR TITLE
NET_TESTS improvements

### DIFF
--- a/WS2012R2/lisa/setupscripts/InjectIPconstants.ps1
+++ b/WS2012R2/lisa/setupscripts/InjectIPconstants.ps1
@@ -136,6 +136,7 @@ else
 $nic = $False
 $switchs = $False
 $AddressFamily = "IPv4"
+$testMAC = "no"
 
 $params = $testParams.Split(";")
 foreach ($p in $params)
@@ -149,6 +150,7 @@ foreach ($p in $params)
     "AddressFamily" { $AddressFamily    = $fields[1].Trim() }
     "SWITCH"        { $switchs = $fields[1].Trim() }
     "NIC"           { $nic     = $fields[1].Trim() }
+    "TestMAC"       { $testMAC     = $fields[1].Trim() }
     default         {}  # unknown param - just ignore it
     }
 }
@@ -236,6 +238,23 @@ switch ($testType)
 $cmd+="echo `"PING_SUCC=$($PING_SUCC)`" >> ~/constants.sh;";
 $cmd+="echo `"PING_FAIL=$($PING_FAIL)`" >> ~/constants.sh;";
 $cmd+="echo `"PING_FAIL2=$($PING_FAIL2)`" >> ~/constants.sh;";
+
+if ($testMAC -eq "yes"){
+    # Get the MAC that was generated
+    $CurrentDir= "$pwd\"
+    $testfile = "macAddress.file" 
+    $pathToFile="$CurrentDir"+"$testfile" 
+    $streamReader = [System.IO.StreamReader] $pathToFile
+    $macAddress = $streamReader.ReadLine()
+    $streamReader.close() 
+
+    for ($i = 2 ; $i -le 14 ; $i += 3) {
+        $macAddress = $macAddress.insert($i,':')
+    }
+
+    # Send the MAC address to the VM
+    $cmd+="echo `"MAC=$($macAddress)`" >> ~/constants.sh;";    
+}
 
 "PING_SUCC=$PING_SUCC"
 "PING_FAIL=$PING_FAIL"

--- a/WS2012R2/lisa/setupscripts/NET_SendIPtoVM.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_SendIPtoVM.ps1
@@ -169,7 +169,6 @@ foreach ($p in $params)
     "VM2NAME" { $vm2Name = $fields[1].Trim() }
     "sshKey"  { $sshKey  = $fields[1].Trim() }
     "ipv4"    { $ipv4    = $fields[1].Trim() }
-    "MAC"     { $vm2MacAddress = $fields[1].Trim() }
     "VM2SERVER"    { $vm2Server    = $fields[1].Trim() }
     "ENABLE_VMMQ"   { $EnableVmmq    = $fields[1].Trim()}
     default   {}  # unknown param - just ignore it
@@ -216,17 +215,19 @@ if (-not $sshKey)
     return $False
 }
 
-if (-not $vm2MacAddress)
-{
-    "Error: test parameter MAC was not specified"
-    return $False
-}
-
 if (-not $vm2Server)
 {
     $vm2Server = $hvServer
     "vm2Server was set as $hvServer"
 }
+
+# Get the MAC that was generated
+$CurrentDir= "$pwd\"
+$testfile = "macAddressDependency.file" 
+$pathToFile="$CurrentDir"+"$testfile" 
+$streamReader = [System.IO.StreamReader] $pathToFile
+$vm2MacAddress = $streamReader.ReadLine()
+$streamReader.close() 
 
 $checkState = Get-VM -Name $vm2Name -ComputerName $vm2Server
 

--- a/WS2012R2/lisa/setupscripts/NET_UTILS.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_UTILS.ps1
@@ -82,7 +82,7 @@ function getRandUnusedMAC([String]$hvServer,[Char]$delim)
 	{
 		# now get random number
 		[uint64]$randDecAddr = Get-Random -minimum $randStart -maximum $randStop
-		[String]$randAddr = "{0:X}" -f $randDecAddr
+		[String]$randAddr = "{0:X12}" -f $randDecAddr
 
 		# Now set the unicast/multicast flag bit.
 		[Byte] $firstbyte = "0x" + $randAddr.substring(0,2)

--- a/WS2012R2/lisa/setupscripts/StartVM.ps1
+++ b/WS2012R2/lisa/setupscripts/StartVM.ps1
@@ -467,21 +467,14 @@ $nic2 = Get-VMNetworkAdapter -VMName $vm2Name -ComputerName $hvServer -IsLegacy:
 
 #Generate a Mac address for the VM's test nic, if this is not a specified parameter
 if (-not $vm2MacAddress) {
+    $vm2MacAddress = getRandUnusedMAC $hvServer
 
-    for ($i = 0 ; $i -lt 3; $i++)
-        {
-           $vm2MacAddress = getRandUnusedMAC $hvServer
-           if ($vm2MacAddress)
-           {
-                break
-           }
-        }
-        $retVal = isValidMAC $vm2MacAddress
-        if (-not $retVal)
-        {
-            "Could not find a valid MAC for $vm2Name. Received $vm2MacAddress"
-            return $false
-        }
+    $CurrentDir= "$pwd\"
+    $testfile = "macAddressDependency.file" 
+    $pathToFile="$CurrentDir"+"$testfile" 
+    $streamWrite = [System.IO.StreamWriter] $pathToFile
+    $streamWrite.WriteLine($vm2MacAddress)
+    $streamWrite.close()
 }
 
 #construct NET_ADD_NIC_MAC Parameter

--- a/WS2012R2/lisa/xml/NET_Tests.xml
+++ b/WS2012R2/lisa/xml/NET_Tests.xml
@@ -171,10 +171,11 @@ permissions and limitations under the License.
         <test>
             <testName>StaticMAC</testName>
             <setupScript>SetupScripts\NET_ADD_NIC_MAC.ps1</setupScript>
+            <pretest>SetupScripts\InjectIPconstants.ps1</pretest>
             <testParams>
-                <param>NIC=NetworkAdapter,External,External,001600112233</param>
+                <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-07</param>
-                <param>MAC=00:16:00:11:22:33</param>
+                <param>TestMAC=yes</param>
                 <param>REMOTE_SERVER=8.8.4.4</param>
                 <param>LO_IGNORE=yes</param>
                 <!-- <param>GATEWAY=192.168.0.1</param> -->
@@ -269,7 +270,6 @@ permissions and limitations under the License.
                 <param>STATIC_IP=10.10.10.10</param>
                 <param>STATIC_IP2=10.10.10.20</param>
                 <param>NETMASK=255.255.255.0</param>
-                <param>MAC=001600112233</param>
             </testparams>
             <testScript>NET_JUMBO_FRAMES.sh</testScript>
             <files>remote-scripts/ica/NET_JUMBO_FRAMES.sh,remote-scripts/ica/utils.sh</files>
@@ -305,9 +305,8 @@ permissions and limitations under the License.
             </setupScript>
             <pretest>setupscripts\NET_SendIPtoVM.ps1</pretest>
             <testParams>
-                <param>NIC=NetworkAdapter,External,External,001600112200</param>
+                <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-12</param>
-                <param>MAC=001600112233</param>
                 <param>ZERO_FILE=yes</param>
                 <param>FILE_SIZE_GB=2</param>
             </testParams>
@@ -329,7 +328,6 @@ permissions and limitations under the License.
             <testParams>
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-13</param>
-                <param>MAC=001600112233</param>
                 <param>ZERO_FILE=yes</param>
                 <param>FILE_SIZE_GB=1</param>
             </testParams>
@@ -535,7 +533,6 @@ permissions and limitations under the License.
             <testParams>
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-25</param>
-                <param>MAC=001600112233</param>
                 <param>ZERO_FILE=yes</param>
                 <param>FILE_SIZE_GB=10</param>
             </testParams>


### PR DESCRIPTION
This solves https://github.com/LIS/lis-test/issues/554 

1. Fixed getRandUnusedMAC function
2. No more static MACs are used in the XML file. All MAC addresses are
now random-generated