### PR TITLE
Added additional check on NET_Hang_Vxlan.ps1

### DIFF
--- a/WS2012R2/lisa/setupscripts/NET_Hang_Vxlan.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_Hang_Vxlan.ps1
@@ -233,6 +233,13 @@ if ((($majorVersion -le 6) -and ($minorVersion -le 4)) -or $majorVersion -le 5) 
     return $false    
 }
 
+$kernel = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "uname -a | grep 'i686\|i386'"
+if( $kernel.Contains("i686") `
+    -or $kernel.Contains("i386")){
+        Write-Output "Info: Vxlan not supported on 32 bit OS"  | Tee-Object -Append -file $summaryLog
+        return $Skipped
+}
+
 if ($isDynamic -eq $true){
     $vm1MacAddress = $streamReader.ReadLine()
     $streamReader.close()


### PR DESCRIPTION
Given that vxlan is not supported on 32 bit OS, test script will now
check for 32 bit guest. If the test VM is 32bit, TC will enter Test
Skipped state.