### PR TITLE
VLAN Trunking: Added skipped state for RHEL/CentOS 6.6 and lower

### DIFF
--- a/WS2012R2/lisa/setupscripts/NET_VLAN_TRUNKING.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_VLAN_TRUNKING.ps1
@@ -638,6 +638,15 @@ $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
+#
+# Check if the distro version is unsupported
+#
+$sts = SendCommandToVM $ipv4 $sshKey "cat /etc/redhat-release | grep -v '7.\|6.[7-9]'"
+if ($sts[-1]){
+    Write-Output "VLAN Trunking is not supported on RHEL/CentOS 6.x and below" | Tee-Object -Append -file $summaryLog
+    return $Skipped    
+}
+
 #set the parameter for the snapshot
 $snapshotParam = "SnapshotName = ${SnapshotName}"
 


### PR DESCRIPTION
We will now skip VLAN Trunking TC on RHEL/CentOS 6.6 and lower because
the feature is unsupported