### PR TITLE
Add VHDX IDE skipped if vm is gen2, cover AddVhdxHardDisk, Add-VHDXFo…

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/STOR_Lis_Disk.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_Lis_Disk.sh
@@ -179,9 +179,6 @@ function TestFileSystem()
             fi
          fi
     done
-
-
-
 }
 
 
@@ -255,9 +252,9 @@ done
 
 echo "constants disk count = $diskCount"
 
-# Gen2 vm does not support IDE
+# Generation 2 VM does not support IDE disk
 if [ $diskIDECount -ge 1 ] && [ -d /sys/firmware/efi ]; then
-    UpdateSummary "Gen2 vm does not support IDE, skip test"
+    UpdateSummary "Generation 2 VM does not support IDE disk, skip test"
     UpdateTestState $ICA_TESTSKIPPED
     exit 0
 fi

--- a/WS2012R2/lisa/remote-scripts/ica/STOR_Lis_Disk.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_Lis_Disk.sh
@@ -25,7 +25,7 @@ ICA_TESTRUNNING="TestRunning"
 ICA_TESTCOMPLETED="TestCompleted"
 ICA_TESTABORTED="TestAborted"
 ICA_TESTFAILED="TestFailed"
-
+ICA_TESTSKIPPED="TestSkipped"
 CONSTANTS_FILE="constants.sh"
 
 LogMsg()
@@ -234,6 +234,7 @@ echo "Covers : ${TC_COVERED}" >> ~/summary.log
 # Count the number of SCSI= and IDE= entries in constants
 #
 diskCount=0
+diskIDECount=0
 for entry in $(cat ./constants.sh)
 do
     # Convert to lower case
@@ -243,6 +244,7 @@ do
     if [[ $lowStr == ide* ]];
     then
         diskCount=$((diskCount+1))
+        diskIDECount=$((diskIDECount+1))
     fi
 
     if [[ $lowStr == scsi* ]];
@@ -253,6 +255,12 @@ done
 
 echo "constants disk count = $diskCount"
 
+# Gen2 vm does not support IDE
+if [ $diskIDECount -ge 1 ] && [ -d /sys/firmware/efi ]; then
+    UpdateSummary "Gen2 vm does not support IDE, skip test"
+    UpdateTestState $ICA_TESTSKIPPED
+    exit 0
+fi
 #
 # Compute the number of sd* drives on the system.
 #

--- a/WS2012R2/lisa/setupscripts/Add-VHDXForResize.ps1
+++ b/WS2012R2/lisa/setupscripts/Add-VHDXForResize.ps1
@@ -214,13 +214,7 @@ if ($testParams -eq $null -or $testParams.Length -lt 3)
     return $False
 }
 
-
-
-
 $params = $testParams.TrimEnd(";").Split(";")
-
-
-
 
 [int]$max = 0
 $setIndex = $null
@@ -241,8 +235,6 @@ foreach($p in $params){
     }
 }
 
-
-
 $type = $null
 $sectorSize = $null
 $defaultSize = $null
@@ -261,7 +253,6 @@ for ($pair=0; $pair -le $max; $pair++) {
           "SectorSize"    { $sectorSize   = $value }
           "DefaultSize"   { $defaultSize = $value }
           "ControllerType"   { $controllerType = $value }
-
           default     {}  # unknown param - just ignore it
         }
     }
