### PR TITLE
Update STOR_VSS_BackupRestore for hyper-v 2012 host and skip for IDE …

### DIFF
--- a/WS2012R2/lisa/setupscripts/STOR_VSS_3Chain_VHD_backup.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_3Chain_VHD_backup.ps1
@@ -24,20 +24,20 @@
     This script tests VSS backup functionality.
 
 .Description
-    This script will create a new VM with a 3-chained differencing disk 
-    attached based on the source vm vhd/x. 
+    This script will create a new VM with a 3-chained differencing disk
+    attached based on the source vm vhd/x.
     If the source Vm has more than 1 snapshot, they will be removed except
     the latest one. If the VM has no snapshots, the script will create one.
-    After that it will proceed with backup/restore operation. 
-    
-    It uses a second partition as target. 
+    After that it will proceed with backup/restore operation.
+
+    It uses a second partition as target.
 
     Note: The script has to be run on the host. A second partition
-    different from the Hyper-V one has to be available. 
+    different from the Hyper-V one has to be available.
 
     <test>
         <testName>VSS_BackupRestore_3Chain_VHD</testName>
-        <testScript>setupscripts\VSS_3Chain_VHD_backup.ps1</testScript> 
+        <testScript>setupscripts\VSS_3Chain_VHD_backup.ps1</testScript>
         <testParams>
             <param>driveletter=F:</param>
         </testParams>
@@ -77,12 +77,12 @@ function FixSnapshots($vmName, $hvServer)
     # Get latest snapshot
     $latestsnapshot = Get-VMSnapshot -VMName $vmName | sort CreationTime | select -Last 1
     $LastestSnapName = $latestsnapshot.name
-    
+
     # Delete all snapshots except the latest
     if ($snapnumber -gt 1)
     {
         Write-Output "INFO: $vmName has $snapnumber snapshots. Removing all except $LastestSnapName"
-        foreach ($snap in $vmsnapshots) 
+        foreach ($snap in $vmsnapshots)
         {
             if ($snap.id -ne $latestsnapshot.id)
             {
@@ -103,7 +103,7 @@ function FixSnapshots($vmName, $hvServer)
     ElseIf ($snapnumber -eq 0)
     {
         Write-Output "INFO: There are no snapshots for $vmName. Creating one ..."
-        $sts = Checkpoint-VM -VMName $vmName -ComputerName $hvServer 
+        $sts = Checkpoint-VM -VMName $vmName -ComputerName $hvServer
         if (-not $?)
         {
            Write-Output "ERROR: Unable to create snapshot of ${vmName}: `n${sts}"
@@ -139,14 +139,14 @@ $params = $testParams.Split(";")
 foreach ($p in $params)
 {
   $fields = $p.Split("=")
-    
+
   switch ($fields[0].Trim())
     {
     "sshKey" { $sshKey  = $fields[1].Trim() }
     "ipv4"   { $ipv4    = $fields[1].Trim() }
     "rootDir" { $rootDir = $fields[1].Trim() }
     "driveletter" { $driveletter = $fields[1].Trim() }
-     default  {}          
+     default  {}
     }
 }
 
@@ -206,19 +206,29 @@ else {
 	return $false
 }
 
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
 
 $sts = runSetup $vmName $hvServer $driveletter
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
 	return $False
 }
 
 # Stop the running VM so we can create New VM from this parent disk.
 # Shutdown gracefully so we dont corrupt VHD.
-Stop-VM -Name $vmName 
+Stop-VM -Name $vmName
 if (-not $?)
     {
-       Write-Output "Error: Unable to Shut Down VM" 
+       Write-Output "Error: Unable to Shut Down VM"
        return $False
     }
 
@@ -240,13 +250,13 @@ if (-not $sts[-1])
     return $False
 }
 
-# Get Parent VHD 
+# Get Parent VHD
 $ParentVHD = GetParentVHD $vmName $hvServer
 if(-not $ParentVHD)
 {
     "Error: Error getting Parent VHD of VM $vmName"
     return $False
-} 
+}
 
 Write-Output "INFO: Successfully Got Parent VHD"
 
@@ -258,7 +268,7 @@ if(-not $CreateVHD)
 {
     Write-Output "Error: Error Creating Child and Grand Child VHD of VM $vmName"
     return $False
-} 
+}
 
 Write-Output "INFO: Successfully created GrandChild VHD"
 
@@ -266,14 +276,14 @@ Write-Output "INFO: Successfully created GrandChild VHD"
 # New VM is static hardcoded since we do not need it to be dynamic
 $GChildVHD = $CreateVHD
 
-# Get-VM 
+# Get-VM
 $vm = Get-VM -Name $vmName -ComputerName $hvServer
 
 # Get the VM Network adapter so we can attach it to the new VM
 $VMNetAdapter = Get-VMNetworkAdapter $vmName
 if (-not $?)
     {
-       Write-Output "Error: Get-VMNetworkAdapter" 
+       Write-Output "Error: Get-VMNetworkAdapter"
        return $false
     }
 
@@ -283,7 +293,7 @@ $vm_gen = $vm.Generation
 $newVm = New-VM -Name $vmName1 -VHDPath $GChildVHD -MemoryStartupBytes 1024MB -SwitchName $VMNetAdapter[0].SwitchName -Generation $vm_gen
 if (-not $?)
     {
-       Write-Output "Error: Creating New VM" 
+       Write-Output "Error: Creating New VM"
        return $False
     }
 
@@ -302,7 +312,7 @@ echo "Successfully created new 3 Chain VHD VM $vmName1" >> $summaryLog
 Write-Output "INFO: New 3 Chain VHD VM $vmName1 created"
 
 $timeout = 600
-$sts = Start-VM -Name $vmName1 -ComputerName $hvServer 
+$sts = Start-VM -Name $vmName1 -ComputerName $hvServer
 $logMsg = Get-VM -Name $vmName1
 Write-Output $logMsg
 if (-not (WaitForVMToStartKVP $vmName1 $hvServer $timeout ))
@@ -316,7 +326,7 @@ Write-Output "INFO: New VM $vmName1 started"
 echo "`n"
 
 $sts = startBackup $vmName1 $driveletter
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
 	Write-Output "INFO: Failed backup"
 	return $False
@@ -325,19 +335,19 @@ if (-not $sts[-1])
 }
 
 $sts = restoreBackup $backupLocation
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
 	Write-Output "INFO: Failed restore"
 	return $False
 }
 
 $sts = checkResults $vmName1 $hvServer
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
 	Write-Output "INFO: Failed result"
 	$retVal = $False
 }
