### PR TITLE
Fixed version comparison for extra settings config

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Config.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Config.sh
@@ -165,7 +165,7 @@ ConfigRhel()
         GetOSVersion
     fi
 
-    if [[ $os_RELEASE =~ ^5.* ]] || [[ $os_RELEASE =~ ^6.[0-2] ]] ; then
+    if [[ $os_RELEASE.$os_UPDATE =~ ^5.* ]] || [[ $os_RELEASE.$os_UPDATE =~ ^6.[0-2] ]] ; then
         RhelExtraSettings
     fi
 


### PR DESCRIPTION
On RHEL 6.2 or lower the extra kdump configurations were not being made due to improper version comparison. A change was made so that the full version is evaluated now.