### PR TITLE
Add Stor VHDXResize skipped if host version lower than 9600

### DIFF
--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
@@ -151,6 +151,18 @@ else
     return $false
 }
 
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
+
 if ( $controllerType -eq "IDE" )
 {
     $vmGeneration = GetVMGeneration $vmName $hvServer

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_DiskOver2TB.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_DiskOver2TB.ps1
@@ -135,6 +135,28 @@ else
     cd $rootDir
 }
 
+# Source TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
+
 # Source STOR_VHDXResize_Utils.ps1
 if (Test-Path ".\setupScripts\STOR_VHDXResize_Utils.ps1")
 {
@@ -147,6 +169,8 @@ else
 }
 
 Write-Output "Covers: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+
 
 #
 # Convert the new size

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowFS.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowFS.ps1
@@ -137,6 +137,27 @@ else
 {
     cd $rootDir
 }
+# Source TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1")
+{
+    . .\setupScripts\TCUtils.ps1
+}
+else
+{
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
 
 # Source STOR_VHDXResize_Utils.ps1
 if (Test-Path ".\setupScripts\STOR_VHDXResize_Utils.ps1")

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
@@ -156,6 +156,18 @@ else
     return $False
 }
 
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
+
 if ( $controllerType -eq "IDE" )
 {
     $vmGeneration = GetVMGeneration $vmName $hvServer


### PR DESCRIPTION
Add skipped if host version is lower than 2012R2, even already have <dependency> in the case STOR_VHDXResize.xml file, currently it cannot return skip, locally(downstream) we run same xml file for all the cases, so open this pull request.

Thank you