### PR TITLE
Fix GetVMGeneration method

### DIFF
--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1551,7 +1551,7 @@ function GetVMGeneration([String] $vmName, [String] $hvServer)
     $vmInfo = Get-VM -Name $vmName -ComputerName $hvServer
 
     # Hyper-V Server 2012 (no R2) only supports generation 1 VM
-    if ( $vmInfo.Generation -eq "")
+    if (!$vmInfo.Generation)
     {
         $vmGeneration = 1
     }


### PR DESCRIPTION
GetVMGeneration method was not returning a value on WS2012 and some
Storage tests used to fail because of that.