### PR TITLE
Combine NMI_Send_Interrupt to NMI_Verify_Interrupt and update NMI_Verify_Interrupt

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/nmi_verify_interrupt.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/nmi_verify_interrupt.sh
@@ -31,7 +31,8 @@
 #	The test performs the following steps:
 #	 1. Make sure we have a constants.sh file.
 #	 2. Looks for the NMI property of each CPU.
-#	 3. Verifies if each CPU has received a NMI.
+#	 3. For 2012R2, verifies if each CPU has received a NMI.
+#  4. For 2016, verifies only cpu0 has received a NMI.
 #
 #	 To pass test parameters into test cases, the host will create
 #	 a file named constants.sh.  This file contains one or more
@@ -39,57 +40,16 @@
 #
 ################################################################
 
-ICA_TESTRUNNING="TestRunning"      # The test is running
-ICA_TESTCOMPLETED="TestCompleted"  # The test completed successfully
-ICA_TESTABORTED="TestAborted"      # Error during setup of test
-ICA_TESTFAILED="TestFailed"        # Error during execution of test
-
-CONSTANTS_FILE="constants.sh"
-
-LogMsg()
-{
-    echo `date "+%a %b %d %T %Y"` : ${1}    # To add the timestamp to the log file
+dos2unix utils.sh
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 1
 }
 
-UpdateTestState()
-{
-    echo $1 > $HOME/state.txt
-}
-
-#
-# Update LISA with the current status
-#
-cd ~
-UpdateTestState $ICA_TESTRUNNING
-LogMsg "Updating test case state to running"
-
-#
-# Source the constants file
-#
-if [ -e ./${CONSTANTS_FILE} ]; then
-    source ${CONSTANTS_FILE}
-else
-    msg="Error: no ${CONSTANTS_FILE} file"
-    LogMsg $msg
-    echo $msg >> ~/summary.log
-    UpdateTestState $ICA_TESTABORTED
-    exit 10
-fi
-
-if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
-    rm -rf ~/summary.log
-fi
-
-#
-# Identifying the test-case ID
-#
-if [ ! ${TC_COVERED} ]; then
-    LogMsg "The TC_COVERED variable is not defined."
-    echo "The TC_COVERED variable is not defined." >> ~/summary.log
-fi
-
-echo "This script covers test case: ${TC_COVERED}" >> ~/summary.log
+# Source constants file and initialize most common variables
+UtilsInit
 
 #
 # Getting the CPUs NMI property count
@@ -111,27 +71,31 @@ do
             nmiCount=`echo $line | cut -f $(( $i+2 )) -d ' '`
             LogMsg "CPU ${i} interrupt count = ${nmiCount}"
 
-            # only not CPU0 and 2016 should not receive NMI
-            if [ $i -eq 0 ] || [ $BuildNumber -lt 14393 ]; then
+            # CPU0 or 2012R2(14393 > BuildNumber >= 9600) all CPUs should receive NMI
+            if [ $i -eq 0 ] || ([ $BuildNumber -lt 14393 ] && [ $BuildNumber -ge 9600 ]); then
                 if [ $nmiCount -ne 0 ]; then
                     LogMsg "Info: NMI received at CPU ${i}"
                     echo "Info: NMI received at CPU ${i}" >> ~/summary.log
                 else
                     LogMsg "Error: CPU {$i} did not receive a NMI!"
                     echo "Error: CPU {$i} did not receive a NMI!" >> ~/summary.log
-                    UpdateTestState $ICA_TESTFAILED
+                    SetTestStateFailed
                     exit 10
                 fi
-            else
+            # only not CPU0 and 2016 (BuildNumber >= 14393) should not receive NMI
+            elif [ $BuildNumber -ge 14393 ]; then
                 if [ $nmiCount -eq 0 ]; then
                     LogMsg "Info: CPU {$i} did not receive a NMI, this is expected"
                     echo "Info: CPU {$i} did not receive a NMI, this is expected" >> ~/summary.log
                 else
                     LogMsg "Error: CPU {$i} received a NMI!"
                     echo "Error: CPU {$i} received a NMI!" >> ~/summary.log
