### PR TITLE
NET Max Synthetic NICs - Additional host check added

### DIFF
--- a/WS2012R2/lisa/setupscripts/NET_Add_Max_NIC.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_Add_Max_NIC.ps1
@@ -147,6 +147,10 @@ foreach($p in $params)
 	if ($temp[0].Trim() -eq "SYNTHETIC_NICS")
 	{
 		$syntheticNICs = $temp[1] -as [int]
+		[int]$hostBuildNumber = (Get-WmiObject -class Win32_OperatingSystem -ComputerName $hvServer).BuildNumber
+		if ($hostBuildNumber -le 9200) {
+			[int]$syntheticNICs  = 2
+		}
 	}
 	elseif ($temp[0].Trim() -eq "LEGACY_NICS")
 	{

--- a/WS2012R2/lisa/setupscripts/NET_MAX_NIC.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_MAX_NIC.ps1
@@ -240,6 +240,10 @@ del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "Covers: ${tcCovered}" | Tee-Object -Append -file $summaryLog
 
 "Info : Executing bash script"
+[int]$hostBuildNumber = (Get-WmiObject -class Win32_OperatingSystem -ComputerName $hvServer).BuildNumber
+if ($hostBuildNumber -le 9200) {
+	$sts = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "sed -i 's/NICS=7/NICS=2/g' constants.sh"
+}
 
 $sts = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "dos2unix NET_MAX_NIC.sh 2>/dev/null"
 $sts = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "chmod 755 NET_MAX_NIC.sh 2>/dev/null"


### PR DESCRIPTION
Due to a know issue which is affecting WS 2012, max synthetic NICs is
now limited to 3 NICs on this host version