@@ -274,6 +265,16 @@ for ($pair=0; $pair -le $max; $pair++) {
     {
         cd $rootDir
     }
+    # Source TCUitls.ps1
+    if (Test-Path ".\setupScripts\TCUtils.ps1")
+    {
+        . .\setupScripts\TCUtils.ps1
+    }
+    else
+    {
+        "Error: Could not find setupScripts\TCUtils.ps1"
+        return $False
+    }
     # Source STOR_VHDXResize_Utils.ps1
     if (Test-Path ".\setupScripts\STOR_VHDXResize_Utils.ps1")
     {
@@ -282,7 +283,7 @@ for ($pair=0; $pair -le $max; $pair++) {
     else
     {
         "Error: Could not find setupScripts\STOR_VHDXResize_Utils.ps1"
-        return $false
+        return $False
     }
 
     # Check and create SCSI controller
@@ -298,6 +299,13 @@ for ($pair=0; $pair -le $max; $pair++) {
     # Check IDE controller
     elseif ( $controllerType -eq "IDE" )
     {
+        $vmGeneration = GetVMGeneration $vmName $hvServer
+        if ($vmGeneration -eq 2 )
+        {
+            Write-Output "vm generation 2 does not support IDE disk, please skip this case in test script "
+            return $True
+        }
+
          Write-Output "ControllerType is IDE"
     }
     else

--- a/WS2012R2/lisa/setupscripts/Add-VHDXForResize.ps1
+++ b/WS2012R2/lisa/setupscripts/Add-VHDXForResize.ps1
@@ -265,7 +265,7 @@ for ($pair=0; $pair -le $max; $pair++) {
     {
         cd $rootDir
     }
-    # Source TCUitls.ps1
+    # Source TCUtils.ps1
     if (Test-Path ".\setupScripts\TCUtils.ps1")
     {
         . .\setupScripts\TCUtils.ps1
@@ -302,7 +302,7 @@ for ($pair=0; $pair -le $max; $pair++) {
         $vmGeneration = GetVMGeneration $vmName $hvServer
         if ($vmGeneration -eq 2 )
         {
-            Write-Output "vm generation 2 does not support IDE disk, please skip this case in test script "
+            Write-Output "Generation 2 VM does not support IDE disk, please skip this case in the test script"
             return $True
         }
 

--- a/WS2012R2/lisa/setupscripts/AddVhdxHardDisk.ps1
+++ b/WS2012R2/lisa/setupscripts/AddVhdxHardDisk.ps1
@@ -359,11 +359,6 @@ if ($testParams -eq $null -or $testParams.Length -lt 3)
     return $False
 }
 
-$vmGeneration = Get-VM $vmName -ComputerName $hvServer| select -ExpandProperty Generation -ErrorAction SilentlyContinue
-if ($? -eq $False)
-{
-   $vmGeneration = 1
-}
 $params = $testParams.TrimEnd(";").Split(";")
 foreach ($p in $params)
 {
@@ -384,6 +379,30 @@ foreach ($p in $params)
     }
 }
 
+if (-not $rootDir)
+{
+    "Error: no rootdir was specified"
+    return $False
+}
+
+cd $rootDir
+# Source TCUitls.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+$vmGeneration = GetVMGeneration $vmName $hvServer
+if ($IDECount -ge 1 -and $vmGeneration -eq 2 )
+{
+     write-output "vm generation 2 does not support IDE disk, please skip this case in test script"
+     return $True
+}
 # if define diskCount number, only support one SCSI parameter
 if ($diskCount -ne $null)
 {

--- a/WS2012R2/lisa/setupscripts/AddVhdxHardDisk.ps1
+++ b/WS2012R2/lisa/setupscripts/AddVhdxHardDisk.ps1
@@ -386,7 +386,7 @@ if (-not $rootDir)
 }
 
 cd $rootDir
-# Source TCUitls.ps1
+# Source TCUtils.ps1
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
     . .\setupScripts\TCUtils.ps1
@@ -400,7 +400,7 @@ else
 $vmGeneration = GetVMGeneration $vmName $hvServer
 if ($IDECount -ge 1 -and $vmGeneration -eq 2 )
 {
-     write-output "vm generation 2 does not support IDE disk, please skip this case in test script"
+     Write-Output "Generation 2 VM does not support IDE disk, please skip this case in the test script"
      return $True
 }
 # if define diskCount number, only support one SCSI parameter

--- a/WS2012R2/lisa/setupscripts/DiffDiskGrowthSetup.ps1
+++ b/WS2012R2/lisa/setupscripts/DiffDiskGrowthSetup.ps1
@@ -40,7 +40,7 @@
    The following are some examples:
    SCSI=0,0,Diff : Add a hard drive on SCSI controller 0, Lun 0, vhd type of Dynamic
    IDE=1,1,Diff  : Add a hard drive on IDE controller 1, IDE port 1, vhd type of Diff
-   
+
    Note: This setup script only adds differencing disks.
 
     A typical XML definition for this test case would look similar
@@ -51,10 +51,10 @@
         <setupScript>setupscripts\DiffDiskGrowthSetup.ps1</setupScript>
         <cleanupScript>setupscripts\DiffDiskGrowthCleanup.ps1</cleanupScript>
         <timeout>18000</timeout>
-        <testparams>                
-                <param>IDE=1,1,Diff</param>      
+        <testparams>
+                <param>IDE=1,1,Diff</param>
                 <param>ParentVhd=VHDXParentDiff.vhdx</param>
-                <param>TC_COUNT=DSK_VHDX-75</param>            
+                <param>TC_COUNT=DSK_VHDX-75</param>
         </testparams>
     </test>
 
@@ -68,7 +68,7 @@
     Test data for this test case
 
 .Example
-    setupScripts\DiffDiskGrowthSetup.ps1 -vmName VMname -hvServer localhost -testParams "IDE=1,1,Diff;ParentVhd=VHDXParentDiff.vhdx;sshkey=rhel5_id_rsa.ppk;ipv4=IP;RootDir=" 
+    setupScripts\DiffDiskGrowthSetup.ps1 -vmName VMname -hvServer localhost -testParams "IDE=1,1,Diff;ParentVhd=VHDXParentDiff.vhdx;sshkey=rhel5_id_rsa.ppk;ipv4=IP;RootDir="
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
@@ -182,13 +182,13 @@ foreach ($p in $params)
     }
 
     $tokens = $p.Trim().Split('=')
-    
+
     if ($tokens.Length -ne 2)
     {
         # Just ignore it
          continue
     }
-    
+
     $lValue = $tokens[0].Trim()
     $rValue = $tokens[1].Trim()
 
@@ -211,30 +211,39 @@ foreach ($p in $params)
     }
 
     #
+    # rootDIR test param
+    #
+    if ($lValue -eq "rootDIR")
+    {
+        $rootDir = $rValue
+        continue
+    }
+
+    #
     # Controller type testParam
     #
     if (@("IDE", "SCSI") -contains $lValue)
     {
         $controllerType = $lValue
-        
+
         $SCSI = $false
         if ($controllerType -eq "SCSI")
         {
             $SCSI = $true
         }
-            
+
         $diskArgs = $rValue.Split(',')
-        
+
         if ($diskArgs.Length -ne 3)
         {
             "Error: Incorrect number of disk arguments: $p"
             return $False
         }
-        
+
         $controllerID = $diskArgs[0].Trim()
         $lun = $diskArgs[1].Trim()
         $vhdType = $diskArgs[2].Trim()
-        
+
         #
         # Just a reminder. The test case is testing differencing disks.
         # If we are asked to create a disk other than a differencing disk,
@@ -248,6 +257,15 @@ foreach ($p in $params)
     }
 }
 
+if (-not $rootDir)
+{
+    "Warn : no rootdir was specified"
+}
+else
+{
+    cd $rootDir
+}
+
 # Source TCUtils.ps1 for common functions
 if (Test-Path ".\setupScripts\TCUtils.ps1") {
 	. .\setupScripts\TCUtils.ps1
@@ -255,7 +273,7 @@ if (Test-Path ".\setupScripts\TCUtils.ps1") {
 }
 else {
 	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
+	return $False
 }
 
 #
@@ -265,6 +283,13 @@ if (-not $controllerType)
 {
     "Error: No controller type specified in the test parameters"
     return $False
+}
+
+$vmGeneration = GetVMGeneration $vmName $hvServer
+if ( $controllerType -eq "IDE" -and $vmGeneration -eq 2 )
+{
+        Write-Output "Generation 2 VM does not support IDE disk, please skip this case in the test script"
+        return $True
 }
 
 if (-not $controllerID)
@@ -294,7 +319,7 @@ if (-not $parentVhd)
         "Error: Failed to create parent $vhdFormat on $hvServer"
         return $False
     }
-    else 
+    else
     {
         "Info: Parent disk $parentVhd created"
     }
@@ -308,7 +333,7 @@ if ($SCSI)
         "Error: CreateHardDrive was passed a bad SCSI Controller ID: $ControllerID"
         return $false
     }
-    
+
     # Create the SCSI controller if needed
     $sts = CreateController $vmName $hvServer $controllerID
     if (-not $sts[$sts.Length-1])
@@ -326,11 +351,6 @@ else # Make sure the controller ID is valid for IDE
     }
 }
 
