### PR TITLE
CORE: Increase timeout in 'Reboot Different Memory Settings' TC

### DIFF
--- a/WS2012R2/lisa/setupscripts/CORE_RebootDiffMemory.ps1
+++ b/WS2012R2/lisa/setupscripts/CORE_RebootDiffMemory.ps1
@@ -253,7 +253,7 @@ ForEach ($memory in $memArgs)
     #
     # Wait for VM to start ssh
     #
-    $sts = WaitForVMToStartSSH $ipv4 20
+    $sts = WaitForVMToStartSSH $ipv4 60
     if(-not $sts[-1]){
         Write-Output "ERROR: Port 22 not open" | Tee-Object -Append -file $summaryLog
         $retVal = $False


### PR DESCRIPTION
In some cases the 20 seconds timeout was too low, and TC returned false
errors