### PR TITLE
SR-IOV: New TC - Max NICs with Max vCPUs

### DIFF
--- a/WS2012R2/lisa/xml/SR-IOV.xml
+++ b/WS2012R2/lisa/xml/SR-IOV.xml
@@ -74,6 +74,7 @@
                 <suiteTest>Multiple_basic</suiteTest>
                 <suiteTest>Multiple_fileCopy</suiteTest>
                 <suiteTest>MaxNICS</suiteTest>
+                <suiteTest>MaxNICS_vCPU</suiteTest>
 
                 <!-- Pause/Save VM tests with Single/Multiple NICs -->
                 <suiteTest>Single_PauseVM</suiteTest>
@@ -476,6 +477,26 @@
                 <param>TC_COVERED=SRIOV-26</param>
                 <param>MAX_NICS=yes</param>
                 <param>Clean_Dependency=yes</param>
+            </testParams>
+            <timeout>1600</timeout>
+        </test>
+
+        <test>
+            <testName>MaxNICS_vCPU</testName>
+            <testScript>SR-IOV_MaxNIC.sh</testScript>
+            <files>remote-scripts/ica/SR-IOV_MaxNIC.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+                <file>setupscripts\SR-IOV_enable.ps1</file>
+            </setupScript> 
+            <noReboot>False</noReboot>
+            <testParams>
+                <param>TC_COVERED=SRIOV-26B</param>
+                <param>MAX_NICS=yes</param>
+                <param>Clean_Dependency=yes</param>
+                <!-- This is based on the physical CPU hardware topology -->
+                <param>numaNodes=36</param>
             </testParams>
             <timeout>1600</timeout>
         </test>


### PR DESCRIPTION
Due to an issue showing up on SR-IOV when using a VM with 32+ vCPUs and
7 SR-IOV NICs, we're adding a new TC for this particular case.

-Create a Linux VM and configure it with the Max number of synthetic NICs
(7 NICs) and Max number of vCPUs allowed by host/vm generation.
-Configure SR-IOV on each NIC.
-Verify network connectivity over each SR-IOV device.