### PR TITLE
Added TimeSyncNTP exit condition

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/CORE_TimeSync_NTP.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/CORE_TimeSync_NTP.sh
@@ -250,6 +250,16 @@ while [ $isOver == false ]; do
     delay=$(ntpq -c rl | grep offset= | awk -F "=" '{print $3}' | awk '{print $1}')
     delay=$(echo $delay | sed s'/.$//')
 
+    # If the above value is not a number it means the output is an error message and exit loop
+    re='^-?[0-9]+([.][0-9]+)?$'
+    if ! [[ $delay =~ $re ]] ; then
+        ntpqErr="$(ntpq -c rl 2>&1)"
+        LogMsg "ERROR: ntpq returned $ntpqErr. Aborting test."
+        UpdateTestState $ICA_TESTABORTED
+        isOver=true
+        exit 1
+    fi
+
     # Transform from milliseconds to seconds
     delay=$(echo $delay 1000 | awk '{ print $1/$2 }')
 


### PR DESCRIPTION
In case ntpq command outputs an error, the test will be aborted.