### PR TITLE
Code redesign for stress reload modules test

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/CORE_StressReloadModules.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/CORE_StressReloadModules.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 ########################################################################
@@ -27,14 +26,10 @@
 # CORE_StressReloadModules.sh
 # Description:
 #    This script will first check the existence of Hyper-V kernel modules.
-#    Then it will reload the modules 500 times to stress the system.
+#    Then it will reload the modules in a loop in order to stress the system.
 #    It also checks that hyperv_fb cannot be unloaded.
 #    When done it will bring up the eth0 interface and check again for
 #    the presence of Hyper-V modules.
-#
-#    To pass test parameters into test cases, the host will create
-#    a file named constants.sh. This file contains one or more
-#    variable definition.
 #
 ################################################################
 
@@ -45,12 +40,12 @@ LogMsg()
 
 UpdateTestState()
 {
-    echo $1 > $HOME/state.txt
+    echo "$1" > $HOME/state.txt
 }
 
 UpdateSummary()
 {
-    echo $1 >> ~/summary.log
+    echo "$1" >> ~/summary.log
 }
 
 VerifyModules()
@@ -61,103 +56,91 @@ VerifyModules()
     #
     # Did VMBus load
     #
-    LogMsg "Checking if hv_vmbus loaded..."
+    LogMsg "Info: Checking if hv_vmbus is loaded..."
 
     grep -q "vmbus" $MODULES
     if [ $? -ne 0 ]; then
-        msg="hv_vmbus not loaded"
-        LogMsg "Error: ${msg}"
-        echo $msg >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
-        exit 20
+        msg="Warning: hv_vmbus not loaded or built-in"
+        LogMsg "${msg}"
+        echo "$msg" >> ~/summary.log
     fi
-    LogMsg "hv_vmbus loaded OK"
+    LogMsg "Info: hv_vmbus loaded OK"
 
     #
     # Did storvsc load
     #
-    LogMsg "Checking if storvsc loaded..."
+    LogMsg "Info: Checking if storvsc is loaded..."
 
     grep -q "storvsc" $MODULES
     if [ $? -ne 0 ]; then
-        msg="hv_storvsc not loaded"
-        LogMsg "Error: ${msg}"
-        echo $msg >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
-        exit 30
+        msg="Warning: hv_storvsc not loaded or built-in"
+        LogMsg "${msg}"
+        echo "$msg" >> ~/summary.log
     fi
-    LogMsg "hv_storvsc loaded OK"
+    LogMsg "Info: hv_storvsc loaded OK"
 
     #
     # Did netvsc load
     #
-    LogMsg "Checking if hv_netvsc loaded..."
+    LogMsg "Info: Checking if hv_netvsc is loaded..."
 
     grep -q "hv_netvsc" $MODULES
     if [ $? -ne 0 ]; then
-        msg="hv_netvsc not loaded"
-        LogMsg "Error: ${msg}"
-        echo $msg >> ~/summary.log
+        msg="Error: hv_netvsc not loaded"
+        LogMsg "${msg}"
+        echo "$msg" >> ~/summary.log
         UpdateTestState $ICA_TESTFAILED
-        exit 30
+        exit 1
     fi
-    LogMsg "hv_netvsc loaded OK"
+    LogMsg "Info: hv_netvsc loaded OK"
 
     #
     # Did utils load
     #
-    LogMsg "Checking if hv_utils loaded..."
+    LogMsg "Info: Checking if hv_utils is loaded..."
 
     grep -q "utils" $MODULES
     if [ $? -ne 0 ]; then
-        msg="hv_utils not loaded"
-        LogMsg "Error: ${msg}"
-        echo $msg >> ~/summary.log
+        msg="Error: hv_utils not loaded"
+        LogMsg "${msg}"
+        echo "$msg" >> ~/summary.log
         UpdateTestState $ICA_TESTFAILED
-        exit 30
+        exit 1
     fi
-    LogMsg "hv_utils loaded OK"
+    LogMsg "Info: hv_utils loaded OK"
 }
 
-cd ~
-UpdateTestState "TestRunning"
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
 
+# Create the state.txt file so ICA knows we are running
+UpdateTestState $ICA_TESTRUNNING
+
+# Cleanup any old summary.log files
 if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
     rm -rf ~/summary.log
 fi
 
 if [ -e $HOME/constants.sh ]; then
     . $HOME/constants.sh
-else
-    LogMsg "ERROR: Unable to source the constants file."
-    UpdateTestState "TestAborted"
-    exit 1
 fi
 
-#Check for Testcase covered
-if [ ! ${TC_COVERED} ]; then
-    LogMsg "Error: The TC_COVERED variable is not defined."
-    echo "Error: The TC_COVERED variable is not defined." >> ~/summary.log
-fi
-
-echo "Covers : ${TC_COVERED}" >> ~/summary.log
-
-#
-# Start the test
-#
-LogMsg "Starting test"
+echo "Covers: ${TC_COVERED}" >> ~/summary.log
 
 VerifyModules
 
 modprobe -r hyperv_fb
 if [ $? -eq 0 ]; then
-    msg="hyperv_fb could be disabled."
-    LogMsg "Error: ${msg}"
-    echo $msg >> ~/summary.log
+    msg="Error: hyperv_fb could be disabled!"
+    LogMsg "${msg}"
+    echo "$msg" >> ~/summary.log
     UpdateTestState $ICA_TESTFAILED
-    exit 30
+    exit 1
 fi
+
 pass=0
 START=$(date +%s)
 while [ $pass -lt 100 ]
@@ -179,19 +162,19 @@ do
 done
 END=$(date +%s)
 DIFF=$(echo "$END - $START" | bc)
-echo $DIFF
-echo "Finished testing, bringing up eth0"
+
+echo "Info: Finished testing, bringing up eth0"
 ifdown eth0
 ifup eth0
 VerifyModules
 
 ipAddress=$(ifconfig | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | cut -d' ' -f1)
 if [[ ${ipAddress} -eq '' ]]; then
-    LogMsg "Waiting for interface to receive an IP"
+    LogMsg "Info: Waiting for interface to receive an IP"
     sleep 30
 fi
 
-echo "Test ran for ${DIFF} seconds" >> ~/summary.log
+echo "Info: Test ran for ${DIFF} seconds" >> ~/summary.log
 
 LogMsg "#########################################################"
 LogMsg "Result : Test Completed Successfully"


### PR DESCRIPTION
hv_vmbus and hv_netvsc can be kernel built-in , no longer failing test
if these modules are not showing up in the list of loaded modules.