### PR TITLE
Update Hyperv_Daemons_File_Status by removing multi-user.target.wants

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
@@ -124,10 +124,9 @@ CheckHypervDaemons()
 CheckDaemonsFilesRHEL7()
 {
   dameonFile=`ls /usr/lib/systemd/system | grep -i $1`
-  dameonFile2=`ls /etc/systemd/system/multi-user.target.wants | grep -i $1`
-  if [[ "$dameonFile" != $1 ]] || [[ "$dameonFile2" != $1 ]] ; then
-    LogMsg "ERROR: $1 is not in /usr/lib/systemd/system or /etc/systemd/system/multi-user.target.wants , test failed"
-    UpdateSummary "ERROR: $1 is not in /usr/lib/systemd/system or /etc/systemd/system/multi-user.target.wants , test failed"
+  if [[ "$dameonFile" != $1 ]] ; then
+    LogMsg "ERROR: $1 is not in /usr/lib/systemd/system, test failed"
+    UpdateSummary "ERROR: $1 is not in /usr/lib/systemd/system, test failed"
     UpdateTestState $ICA_TESTFAILED
     exit 1
   fi


### PR DESCRIPTION
After rhel7.3 release with hyperv-daemons version hyperv-daemons-0-0.29.20160216git.el7.x86_64, there are no related hypervkvpd, hypervfcopyd, hypervvssd service files under /etc/systemd/system/multi-user.target.wants, also due to no impact on older versions,  directly remove service check under multi-user.target.wants folder.
Thank you.