### PR TITLE
DM_CONFIGURE_MEMORY.ps1: Fix set vm memory failed issue; NUMA_off_ker…

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NUMA_off_kernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NUMA_off_kernel.sh
@@ -232,7 +232,7 @@ case $DISTRO in
         ConfigCentos
     ;;
 
-    "redhat_7" | "centos_7")
+    "redhat_7" | "centos_7" | "fedora_x")
         ConfigRhel
     ;;
 


### PR DESCRIPTION
1. Update DM_CONFIGURE_MEMORY.ps1:

- Set vm memory failed, because it can not get vmName from testParams, vmName para already receive the value, so delete tPvmName para

- Add verification after set vm memory

2. NUMA_off_kernel.sh: Add fedora support