### PR TITLE
Fix module_check for rhel6 without hv_netvsc by default and update xm…

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
@@ -30,11 +30,6 @@ LogMsg()
     echo `date "+%a %b %d %T %Y"` ": ${1}"
 }
 
-UpdateTestState()
-{
-    echo $1 > ~/state.txt
-}
-
 CopyImage()
 {
     if [ -d /root/initr ]; then
@@ -42,7 +37,7 @@ CopyImage()
         rm -rf /root/initr/
     fi
 
-    LogMsg "Creating temporary directory."    
+    LogMsg "Creating temporary directory."
     mkdir /root/initr
     cp $1 /root/initr/boot.img
     cd /root/initr/
@@ -57,7 +52,7 @@ SearchModules()
     [[ -d "/root/initr/usr/lib/modules" ]] && abs_path="/root/initr/usr/lib/modules/" || abs_path="/root/initr/lib/modules/"
     for module in "${hv_modules[@]}"; do
         grep -i $module $abs_path*/modules.dep
-        if [ $? -eq 0 ]; then 
+        if [ $? -eq 0 ]; then
             LogMsg "Info: Module $module was found in initrd."
             echo "Info: Module $module was found in initrd." >> /root/summary.log
         else
@@ -76,28 +71,18 @@ SearchModules()
 #
 ######################################################################
 
-LogMsg "Updating test case state to running"
-UpdateTestState "TestRunning"
+dos2unix utils.sh
 
-CONSTANTS_FILE="constants.sh"
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 1
+}
 
+# Source constants file and initialize most common variables
+UtilsInit
 
-if [ -e ~/${CONSTANTS_FILE} ]; then
-    source ~/${CONSTANTS_FILE}
-else
-    msg="Error: no ${CONSTANTS_FILE} file"
-    echo $msg
-    echo $msg >> ~/summary.log
-    UpdateTestState $ICA_TESTABORTED
-    exit 10
-fi
-
-
-# Remove existing logs
-if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
-    rm -f ~/summary.log
-fi
 
 if [ "${hv_modules:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter fileSystems is not defined in constants file."
@@ -107,17 +92,24 @@ if [ "${hv_modules:-UNDEFINED}" = "UNDEFINED" ]; then
     exit 30
 fi
 
-if [ ! ${TC_COVERED} ]; then
-    LogMsg "The TC_COVERED variable is not defined!"
-  echo "The TC_COVERED variable is not defined!" >> ~/summary.log
-fi
 
-echo "This script covers test case: ${TC_COVERED}" >> ~/summary.log
+if [[ $DISTRO == "redhat_6" ]]; then
+    yum install -y dracut-network
+    dracut -f
+    if [ "$?" = "0" ]; then
+        LogMsg "Info: dracut -f executes successfully"
+    else
+        LogMsg "Error: dracut -f fails to execute"
+        echo "Error: dracut -f fails to execute" >> summary.log
+        UpdateTestState "TestAborted"
+        exit 1
+    fi
+fi
 
 if [ -f /boot/initramfs-0-rescue* ]; then
     img=/boot/initramfs-0-rescue*
 else
-    [[ -f "/boot/initrd-`uname -r`" ]] && img="/boot/initrd-`uname -r`" || [[ -f "/boot/initramfs-`uname -r`.img" ]] && img="/boot/initramfs-`uname -r`.img" || img="/boot/initrd.img-`uname -r`"    
+    [[ -f "/boot/initrd-`uname -r`" ]] && img="/boot/initrd-`uname -r`" || [[ -f "/boot/initramfs-`uname -r`.img" ]] && img="/boot/initramfs-`uname -r`.img" || img="/boot/initrd.img-`uname -r`"
 fi
 
 echo "The initrd test image is: $img" >> summary.log

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -292,7 +292,7 @@
 			<files>remote-scripts/ica/modules_check.sh</files>
 			<testparams>
 				<param>TC_COVERED=CORE-24</param>
-				<param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko)</param>
+				<param>hv_modules=(hid-hyperv.ko hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv_fb hyperv-keyboard.ko)</param>
 			</testparams>
 			<noReboot>True</noReboot>
 			<onError>Continue</onError>

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -292,7 +292,7 @@
 			<files>remote-scripts/ica/modules_check.sh</files>
 			<testparams>
 				<param>TC_COVERED=CORE-24</param>
-				<param>hv_modules=(hid-hyperv.ko hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv_fb.ko hyperv-keyboard.ko)</param>
+				<param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko)</param>
 			</testparams>
 			<noReboot>True</noReboot>
 			<onError>Continue</onError>

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -290,6 +290,7 @@
 			<testName>initrd_modules_check</testName>
 			<testScript>modules_check.sh</testScript>
 			<files>remote-scripts/ica/modules_check.sh</files>
+			<files>remote-scripts/ica/utils.sh</files>
 			<testparams>
 				<param>TC_COVERED=CORE-24</param>
 				<param>hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko)</param>

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -292,7 +292,7 @@
 			<files>remote-scripts/ica/modules_check.sh</files>
 			<testparams>
 				<param>TC_COVERED=CORE-24</param>
-				<param>hv_modules=(hid-hyperv.ko hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv_fb hyperv-keyboard.ko)</param>
+				<param>hv_modules=(hid-hyperv.ko hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv_fb.ko hyperv-keyboard.ko)</param>
 			</testparams>
 			<noReboot>True</noReboot>
 			<onError>Continue</onError>


### PR DESCRIPTION
…l to include more modules

1. For rhel6, by default without hv_netvsc module except install vm by network, so need to install dracut-network, then "yum install -y dracut-network,  dracut -f" to make it available, refer to https://bugzilla.redhat.com/show_bug.cgi?id=1298445 
2. Update hid-hyperv.ko and hyperv_fb.ko to the modules list.