### PR TITLE
Update StateEngine.ps1 and utilFunctions to save xml result if setup …

### DIFF
--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -1130,8 +1130,10 @@ function DoRunSetupScript([System.Xml.XmlElement] $vm, [XML] $xmlData)
                             # Otherwise, terminate testing.
                             #
                             LogMsg 0 "Error: VM $($vm.vmName) setup script ${script} for test ${testName} failed"
-                            $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Failed - setup script failed")
+                            $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Aborted - setup script failed")
                             #$vm.emailSummary += ("    Test {0,-25} : {2}<br />" -f $($vm.currentTest), $iterationMsg, $completionCode)
+                            SetTestResult $vm.currentTest $Aborted
+                            SetRunningTime $vm.currentTest $vm
                             if ($abortOnError)
                             {
                                 $vm.currentTest = "done"
@@ -1159,7 +1161,9 @@ function DoRunSetupScript([System.Xml.XmlElement] $vm, [XML] $xmlData)
                         #
                         LogMsg 0 "Error: VM $($vm.vmName) setup script $($testData.setupScript) for test ${testName} failed"
                         #$vm.emailSummary += "    Test $($vm.currentTest) : Failed - setup script failed<br />"
-                        $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Failed - setup script failed")
+                        $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Aborted - setup script failed")
+                        SetTestResult $vm.currentTest $Aborted
+                        SetRunningTime $vm.currentTest $vm
 
                         if ($abortOnError)
                         {
@@ -1597,7 +1601,7 @@ function DoSystemUp([System.Xml.XmlElement] $vm, [XML] $xmlData)
         $kernelVer = GetKernelVersion
         $firmwareVer = GetFirmwareVersion
         SetOSInfo $kernelVer $firmwareVer
-        
+
         #for SUT VM, needs to wait for NonSUT VM startup
         UpdateState $vm $WaitForDependencyVM
     }
@@ -1932,7 +1936,11 @@ function DoRunPreTestScript([System.Xml.XmlElement] $vm, [XML] $xmlData)
                             if (! $sts)
                             {
                                 LogMsg 0 "Error: $($vm.vmName) PreTest script ${script} for test $($testData.testName) failed"
-                                $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Failed - pretest script failed")
+                                $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Aborted - pretest script failed")
+
+                                SetTestResult $vm.currentTest $Aborted
+                                SetRunningTime $vm.currentTest $vm
+
                                 UpdateState $vm $DetermineReboot
                                 return
                             }
@@ -1946,7 +1954,10 @@ function DoRunPreTestScript([System.Xml.XmlElement] $vm, [XML] $xmlData)
                         if (-not $sts)
                         {
                             LogMsg 0 "Error: VM $($vm.vmName) preTest script for test $($testData.testName) failed"
-                            $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Failed - pretest script failed")
+                            $vm.emailSummary += ("    Test {0, -25} : {1}<br />" -f ${testName}, "Aborted - pretest script failed")
+
+                            SetTestResult $vm.currentTest $Aborted
+                            SetRunningTime $vm.currentTest $vm
                             UpdateState $vm $DetermineReboot
                             return
                         }
@@ -2736,7 +2747,8 @@ function DoDetermineReboot([System.Xml.XmlElement] $vm, [XML] $xmlData)
             {
                 LogMsg 0 "Warn : $($vm.vmName) The <NoReboot> flag prevented running cleanup script for test $($testData.testName)"
             }
-
+            #save currentTest name before update
+            $currentTestName = $vm.currentTest
             UpdateCurrentTest $vm $xmlData
 
             $iterationMsg = $null
@@ -2752,7 +2764,7 @@ function DoDetermineReboot([System.Xml.XmlElement] $vm, [XML] $xmlData)
             }
             else
             {
-                SetRunningTime $vm.currentTest $vm
+                SetRunningTime $currentTestName $vm
                 #
                 # Mark next test not rebooted
                 #

--- a/WS2012R2/lisa/utilFunctions.ps1
+++ b/WS2012R2/lisa/utilFunctions.ps1
@@ -282,13 +282,11 @@ function SetRunningTime([String] $testName, [System.Xml.XmlElement] $vm)
         SetRunningTime $testName $vm
     #>
     LogMsg 6 ("Info :    SetRunningTime($testName)")
-
     $caseEndTime = [DateTime]::Now
     $deltaTime = $caseEndTime - [DateTime]::Parse($vm.caseStartTime)
     LogMsg 0 "Info : $($vm.vmName) currentTest lasts $($deltaTime.hours) Hours, $($deltaTime.minutes) Minutes, $($deltaTime.seconds) seconds."
 
     $runningTime = "{0:N2}" -f $deltaTime.TotalMinutes
-
     foreach ($testCase in $testResult.testsuite.testcase)
     {
         if ($testCase.name -eq $testName)


### PR DESCRIPTION
…or pretest failed

Mainly fix two issues:
1) when setup or pretest case failed, before cannot save result to xml, change original "Failed" to "Aborted" in output log.
2) change the time output, before if noReboot set as true, there is no time information output in xml result.