-$vmGeneration = Get-VM $vmName -ComputerName $hvServer| select -ExpandProperty Generation -ErrorAction SilentlyContinue
-if ($? -eq $False)
-{
-   $vmGeneration = 1
-}
 
 if ($vmGeneration -eq 1)
 {
@@ -340,7 +360,7 @@ else
 {
     $lun = [int]($diskArgs[1].Trim()) +1
 }
-$drives = Get-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer -ControllerType $controllerType -ControllerNumber $controllerID -ControllerLocation $lun 
+$drives = Get-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer -ControllerType $controllerType -ControllerNumber $controllerID -ControllerLocation $lun
 if ($drives)
 {
     write-output "Error: drive $controllerType $controllerID $Lun already exists"
@@ -360,15 +380,14 @@ if (-not $defaultVhdPath.EndsWith("\"))
     $defaultVhdPath += "\"
 }
 
-
 if ($parentVhd.EndsWith(".vhd"))
 {
-    # To Make sure we do not use exisiting Diff disk, del if exists 
-    $vhdName = $defaultVhdPath + ${vmName} +"-" + ${controllerType} + "-" + ${controllerID}+ "-" + ${lun} + "-" + "Diff.vhd"  
+    # To Make sure we do not use exisiting Diff disk, del if exists
+    $vhdName = $defaultVhdPath + ${vmName} +"-" + ${controllerType} + "-" + ${controllerID}+ "-" + ${lun} + "-" + "Diff.vhd"
 }
 else
 {
-    $vhdName = $defaultVhdPath + ${vmName} +"-" + ${controllerType} + "-" + ${controllerID}+ "-" + ${lun} + "-" + "Diff.vhdx"  
+    $vhdName = $defaultVhdPath + ${vmName} +"-" + ${controllerType} + "-" + ${controllerID}+ "-" + ${lun} + "-" + "Diff.vhdx"
 }
 
 $vhdFileInfo = GetRemoteFileInfo  $vhdName  $hvServer
@@ -400,7 +419,7 @@ if (-not $parentFileInfo)
 
 #
 # Create the .vhd file
-$newVhd = New-Vhd -Path $vhdName -ParentPath $parentVhdFilename -ComputerName $hvServer -Differencing          
+$newVhd = New-Vhd -Path $vhdName -ParentPath $parentVhdFilename -ComputerName $hvServer -Differencing
 if (-not $newVhd)
 {
     "Error: unable to create a new .vhd file"
@@ -419,7 +438,7 @@ if ($newVhd.ParentPath -ne $parentVhdFilename)
 # Attach the .vhd file to the new drive
 #
 $error.Clear()
-$disk = Add-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer -ControllerType $controllerType -ControllerNumber $controllerID -ControllerLocation $lun -Path $vhdName    
+$disk = Add-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer -ControllerType $controllerType -ControllerNumber $controllerID -ControllerLocation $lun -Path $vhdName
 if ($error.Count -gt 0)
 {
     "Error: Add-VMHardDiskDrive failed to add drive on ${controllerType} ${controllerID} ${Lun}s"
@@ -431,5 +450,5 @@ else
     "Info: Child disk $vhdName created and attached to ${controllerType} : ${controllerID} : ${Lun}"
     $retVal = $true
 }
-    
+
 return $retVal

--- a/WS2012R2/lisa/setupscripts/DiffDiskGrowthTestCase.ps1
+++ b/WS2012R2/lisa/setupscripts/DiffDiskGrowthTestCase.ps1
@@ -87,7 +87,7 @@ $sshKey = $null
 $ipv4 = $null
 $TC_COVERED = $null
 $vhdFormat = $null
-$vmGeneration = $null 
+$vmGeneration = $null
 $retVal = $False
 
 $remoteScript = "PartitionDisks.sh"
@@ -193,6 +193,16 @@ if ($null -eq $rootdir)
 
 cd $rootdir
 
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $False
+}
+
 # del $summaryLog -ErrorAction SilentlyContinue
 $summaryLog = "${vmName}_summary.log"
 "Covers: ${TC_COVERED}" >> $summaryLog
@@ -203,6 +213,13 @@ if (-not $controllerType)
 {
     "Error: Missing controller type in test parameters"
     return $False
+}
+
+$vmGeneration = GetVMGeneration $vmName $hvServer
+if ( $controllerType -eq "IDE" -and $vmGeneration -eq 2 )
+{
+    Write-Output "Generation 2 VM does not support IDE disk, skip test"
+    return $Skipped
 }
 
 if (-not $controllerID)
@@ -268,12 +285,6 @@ $defaultVhdPath = $hostInfo.VirtualHardDiskPath
 if (-not $defaultVhdPath.EndsWith("\"))
 {
     $defaultVhdPath += "\"
-}
-
-$vmGeneration = Get-VM $vmName -ComputerName $hvServer| select -ExpandProperty Generation -ErrorAction SilentlyContinue
-if ($? -eq $False)
-{
-   $vmGeneration = 1
 }
 
 if ($vmGeneration -eq 1)

--- a/WS2012R2/lisa/setupscripts/Remove-VHDXHardDisk.ps1
+++ b/WS2012R2/lisa/setupscripts/Remove-VHDXHardDisk.ps1
@@ -120,12 +120,43 @@ foreach($p in $params){
     "Type?"          { $v = $value.substring(4) }
     "SectorSize?"    { $v = $value.substring(10) }
     "DefaultSize?"   { $v = $value.substring(11) }
+    "ControllerType"   { $controllerType = $fields[1].Trim() }
+    "rootDIR"   { $rootDir = $fields[1].Trim() }
     default     {}  # unknown param - just ignore it
     }
     if ([int]$v -gt $max -and $v -ne $null){
         $max = [int]$v
     }
 }
+
+if (-not $rootDir)
+{
+    "Error: no rootdir was specified"
+    return $False
+}
+
+cd $rootDir
+# Source TCUitls.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+if ( $controllerType -eq "IDE" )
+{
+    $vmGeneration = GetVMGeneration $vmName $hvServer
+    if ($vmGeneration -eq 2 )
+    {
+        write-output "vm generation 2 does not support IDE disk, please skip this case in test script "
+        return $True
+    }
+}
+
+
 for($pair=0; $pair -le $max; $pair++){
 
   foreach ($p in $params)

--- a/WS2012R2/lisa/setupscripts/Remove-VHDXHardDisk.ps1
+++ b/WS2012R2/lisa/setupscripts/Remove-VHDXHardDisk.ps1
@@ -136,7 +136,7 @@ if (-not $rootDir)
 }
 
 cd $rootDir
-# Source TCUitls.ps1
+# Source TCUtils.ps1
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
     . .\setupScripts\TCUtils.ps1
@@ -151,7 +151,7 @@ if ( $controllerType -eq "IDE" )
     $vmGeneration = GetVMGeneration $vmName $hvServer
     if ($vmGeneration -eq 2 )
     {
-        write-output "vm generation 2 does not support IDE disk, please skip this case in test script "
+        Write-Output "Generation 2 VM does not support IDE disk, please skip this case in the test script"
         return $True
     }
 }

--- a/WS2012R2/lisa/setupscripts/RemoveVhdxHardDisk.ps1
+++ b/WS2012R2/lisa/setupscripts/RemoveVhdxHardDisk.ps1
@@ -328,6 +328,7 @@ if (-not $rootDir)
 }
 
 cd $rootDir
+# Source TCUtils.ps1
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
     . .\setupScripts\TCUtils.ps1
@@ -341,7 +342,7 @@ else
 $vmGeneration = GetVMGeneration $vmName $hvServer
 if ($IDECount -ge 1 -and $vmGeneration -eq 2 )
 {
-     write-output "vm generation 2 does not support IDE disk, please skip this case in test script"
+     Write-Output "Generation 2 VM does not support IDE disk, please skip this case in the test script"
      return $True
 }
 
@@ -354,8 +355,6 @@ if ($diskCount -ne $null)
       return  $False
   }
 }