-else 
+else
 {
 	$retVal = $True
     $results = $sts
@@ -352,7 +362,7 @@ if (-not $?)
        $retVal= $False
     }
 
-Write-Output "INFO: New VM's IP is $ipv4" 
+Write-Output "INFO: New VM's IP is $ipv4"
 
 
 
@@ -361,18 +371,18 @@ Write-Output "INFO: Test ${results}"
 $sts = Stop-VM -Name $vmName1 -TurnOff
 if (-not $?)
     {
-       Write-Output "Error: Unable to Shut Down VM $vmName1" 
-       
+       Write-Output "Error: Unable to Shut Down VM $vmName1"
+
     }
 
 runCleanup $backupLocation
 
-# Clean Delete New VM created 
+# Clean Delete New VM created
 $sts = Remove-VM -Name $vmName1 -Confirm:$false -Force
 if (-not $?)
 {
-    Write-Output "Error: Deleting New VM $vmName1"  
-} 
+    Write-Output "Error: Deleting New VM $vmName1"
+}
 
 Write-Output "INFO: Deleted VM $vmName1"
 

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_DiskStress.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_DiskStress.ps1
@@ -24,19 +24,19 @@
     This script tests VSS backup functionality.
 
 .Description
-    This script will push VSS_Disk_Stress.sh script to the vm. 
-    While the script is running it will perform the backup/restore operation. 
-    
-    It uses a second partition as target. 
+    This script will push VSS_Disk_Stress.sh script to the vm.
+    While the script is running it will perform the backup/restore operation.
+
+    It uses a second partition as target.
 
     Note: The script has to be run on the host. A second partition
-    different from the Hyper-V one has to be available. 
+    different from the Hyper-V one has to be available.
 
     A typical xml entry looks like this:
 
     <test>
     <testName>VSS_BackupRestore_DiskStress</testName>
-        <testScript>setupscripts\VSS_BackupRestore_DiskStress.ps1</testScript> 
+        <testScript>setupscripts\VSS_BackupRestore_DiskStress.ps1</testScript>
         <testParams>
             <param>driveletter=F:</param>
             <param>iOzoneVers=3_424</param>
@@ -45,8 +45,8 @@
         <timeout>1200</timeout>
         <OnERROR>Continue</OnERROR>
     </test>
