### PR TITLE
Skip vmbus panic notifier on older platforms

### DIFF
--- a/WS2012R2/lisa/setupscripts/INST_LIS_TestVMShutdown.ps1
+++ b/WS2012R2/lisa/setupscripts/INST_LIS_TestVMShutdown.ps1
@@ -63,24 +63,6 @@ $testCaseTimeout = 600
 
 #####################################################################
 #
-# CheckVMState()
-#
-#####################################################################
-function CheckVMState([String] $vmName, [String] $newState)
-{
-    $stateChanged = $False
-    
-    $vm = Get-VM $vmName -ComputerName $hvServer    
-    if ($($vm.State.ToString()) -eq $newState)
-    {
-        $stateChanged = $True
-    }
-    
-    return $stateChanged
-}
-
-#####################################################################
-#
 # Main script body
 #
 #####################################################################
@@ -191,10 +173,8 @@ if ($vcpu)
 #
 "Info: Shutting down the VM"
 Stop-VM -Name $vmName -ComputerName $hvServer -Force
-while ($testCaseTimeout -gt 0)
-{
-    if ( (CheckVMState $vmName "Off"))
-    {
+while ($testCaseTimeout -gt 0) {
+    if ((CheckVMState $vmName $hvServer) -eq "Off") {
         break
     }   
 
@@ -202,8 +182,7 @@ while ($testCaseTimeout -gt 0)
     $testCaseTimeout -= 2
 }
 
-if ($testCaseTimeout -eq 0)
-{
+if ($testCaseTimeout -eq 0) {
     "Error: Test case timed out waiting for VM to go to Stopped"
     return $False
 }
@@ -221,10 +200,8 @@ if ($? -ne "True")
     return $False
 }
 
-while ($testCaseTimeout -gt 0)
-{
-    if ( (CheckVMState $vmName "Running"))
-    {
+while ($testCaseTimeout -gt 0) {
+    if ( (CheckVMState $vmName $hvServer) -eq "Running") {
         break
     }   
 
@@ -232,8 +209,7 @@ while ($testCaseTimeout -gt 0)
     $testCaseTimeout -= 2
 }
 
-if ($testCaseTimeout -eq 0)
-{
+if ($testCaseTimeout -eq 0) {
     "Error: Test case timed out for VM to go to Running"
     return $False
 }

--- a/WS2012R2/lisa/setupscripts/VMBus_PanicNotifier.ps1
+++ b/WS2012R2/lisa/setupscripts/VMBus_PanicNotifier.ps1
@@ -125,10 +125,22 @@ $summaryLog  = "${vmName}_summary.log"
 Del $summaryLog -ErrorAction SilentlyContinue
 echo "Covers : ${tcCovered}" >> $summaryLog
 
-#
-# Source the TCUtils.ps1 file
-#
-. .\setupscripts\TCUtils.ps1
+# Source TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+    . .\setupScripts\TCUtils.ps1
+} else {
+    "Error: Could not find setupScripts\TCUtils.ps1"
+}
+
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
+    return $False
+}
+elseif ($BuildNumber -lt 9600) {
+	"Info: Feature supported only on WS2012R2 and newer"
+    return $Skipped
+}
 
 #
 # Ensure required parameters were specified


### PR DESCRIPTION
VMBus panic notifier is supported only on WS2012R2 and newer, exiting
automation with Skip state otherwise