### PR TITLE
Skip hypervvssd and hypervfcopyd check for hyperv 2012 host

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
@@ -84,37 +84,46 @@ LinuxRelease()
 }
 
 #######################################################################
-# Check hyper-daemons default files and service status
+# Check hyper-daemons default files and service status.
+# If BuildNumber < 9600, hypervvssd and hypervfcopyd service are inactive,
+# only check hypervkvpd
 #######################################################################
 CheckHypervDaemons()
 {
+    if [ $BuildNumber -lt 9600 ];then
+        hv=('hypervkvpd')
+        hv_alias=('[h]v_kvp_daemon')
+        hv_service=("hypervkvpd.service")
+    else
         hv=('hypervvssd' 'hypervkvpd' 'hypervfcopyd')
         hv_alias=('[h]v_vss_daemon' '[h]v_kvp_daemon' '[h]v_fcopy_daemon')
         hv_service=("hypervkvpd.service" "hypervvssd.service" "hypervfcopyd.service")
-        # Start the hyperv daemons check. This is distro-specific.
-        case $(LinuxRelease) in
-        "RHEL6" | "CENTOS6")
+    fi
+    len_hv=${#hv_service[@]}
+    # Start the hyperv daemons check. This is distro-specific.
+    case $(LinuxRelease) in
+    "RHEL6" | "CENTOS6")
 
-            for (( i=0; i<=2; i++))
-            do
-                CheckDaemonsFilesRHEL6 ${hv_service[$i]}
-                CheckDaemonsStatus ${hv[$i]} ${hv_alias[$i]}
-            done
-            ;;
-        "RHEL7" | "CENTOS7")
-            for (( i=0; i<=2; i++))
-            do
-              CheckDaemonsFilesRHEL7 ${hv_service[$i]}
-              CheckDaemonsStatusRHEL7 ${hv_service[$i]}
-            done
-            ;;
-        *)
-            LogMsg "Distro not supported"
-            UpdateTestState "TestAborted"
-            UpdateSummary "Distro not supported, test aborted"
-            exit 1
+        for (( i=0; i<$len_hv; i++))
+        do
+            CheckDaemonsFilesRHEL6 ${hv_service[$i]}
+            CheckDaemonsStatus ${hv[$i]} ${hv_alias[$i]}
+        done
         ;;
-        esac
+    "RHEL7" | "CENTOS7")
+        for (( i=0; i<$len_hv; i++))
+        do
+          CheckDaemonsFilesRHEL7 ${hv_service[$i]}
+          CheckDaemonsStatusRHEL7 ${hv_service[$i]}
+        done
+        ;;
+    *)
+        LogMsg "Distro not supported"
+        UpdateTestState "TestAborted"
+        UpdateSummary "Distro not supported, test aborted"
+        exit 1
+    ;;
+    esac
 }
 
 #######################################################################

--- a/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
@@ -24,7 +24,7 @@ ICA_TESTRUNNING="TestRunning"
 ICA_TESTCOMPLETED="TestCompleted"
 ICA_TESTABORTED="TestAborted"
 ICA_TESTFAILED="TestFailed"
-
+ICA_TESTSKIPPED="TestSkipped"
 #######################################################################
 # Adds a timestamp to the log file
 #######################################################################
@@ -117,10 +117,16 @@ CheckHypervDaemons()
           CheckDaemonsStatusRHEL7 ${hv_service[$i]}
         done
         ;;
+    "FEDORA")
+            for (( i=0; i<$len_hv; i++))
+            do
+              CheckDaemonsStatusRHEL7 ${hv_service[$i]}
+            done
+            ;;
     *)
         LogMsg "Distro not supported"
-        UpdateTestState "TestAborted"
-        UpdateSummary "Distro not supported, test aborted"
+        UpdateTestState $ICA_TESTSKIPPED
+        UpdateSummary "Distros not supported, test skipped"
         exit 1
     ;;
     esac
@@ -148,6 +154,7 @@ CheckDaemonsFilesRHEL7()
     exit 1
   fi
 }
+
 
 #######################################################################
 # Check hyper-v daemons related file under default folder for rhel 6

--- a/WS2012R2/lisa/setupscripts/Hyperv_Daemons_Basic.ps1
+++ b/WS2012R2/lisa/setupscripts/Hyperv_Daemons_Basic.ps1
@@ -178,13 +178,7 @@ if (-not $retVal[-1]){
     Write-Output "Error: Could not echo BuildNumber=$BuildNumber to vm's constants.sh."
     return $False
 }
+
 $remoteScript = "Hyperv_Daemons_Files_Status.sh"
 $sts = RunRemoteScript $remoteScript
-if (-not $sts[-1])
-{
-		Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
-		Write-Output "ERROR: Running $remoteScript script failed on VM!"
-		return $False
-}
-
-return $True
+return $sts[-1]

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1111,6 +1111,7 @@ function RunRemoteScript($remoteScript)
                     if ($contents -eq $TestAborted)
                     {
                          Write-Output "Info : State file contains TestAborted message."
+                         $retValue = $Aborted
                          break
                     }
                     if ($contents -eq $TestFailed)
@@ -1120,6 +1121,7 @@ function RunRemoteScript($remoteScript)
                     }
                     if ($contents -eq $TestSkipped)
                     {
+                        $retValue = $Skipped
                         Write-Output "Info : State file contains TestSkipped message."
                         break
                     }
@@ -1672,7 +1674,7 @@ function AskVmForTime([String] $sshKey, [String] $ipv4, [string] $command)
     $retVal = $null
 
     $sshKeyPath = Resolve-Path $sshKey
-    
+
     #
     # Note: We did not use SendCommandToVM since it does not return
     #       the output of the command.
@@ -1733,7 +1735,7 @@ function GetUnixVMTime([String] $sshKey, [String] $ipv4)
     {
         return $null
     }
-    
+
     return $unixTimeStr
 }
 
@@ -1832,6 +1834,6 @@ function CheckVMState([String] $vmName, [String] $hvServer)
 {
     $vm = Get-Vm -VMName $vmName -ComputerName $hvServer
     $vmStatus = $vm.state
-    
+
     return $vmStatus
 }


### PR DESCRIPTION
Hyper-v 2012 host does not support backup and fcopy feature, in the vm side, even related file available in the related file, here also ignore check, only verify hypervkvpd status.