-
-
 
 foreach ($p in $params)
 {

--- a/WS2012R2/lisa/setupscripts/RemoveVhdxHardDisk.ps1
+++ b/WS2012R2/lisa/setupscripts/RemoveVhdxHardDisk.ps1
@@ -100,10 +100,6 @@ $IDECount = 0
 $diskCount =$null
 $vmGeneration = $null
 
-$vmGeneration = Get-VM $vmName -ComputerName $hvServer| select -ExpandProperty Generation -ErrorAction SilentlyContinue
-if ($? -eq $False) {
-   $vmGeneration = 1
-}
 
 ############################################################################
 #
@@ -325,6 +321,29 @@ foreach ($p in $params)
     }
 }
 
+if (-not $rootDir)
+{
+    "Error: no rootdir was specified"
+    return $False
+}
+
+cd $rootDir
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+$vmGeneration = GetVMGeneration $vmName $hvServer
+if ($IDECount -ge 1 -and $vmGeneration -eq 2 )
+{
+     write-output "vm generation 2 does not support IDE disk, please skip this case in test script"
+     return $True
+}
 
 # if define diskCount number, only support one SCSI parameter
 if ($diskCount -ne $null)

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
@@ -140,7 +140,7 @@ else
 {
     cd $rootDir }
 
-# Source TCUitls.ps1
+# Source TCUtils.ps1
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
     . .\setupScripts\TCUtils.ps1
