### PR TITLE
skip state for Production Checkpoint if NA

### DIFF
--- a/WS2012R2/lisa/setupscripts/Production_checkpoint.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint.ps1
@@ -112,8 +112,6 @@ if ($null -eq $rootdir)
     return $False
 }
 
-echo $params
-
 # Change the working directory to where we need to be
 cd $rootDir
 
@@ -122,22 +120,17 @@ Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
-#Check if the host supports production checkpoints
-$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
-if (-not $osInfo)
-{
-    "Error: Unable to collect Operating System information"
+# if host build number lower than 10500, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
     return $False
 }
-
-[System.Int32]$buildNR = $osInfo.BuildNumber
-
-if ($buildNR -le 10500){
-    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
-    return $false
+elseif ($BuildNumber -lt 10500) {
+	"Info: Feature supported only on WS2016 and newer"
+    return $Skipped
 }
 
-# Check if the Vm VHD in not on the same drive as the backup destination
+# Check if the VM VHD in not on the same drive as the backup destination
 $vm = Get-VM -Name $vmName -ComputerName $hvServer
 if (-not $vm)
 {

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_3Chain_VHD.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_3Chain_VHD.ps1
@@ -61,7 +61,7 @@
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
 #######################################################################
-# Fix snapshots. If there are more then 1 remove all except latest.
+# Fix snapshots. If there are more than one, remove all except latest.
 #######################################################################
 function FixSnapshots($vmName, $hvServer)
 {
@@ -240,19 +240,14 @@ Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
-#Check if the host supports production checkpoints
-$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
-if (-not $osInfo)
-{
-    "Error: Unable to collect Operating System information"
+# if host build number lower than 10500, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
     return $False
 }
-
-[System.Int32]$buildNR = $osInfo.BuildNumber
-
-if ($buildNR -le 10500){
-    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
-    return $false
+elseif ($BuildNumber -lt 10500) {
+	"Info: Feature supported only on WS2016 and newer"
+    return $Skipped
 }
 
 # Check if the Vm VHD in not on the same drive as the backup destination

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_ISO_NoNetwork.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_ISO_NoNetwork.ps1
@@ -176,8 +176,6 @@ if ($null -eq $rootdir)
     return $False
 }
 
-echo $params
-
 # Change the working directory to where we need to be
 cd $rootDir
 
@@ -186,19 +184,14 @@ Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
-#Check if the host supports production checkpoints
-$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
-if (-not $osInfo)
-{
-    "Error: Unable to collect Operating System information"
+# if host build number lower than 10500, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
     return $False
 }
-
-[System.Int32]$buildNR = $osInfo.BuildNumber
-
-if ($buildNR -le 10500){
-    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
-    return $false
+elseif ($BuildNumber -lt 10500) {
+	"Info: Feature supported only on WS2016 and newer"
+    return $Skipped
 }
 
 # Check if the Vm VHD in not on the same drive as the backup destination

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_failback.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_failback.ps1
@@ -120,19 +120,14 @@ Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
-#Check if the host supports production checkpoints
-$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
-if (-not $osInfo)
-{
-    "Error: Unable to collect Operating System information"
+# if host build number lower than 10500, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
     return $False
 }
-
-[System.Int32]$buildNR = $osInfo.BuildNumber
-
-if ($buildNR -le 10500){
-    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
-    return $false
+elseif ($BuildNumber -lt 10500) {
+	"Info: Feature supported only on WS2016 and newer"
+    return $Skipped
 }
 
 # Check if the Vm VHD in not on the same drive as the backup destination

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_iSCSI.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_iSCSI.ps1
@@ -117,8 +117,6 @@ if ($null -eq $rootdir)
     return $False
 }
 
-echo $params
-
 # Change the working directory to where we need to be
 cd $rootDir
 
@@ -127,19 +125,14 @@ Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
-#Check if the host supports production checkpoints
-$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
-if (-not $osInfo)
-{
-    "Error: Unable to collect Operating System information"
+# if host build number lower than 10500, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
     return $False
 }
-
-[System.Int32]$buildNR = $osInfo.BuildNumber
-
-if ($buildNR -le 10500){
-    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
-    return $false
+elseif ($BuildNumber -lt 10500) {
+	"Info: Feature supported only on WS2016 and newer"
+    return $Skipped
 }
 
 # Check if the Vm VHD in not on the same drive as the backup destination

--- a/WS2012R2/lisa/setupscripts/Production_checkpoint_partition.ps1
+++ b/WS2012R2/lisa/setupscripts/Production_checkpoint_partition.ps1
@@ -128,19 +128,14 @@ Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
-#Check if the host supports production checkpoints
-$osInfo = GWMI Win32_OperatingSystem -ComputerName $hvServer
-if (-not $osInfo)
-{
-    "Error: Unable to collect Operating System information"
+# if host build number lower than 10500, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0) {
     return $False
 }
-
-[System.Int32]$buildNR = $osInfo.BuildNumber
-
-if ($buildNR -le 10500){
-    Write-Output "ERROR: This Windows Server version doesn't support production checkpoints"
-    return $false
+elseif ($BuildNumber -lt 10500) {
+	"Info: Feature supported only on WS2016 and newer"
+    return $Skipped
 }
 
 # Check if the Vm VHD in not on the same drive as the backup destination


### PR DESCRIPTION
Exit with state Skipped if Production checkpoint automation is ran on
anything older than WS2016