-    
-    The iOzoneVers param is needed for the download of the correct iOzone version. 
+
+    The iOzoneVers param is needed for the download of the correct iOzone version.
 
 .Parameter vmName
     Name of the VM to backup/restore.
@@ -67,10 +67,10 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 $retVal = $false
 $remoteScript = "STOR_VSS_Disk_Stress.sh"
 
-####################################################################### 
-# 
-# Main script body 
-# 
+#######################################################################
+#
+# Main script body
+#
 #######################################################################
 
 # Check input arguments
@@ -95,7 +95,7 @@ foreach ($p in $params)
         "driveletter" { $driveletter = $fields[1].Trim() }
         "iOzoneVers" { $iOzoneVers = $fields[1].Trim() }
         "TestLogDir" { $TestLogDir = $fields[1].Trim() }
-        default  {}          
+        default  {}
         }
 }
 
@@ -163,9 +163,19 @@ else {
 	"Error: Could not find setupScripts\STOR_VSS_Utils.ps1"
 	return $false
 }
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
 
 $sts = runSetup $vmName $hvServer $driveletter
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
     return $False
 }
@@ -188,7 +198,7 @@ if (-not $sts[-1])
 {
     return $False
 }
-else 
+else
 {
     $backupLocation = $sts
 }
@@ -202,11 +212,11 @@ if (-not $sts[-1])
 }
 
 $sts = checkResults $vmName $hvServer
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
     $retVal = $False
-} 
-else 
+}
+else
 {
 	$retVal = $True
     $results = $sts

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_ISCSI.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_ISCSI.ps1
@@ -25,18 +25,18 @@
 
 .Description
     This script will connect to a iSCSI target, format and mount the iSCSI disk.
-    After that it will proceed with backup/restore operation. 
-    
-    It uses a second partition as target. 
+    After that it will proceed with backup/restore operation.
+
+    It uses a second partition as target.
 
     Note: The script has to be run on the host. A second partition
-    different from the Hyper-V one has to be available. 
+    different from the Hyper-V one has to be available.
 
     A typical xml entry looks like this:
 
     <test>
         <testName>VSS_BackupRestore_ISCSI</testName>
-        <testScript>setupscripts\VSS_BackupRestore_ISCSI.ps1</testScript> 
+        <testScript>setupscripts\VSS_BackupRestore_ISCSI.ps1</testScript>
         <testParams>
             <param>driveletter=F:</param>
             <param>TargetIP=10.7.1.10</param>
@@ -65,10 +65,10 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 $retVal = $false
 $remoteScript = "STOR_VSS_ISCSI_PartitionDisks.sh"
 
-####################################################################### 
-# 
-# Main script body 
-# 
+#######################################################################
+#
+# Main script body
+#
 #######################################################################
 
 # Check input arguments
@@ -94,7 +94,7 @@ foreach ($p in $params)
         "FILESYS" { $FILESYS = $fields[1].Trim() }
         "TargetIP" { $TargetIP = $fields[1].Trim() }
         "TestLogDir" { $TestLogDir = $fields[1].Trim() }
-        default  {}          
+        default  {}
         }
 }
 
@@ -164,9 +164,19 @@ else {
 	return $false
 }
 
+# if host build number lower than 9600, skip test
+$BuildNumber = GetHostBuildNumber $hvServer
+if ($BuildNumber -eq 0)
+{
+    return $false
+}
+elseif ($BuildNumber -lt 9600)
+{
+    return $Skipped
+}
 
 $sts = runSetup $vmName $hvServer $driveletter
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
     return $False
 }
@@ -201,7 +211,7 @@ if (-not $sts[-1])
 {
     return $False
 }
-else 
+else
 {
     $backupLocation = $sts
 }
@@ -213,11 +223,11 @@ if (-not $sts[-1])
 }
 
 $sts = checkResults $vmName $hvServer
-if (-not $sts[-1]) 
+if (-not $sts[-1])
 {
     $retVal = $False
-} 
-else 
+}
+else
 {
 	$retVal = $True
     $results = $sts


### PR DESCRIPTION
…on gen2

Update STOR_VSS_BackupRestore for skip IDE when testing on Gen2 and skip for 2012 host. Even has xml config about dependency hostVersion config, locally we run all the cases in one xml, need to update script to make it independently.

Hi Chris,
Before we cannot run successfully on Hyper-V 2012R2 host, since after vm restore, it cannot be stopped normally,  refer to bug https://bugzilla.redhat.com/show_bug.cgi?id=1304248. It is so great latest backup script can run successfully on 2012R2 host, could you please share how it works? I did not find any clue from test script yet.