### PR TITLE
Updated CopyFileSCP to use dynamic VHDX

### DIFF
--- a/WS2012R2/lisa/xml/NET_Tests.xml
+++ b/WS2012R2/lisa/xml/NET_Tests.xml
@@ -386,14 +386,13 @@ permissions and limitations under the License.
             <testScript>setupscripts\NET_filecopy_scp.ps1</testScript>
             <testParams>
                 <param>TC_COVERED=NET-19</param>
-                <param>SCSI=1,0,Dynamic,512,15GB</param>
-                <param>Type=Fixed</param>
+                <param>Type=Dynamic</param>
                 <param>SectorSize=512</param>
                 <param>DefaultSize=25GB</param>
                 <param>ControllerType=SCSI</param>
             </testParams>
             <cleanupScript>SetupScripts\Remove-VHDXHardDisk.ps1</cleanupScript>
-            <timeout>3000</timeout>
+            <timeout>2400</timeout>
             <onError>Continue</onError>
         </test>
 


### PR DESCRIPTION
Updated CopyFileSCP to use dynamic VHDX instead of fixed VHDX
to reduce pretesting time