### PR TITLE
Increased attempts number

### DIFF
--- a/WS2012R2/lisa/setupscripts/CORE_reload_modules.ps1
+++ b/WS2012R2/lisa/setupscripts/CORE_reload_modules.ps1
@@ -72,7 +72,7 @@ function CheckResult()
     $TestCompleted = "TestCompleted"
     $TestAborted   = "TestAborted"
     $TestRunning   = "TestRunning"
-    $attempts      = 100    
+    $attempts      = 200    
      
     Write-Output "Info : pscp -q -i ssh\${sshKey} root@${ipv4}:$stateFile}"
     while ($attempts -ne 0 ){


### PR DESCRIPTION
The StressRealoadModules automation failed
because the PS script exited before the
bash script finished running on VM. In order to fix
that the number of checks performed from the host,
on the VM state file, was increased from 100 to 200 (with a 10s
sleep time in between attempts).