-                    UpdateTestState $ICA_TESTFAILED
+                    SetTestStateFailed
                     exit 10
                 fi
+            # lower than 9600, return skipped
+            else
+                SetTestStateSkipped
             fi
 
         done
@@ -139,5 +103,5 @@ do
 done < "/proc/interrupts"
 
 LogMsg "Test completed successfully"
-UpdateTestState "TestCompleted"
+SetTestStateCompleted
 exit 0

--- a/WS2012R2/lisa/setupscripts/NMI_Verify_Interrupt.ps1
+++ b/WS2012R2/lisa/setupscripts/NMI_Verify_Interrupt.ps1
@@ -208,11 +208,6 @@ if ($BuildNumber -eq 0)
 {
     return $false
 }
-# not supported if host is 2012 and 2008
-if ($BuildNumber -lt 9600)
-{
-    return $Skipped
-}
 
 $retVal = SendCommandToVM $ipv4 $sshkey "echo BuildNumber=$BuildNumber >> /root/constants.sh"
 if (-not $retVal[-1]){

--- a/WS2012R2/lisa/setupscripts/NMI_Verify_Interrupt.ps1
+++ b/WS2012R2/lisa/setupscripts/NMI_Verify_Interrupt.ps1
@@ -24,10 +24,10 @@
 	Sends a NMI to a given VM by using the Debug-VM cmdlet
 
 .Description
-	The script will send a NMI to the specific VM. Script must be executed 
-	under PowerShell running with Administrator rights, unprivileged user 
+	The script will send a NMI to the specific VM. Script must be executed
+	under PowerShell running with Administrator rights, unprivileged user
 	can not send the NMI to VM.
-	This must be used along with the nmi_verify_interrupt.sh bash script to 
+	This must be used along with the nmi_verify_interrupt.sh bash script to
 	check if the NMI is successfully detected by the Linux guest VM.
 
 	The test case definition for this test case would look similar to:
@@ -42,7 +42,7 @@
             </testParams>
             <noReboot>True</noReboot>
         </test>
-		
+
 	<test>
             <testName>NMI_Verify_Interrupt</testName>
             <testScript>nmi_verify_interrupt.sh</testScript>
@@ -103,14 +103,22 @@ $params = $testParams.Split(";")
 foreach ($p in $params)
 {
     $fields = $p.Split("=")
-    
+
     if ($fields[0].Trim() -eq "TC_COVERED")
     {
         $TC_COVERED = $fields[1].Trim()
     }
-     if ($fields[0].Trim() -eq "rootDir")
-    {
+    if ($fields[0].Trim() -eq "ipv4") {
+        $ipv4 = $fields[1].Trim()
+    }
+    if ($fields[0].Trim() -eq "rootDir") {
         $rootDir = $fields[1].Trim()
+    }
+    if ($fields[0].Trim() -eq "sshkey") {
+        $sshkey = $fields[1].Trim()
+    }
+    if ($fields[0].Trim() -eq "TestLogDir") {
+        $TestLogDir = $fields[1].Trim()
     }
 }
 
@@ -182,4 +190,44 @@ else
     $retVal = $false
 }
 
-return $retval
+# Source TCUtils.ps1 for test related functions
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    LogMsg 0 "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# get host build number
+$BuildNumber = GetHostBuildNumber $hvServer
+
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+# not supported if host is 2012 and 2008
+if ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
+
+$retVal = SendCommandToVM $ipv4 $sshkey "echo BuildNumber=$BuildNumber >> /root/constants.sh"
+if (-not $retVal[-1]){
+    Write-Output "Error: Could not echo BuildNumber=$BuildNumber to vm's constants.sh."
+    return $false
+}
+
+$retVal = RunRemoteScript nmi_verify_interrupt.sh
+if( $retVal[-1] )
+{
+    Write-output "Info: Verify NMI on VM $vmName successfully" | Tee-Object -Append -file $summaryLog
+    return $true
+}
+else
+{
+    Write-output "Error: Verify NMI on VM $vmName failed" | Tee-Object -Append -file $summaryLog
+    return $false
+}

--- a/WS2012R2/lisa/xml/NMI_Tests.xml
+++ b/WS2012R2/lisa/xml/NMI_Tests.xml
@@ -68,6 +68,7 @@
             <testName>NMI_Verify_Interrupt</testName>
             <testScript>setupscripts\NMI_Verify_Interrupt.ps1</testScript>
             <files>remote-scripts\ica\nmi_verify_interrupt.sh</files>
+            <files>remote-scripts/ica/utils.sh</files>
             <timeout>300</timeout>
             <RevertDefaultSnapshot>True</RevertDefaultSnapshot>
             <onError>Continue</onError>

--- a/WS2012R2/lisa/xml/NMI_Tests.xml
+++ b/WS2012R2/lisa/xml/NMI_Tests.xml
@@ -66,7 +66,7 @@
 
         <test>
             <testName>NMI_Verify_Interrupt</testName>
-            <testScript>setupscripts\NMI_Send_Interrupt.ps1</testScript>
+            <testScript>setupscripts\NMI_Verify_Interrupt.ps1</testScript>
             <files>remote-scripts\ica\nmi_verify_interrupt.sh</files>
             <timeout>300</timeout>
             <RevertDefaultSnapshot>True</RevertDefaultSnapshot>

--- a/WS2012R2/lisa/xml/NMI_Tests.xml
+++ b/WS2012R2/lisa/xml/NMI_Tests.xml
@@ -45,7 +45,7 @@
         <suite>
             <suiteName>NMI</suiteName>
             <suiteTests>
-                <suiteTest>NMI_Send_Interrupt</suiteTest>
+                <!-- <suiteTest>NMI_Send_Interrupt</suiteTest> -->
                 <suiteTest>NMI_Verify_Interrupt</suiteTest>
                 <suiteTest>NMI_different_vmStates</suiteTest>
             </suiteTests>
@@ -53,7 +53,7 @@
     </testSuites>
 
     <testCases>
-        <test>
+        <!-- <test>
             <testName>NMI_Send_Interrupt</testName>
             <testScript>setupscripts\NMI_Send_Interrupt.ps1</testScript>
             <timeout>300</timeout>
@@ -62,20 +62,21 @@
             <testParams>
                 <param>TC_COVERED=NMI-01a</param>
             </testParams>
-        </test>
+        </test> -->
 
         <test>
             <testName>NMI_Verify_Interrupt</testName>
-            <testScript>nmi_verify_interrupt.sh</testScript>
+            <testScript>setupscripts\NMI_Send_Interrupt.ps1</testScript>
             <files>remote-scripts\ica\nmi_verify_interrupt.sh</files>
             <timeout>300</timeout>
+            <RevertDefaultSnapshot>True</RevertDefaultSnapshot>
             <onError>Continue</onError>
             <noReboot>False</noReboot>
             <testParams>
-                <param>TC_COVERED=NMI-01b</param>
+                <param>TC_COVERED=NMI-01</param>
             </testParams>
         </test>
-		
+
         <test>
             <testName>NMI_different_vmStates</testName>
             <testScript>setupscripts\NMI_different_vmStates.ps1</testScript>


### PR DESCRIPTION
Refer to http://driverdev.linuxdriverproject.org/pipermail/driverdev-devel/2016-November/097202.html:
Prior to WS2016 the NMI is injected to all CPUs of the guest and WS2016 injects it to CPU0 only.

Update:
1. Remove NMI_Send_Interrupt, combine it to NMI_Verify_Interrupt
2. When host version is older than WS2012R2, return skipped
3. When host version is WS2012R2, check the NMI is injected to all CPUs of the guest
4. When host version is WS2016, check the NMI is only injected to CPU0