@@ -156,7 +156,7 @@ if ( $controllerType -eq "IDE" )
     $vmGeneration = GetVMGeneration $vmName $hvServer
     if ($vmGeneration -eq 2 )
     {
-         write-output "vm generation 2 does not support IDE disk"
+         Write-Output "Generation 2 VM does not support IDE disk, skip test"
          return $Skipped
     }
 }

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
@@ -138,7 +138,27 @@ if (-not $rootDir)
 }
 else
 {
-    cd $rootDir
+    cd $rootDir }
+
+# Source TCUitls.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+if ( $controllerType -eq "IDE" )
+{
+    $vmGeneration = GetVMGeneration $vmName $hvServer
+    if ($vmGeneration -eq 2 )
+    {
+         write-output "vm generation 2 does not support IDE disk"
+         return $Skipped
+    }
 }
 
 # Source STOR_VHDXResize_Utils.ps1

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
@@ -145,7 +145,7 @@ else
     cd $rootDir
 }
 
-# Source TCUitls.ps1
+# Source TCUtils.ps1
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
     . .\setupScripts\TCUtils.ps1
@@ -161,7 +161,7 @@ if ( $controllerType -eq "IDE" )
     $vmGeneration = GetVMGeneration $vmName $hvServer
     if ($vmGeneration -eq 2 )
     {
-         write-output "vm generation 2 does not support IDE disk"
+         Write-Output "Generation 2 VM does not support IDE disk, skip test"
          return $Skipped
     }
 }

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
@@ -145,6 +145,27 @@ else
     cd $rootDir
 }
 
