### PR TITLE
Moved ConvertToMemSize method to TCUtils

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_CONFIGURE_MEMORY.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_CONFIGURE_MEMORY.ps1
@@ -72,46 +72,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-# Convert a string to int64 for use with the Set-VMMemory cmdlet
-function ConvertToMemSize([String] $memString, [String]$hvServer)
-{
-    $memSize = [Int64] 0
-
-    if ($memString.EndsWith("MB"))
-    {
-        $num = $memString.Replace("MB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1MB
-    }
-    elseif ($memString.EndsWith("GB"))
-    {
-        $num = $memString.Replace("GB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1GB
-    }
-    elseif( $memString.EndsWith("%"))
-    {
-        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
-        if (-not $osInfo)
-        {
-            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
-            return $False
-        }
-
-        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
-        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
-        $num = [Int64] ($memPercent * $hostMemCapacity)
-
-        # Align on a 4k boundry
-        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
-    }
-    # we received the number of bytes
-    else
-    {
-        $memSize = ([Convert]::ToInt64($memString))
-    }
-
-    return $memSize
-}
-
 #
 # Check input arguments
 #
@@ -139,6 +99,15 @@ $tpEnabled = $null
 [int64]$tPmaxMem = 0
 [int64]$tPstartupMem = 0
 [int64]$tPmemWeight = -1
+
+# Source TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+  . .\setupScripts\TCUtils.ps1
+}
+else {
+  "Error: Could not find setupScripts\TCUtils.ps1"
+  return $false
+}
 
 #
 # Parse the testParams string, then process each parameter

--- a/WS2012R2/lisa/setupscripts/Runtime_Mem_Configure.ps1
+++ b/WS2012R2/lisa/setupscripts/Runtime_Mem_Configure.ps1
@@ -39,48 +39,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-
-# Convert a string to int64 for use with the Set-VMMemory cmdlet
-function ConvertToMemSize([String] $memString, [String]$hvServer)
-{
-    $memSize = [Int64] 0
-
-    if ($memString.EndsWith("MB"))
-    {
-        $num = $memString.Replace("MB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1MB
-    }
-    elseif ($memString.EndsWith("GB"))
-    {
-        $num = $memString.Replace("GB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1GB
-    }
-    elseif( $memString.EndsWith("%"))
-    {
-        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
-        if (-not $osInfo)
-        {
-            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
-            return $False
-        }
-
-        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
-        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
-        $num = [Int64] ($memPercent * $hostMemCapacity)
-
-        # Align on a 4k boundry
-        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
-    }
-    # we received the number of bytes
-    else
-    {
-        $memSize = ([Convert]::ToInt64($memString))
-    }
-
-    return $memSize
-}
-
-
 #
 # Check input arguments
 #
@@ -103,6 +61,15 @@ if (-not $testParams){
 $DM_Enabled = $false
 
 [int64]$startupMem = 0
+
+# Source TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+  . .\setupScripts\TCUtils.ps1
+}
+else {
+  "Error: Could not find setupScripts\TCUtils.ps1"
+  return $false
+}
 
 #
 # Parse the testParams string, then process each parameter

--- a/WS2012R2/lisa/setupscripts/Runtime_Mem_HotAdd_Chunks.ps1
+++ b/WS2012R2/lisa/setupscripts/Runtime_Mem_HotAdd_Chunks.ps1
@@ -45,41 +45,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-# Convert a string to int64 for use with the Set-VMMemory cmdlet
-function ConvertToMemSize([String] $memString, [String]$hvServer)
-{
-    $memSize = [Int64] 0
-
-    if ($memString.EndsWith("MB")){
-        $num = $memString.Replace("MB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1MB
-    }
-    elseif ($memString.EndsWith("GB")){
-        $num = $memString.Replace("GB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1GB
-    }
-    elseif( $memString.EndsWith("%")){
-        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
-        if (-not $osInfo){
-            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
-            return $False
-        }
-
-        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
-        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
-        $num = [Int64] ($memPercent * $hostMemCapacity)
-
-        # Align on a 4k boundry
-        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
-    }
-    # we received the number of bytes
-    else{
-        $memSize = ([Convert]::ToInt64($memString))
-    }
-
-    return $memSize
-}
-
 function checkStressNg([String]$conIpv4, [String]$sshKey)
 {
     $cmdToVM = @"
@@ -139,11 +104,11 @@ $scriptBlock = {
   }
 
   # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1"){
+  if (Test-Path ".\setupScripts\TCUtils.ps1") {
     . .\setupScripts\TCUtils.ps1
     "Sourced TCUtils.ps1"
   }
-  else{
+  else {
     "Error: Could not find setupScripts\TCUtils.ps1"
     return $false
   }

--- a/WS2012R2/lisa/setupscripts/Runtime_Mem_HotAdd_reboot.ps1
+++ b/WS2012R2/lisa/setupscripts/Runtime_Mem_HotAdd_reboot.ps1
@@ -47,41 +47,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-# Convert a string to int64 for use with the Set-VMMemory cmdlet
-function ConvertToMemSize([String] $memString, [String]$hvServer)
-{
-    $memSize = [Int64] 0
-
-    if ($memString.EndsWith("MB")){
-        $num = $memString.Replace("MB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1MB
-    }
-    elseif ($memString.EndsWith("GB")){
-        $num = $memString.Replace("GB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1GB
-    }
-    elseif( $memString.EndsWith("%")){
-        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
-        if (-not $osInfo){
-            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
-            return $False
-        }
-
-        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
-        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
-        $num = [Int64] ($memPercent * $hostMemCapacity)
-
-        # Align on a 4k boundry
-        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
-    }
-    # we received the number of bytes
-    else{
-        $memSize = ([Convert]::ToInt64($memString))
-    }
-
-    return $memSize
-}
-
 #######################################################################
 #
 # Main script body
@@ -136,10 +101,10 @@ else{
 }
 
 # Source TCUtils.ps1 for getipv4 and other functions
-if (Test-Path ".\setupScripts\TCUtils.ps1"){
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
   . .\setupScripts\TCUtils.ps1
 }
-else{
+else {
   "Error: Could not find setupScripts\TCUtils.ps1"
   return $false
 }

--- a/WS2012R2/lisa/setupscripts/Runtime_Mem_MultipleAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/Runtime_Mem_MultipleAddRemove.ps1
@@ -43,41 +43,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-# Convert a string to int64 for use with the Set-VMMemory cmdlet
-function ConvertToMemSize([String] $memString, [String]$hvServer)
-{
-    $memSize = [Int64] 0
-
-    if ($memString.EndsWith("MB")){
-        $num = $memString.Replace("MB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1MB
-    }
-    elseif ($memString.EndsWith("GB")){
-        $num = $memString.Replace("GB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1GB
-    }
-    elseif( $memString.EndsWith("%")){
-        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
-        if (-not $osInfo){
-            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
-            return $False
-        }
-
-        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
-        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
-        $num = [Int64] ($memPercent * $hostMemCapacity)
-
-        # Align on a 4k boundry
-        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
-    }
-    # we received the number of bytes
-    else{
-        $memSize = ([Convert]::ToInt64($memString))
-    }
-
-    return $memSize
-}
-
 function checkStressNg([String]$conIpv4, [String]$sshKey)
 {
     $cmdToVM = @"
@@ -237,10 +202,10 @@ else{
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
-if (Test-Path ".\setupScripts\TCUtils.ps1"){
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
   . .\setupScripts\TCUtils.ps1
 }
-else{
+else {
   "Error: Could not find setupScripts\TCUtils.ps1"
   return $false
 }

--- a/WS2012R2/lisa/setupscripts/Runtime_Mem_StressHotRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/Runtime_Mem_StressHotRemove.ps1
@@ -44,41 +44,6 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-# Convert a string to int64 for use with the Set-VMMemory cmdlet
-function ConvertToMemSize([String] $memString, [String]$hvServer)
-{
-    $memSize = [Int64] 0
-
-    if ($memString.EndsWith("MB")){
-        $num = $memString.Replace("MB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1MB
-    }
-    elseif ($memString.EndsWith("GB")){
-        $num = $memString.Replace("GB","")
-        $memSize = ([Convert]::ToInt64($num)) * 1GB
-    }
-    elseif( $memString.EndsWith("%")){
-        $osInfo = Get-WMIObject Win32_OperatingSystem -ComputerName $hvServer
-        if (-not $osInfo){
-            "Error: Unable to retrieve Win32_OperatingSystem object for server ${hvServer}"
-            return $False
-        }
-
-        $hostMemCapacity = $osInfo.FreePhysicalMemory * 1KB
-        $memPercent = [Convert]::ToDouble("0." + $memString.Replace("%",""))
-        $num = [Int64] ($memPercent * $hostMemCapacity)
-
-        # Align on a 4k boundry
-        $memSize = [Int64](([Int64] ($num / 2MB)) * 2MB)
-    }
-    # we received the number of bytes
-    else{
-        $memSize = ([Convert]::ToInt64($memString))
-    }
-
-    return $memSize
-}
-
 function checkStressNg([String]$conIpv4, [String]$sshKey)
 {
     $cmdToVM = @"
@@ -130,11 +95,11 @@ $scriptBlock = {
   }
 
   # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1"){
+  if (Test-Path ".\setupScripts\TCUtils.ps1") {
     . .\setupScripts\TCUtils.ps1
     "Sourced TCUtils.ps1"
   }
-  else{
+  else {
     "Error: Could not find setupScripts\TCUtils.ps1"
     return $false
   }


### PR DESCRIPTION
Moved ConvertToMemSize from different files in TCUtils to reduce redundancy.