### PR TITLE
NUMA_off_kernel.sh: update rhel grub2 config file

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NUMA_off_kernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NUMA_off_kernel.sh
@@ -62,6 +62,7 @@ ConfigRhel()
             fi
             grub2-mkconfig -o /boot/grub2/grub.cfg
         elif [ $VmGeneration -eq 2 ]; then
+	    grub_file=$(find /boot/efi -name grub.cfg)
             LogMsg "Update RHEL7 Gen$VmGeneration grub"
             sed -i '/^GRUB_CMDLINE_LINUX=/ s/"$/ numa=off"/' /etc/default/grub
             if [ $? -ne 0 ]; then
@@ -73,7 +74,7 @@ ConfigRhel()
                 LogMsg "Success: added the 'numa=off' value."
                 UpdateSummary "Success: added the 'numa=off' value."
             fi
-            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+            grub2-mkconfig -o $grub_file
         else
             LogMsg "FAILED: Could not find VmGeneration variable."
             UpdateSummary "FAILED: Could not find VmGeneration variable."


### PR DESCRIPTION
Fix a minor bug:

The grub2 config file on gen2 for fedora is  /boot/efi/EFI/fedora/grub.cfg, so make the config file as a variable