+# Source TCUitls.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $False
+}
+
+if ( $controllerType -eq "IDE" )
+{
+    $vmGeneration = GetVMGeneration $vmName $hvServer
+    if ($vmGeneration -eq 2 )
+    {
+         write-output "vm generation 2 does not support IDE disk"
+         return $Skipped
+    }
+}
+
 # Source STOR_VHDXResize_Utils.ps1
 if (Test-Path ".\setupScripts\STOR_VHDXResize_Utils.ps1")
 {

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1528,3 +1528,36 @@ function ConvertToMemSize([String] $memString, [String]$hvServer)
 
     return $memSize
 }
+
+#####################################################################
+#
+# GetVMGeneration()
+#
+#####################################################################
+function GetVMGeneration([String] $vmName, [String] $server)
+{
+    <#
+    .Synopsis
+        Get VM Generation type
+    .Description
+        Get VM Generation type from host, gen1 or gen2
+    .Parameter vmName
+        Name of the VM
+    .Parameter server
+        Name of the server hosting the VM
+    .Example
+        GetVMGeneration $vmName $server
+    #>
+    $vmInfo = Get-VM -Name $vmName -ComputerName $hvServer
+
+    # hyper-v 2012 only supports gen1.
+    if ( $vmInfo.Generation -eq "")
+    {
+        $vmGeneration = 1
+    }
+    else
+    {
+        $vmGeneration = $vmInfo.Generation
+    }
+    return $vmGeneration
+}

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1534,23 +1534,23 @@ function ConvertToMemSize([String] $memString, [String]$hvServer)
 # GetVMGeneration()
 #
 #####################################################################
-function GetVMGeneration([String] $vmName, [String] $server)
+function GetVMGeneration([String] $vmName, [String] $hvServer)
 {
     <#
     .Synopsis
-        Get VM Generation type
+        Get VM generation type
     .Description
-        Get VM Generation type from host, gen1 or gen2
+        Get VM generation type from host, generation 1 or generation 2
     .Parameter vmName
         Name of the VM
-    .Parameter server
+    .Parameter hvServer
         Name of the server hosting the VM
     .Example
-        GetVMGeneration $vmName $server
+        GetVMGeneration $vmName $hvServer
     #>
     $vmInfo = Get-VM -Name $vmName -ComputerName $hvServer
 
-    # hyper-v 2012 only supports gen1.
+    # Hyper-v server 2012 only supports generation 1 VM.
     if ( $vmInfo.Generation -eq "")
     {
         $vmGeneration = 1


### PR DESCRIPTION
…rResize, related remove and resize scripts

Mainly used to skip test cases for gen 2 VM adding IDE cases. 

For setup script, return $True if need to skip when add IDE to gen2 VM, but related test script needs to return "Skipped"
For test script, return $Skipped if need to skip directly.
