### PR TITLE
Dynamic Memory: Setupscript fix

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_CONFIGURE_MEMORY.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_CONFIGURE_MEMORY.ps1
@@ -123,6 +123,11 @@ foreach ($p in $params)
         continue
     }
 
+    if ($temp[0].Trim() -eq "vmName")
+    {
+       $vmName = $temp[1]
+    }
+
     if($temp[0].Trim() -eq "enableDM")
     {
 


### PR DESCRIPTION
DM_CONFIGURE_MEMORY.ps1 was not setting DM values on dependency VMs  and
this caused most of the tests to fail.