### PR TITLE
Add vssd disable enable vssd

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/STOR_VSS_Set_VSS_Daemon.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_VSS_Set_VSS_Daemon.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+	SetTestStateAborted
+    exit 1
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+# Create the state.txt file so ICA knows we are running
+SetTestStateRunning
+# Set default service name
+serviceName="hypervvssd"
+
+if [[ $serviceAction == "start" ]] || [[ $serviceAction == "stop" ]]; then
+    LogMsg "Info: service action is $action"
+else
+    LogMsg "Info: invalid service action $action"
+    UpdateSummary "Info: invalid action $action, only support stop and start"
+    SetTestStateAborted
+    exit 1
+fi
+
+GetDistro
+case $DISTRO in
+
+    "redhat_7" | "centos_7" | "Fedora" )
+        serviceName=`systemctl list-unit-files | grep -e 'hypervvssd\|[h]v-vss-daemon\|[h]v_vss_daemon'| cut -d " " -f 1`
+    ;;
+    "redhat_6" | "centos_6")
+        serviceName=`chkconfig list | grep -e 'hypervvssd\|[h]v-vss-daemon\|[h]v_vss_daemon'| cut -d " " -f 1`
+    ;;
+    *)
+        LogMsg "Info: Distro $DISTRO is not supported."
+    	UpdateSummary "Distro $DISTRO is not supported, skip test."
+    	SetTestStateSkipped
+	    exit 1
+    ;;
+    esac
+
+service $serviceName $serviceAction
+if [ $? -eq 0 ]; then
+    LogMsg "Set VSS Daemon $serviceName as $serviceAction"
+    SetTestStateCompleted
+    exit 0
+else
+    loginfo="ERROR: Fail to set VSS Daemon $serviceName as $serviceAction"
+    LogMsg "$loginfo"
+    UpdateSummary "$loginfo"
+    SetTestStateFailed
+    exit 1
+fi

--- a/WS2012R2/lisa/remote-scripts/ica/STOR_VSS_Set_VSS_Daemon.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_VSS_Set_VSS_Daemon.sh
@@ -39,10 +39,10 @@ SetTestStateRunning
 serviceName="hypervvssd"
 
 if [[ $serviceAction == "start" ]] || [[ $serviceAction == "stop" ]]; then
-    LogMsg "Info: service action is $action"
+    LogMsg "Info: service action is $serviceAction"
 else
-    LogMsg "Info: invalid service action $action"
-    UpdateSummary "Info: invalid action $action, only support stop and start"
+    LogMsg "Info: invalid service action $serviceAction"
+    UpdateSummary "Info: invalid action $serviceAction, only support stop and start"
     SetTestStateAborted
     exit 1
 fi

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
@@ -24,7 +24,7 @@
     This script tests VSS backup functionality.
 
 .Description
-    This script will set IntegrationServices "Backup (volume checkpoint) - VSS as disabled, then do offline backup, set VSS as enabled, then do online backup.
+    This script will set Integration Services "Backup (volume checkpoint)" -VSS as disabled, then do offline backup, set VSS as enabled, then do online backup.
 
     A typical XML definition for this test case would look similar
     to the following:
@@ -142,9 +142,9 @@ else {
 	"Error: Could not find setupScripts\STOR_VSS_Utils.ps1"
 	return $false
 }
-# set the backup type array, if set VSSD as disabled, it
-# exectes offline backup, if VSSD is enabled and
-# hypervvssd is running, it executes online backup.
+# set the backup type array, if set Integration Service VSS
+# as disabled/unchecked, it exectes offline backup, if VSS is
+# enabled/checked and hypervvssd is running, it executes online backup.
 $backupTypes = @("offline","online")
 
 # checkVSSD uses to set integration service,
@@ -172,7 +172,7 @@ for ($i = 0; $i -le 1; $i++ )
 
    if (-not $sts[-1])
    {
-       Write-Output "ERROR: ${vmName} failed to set IntegrationService" >> $summaryLog
+       Write-Output "ERROR: ${vmName} failed to set Integration Service" >> $summaryLog
        return $False
    }
 
@@ -205,9 +205,8 @@ for ($i = 0; $i -le 1; $i++ )
         $backupLocation = $sts
     }
 
-    # check the backup type, if VSS service is disable,
-    # it executes offline backup, otherwise, it executes
-    # online backup.
+    # check the backup type, if VSS integration service is disabled,
+    # it executes offline backup, otherwise, it executes online backup.
     $sts = getBackupType
 
     $temp = $backupTypes[$i]

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
@@ -1,0 +1,226 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    This script tests VSS backup functionality.
+
+.Description
+    This script will set IntegrationServices "Backup (volume checkpoint) - VSS as disabled, then do offline backup, set VSS as enabled, then do online backup.
+
+    A typical XML definition for this test case would look similar
+    to the following:
+
+    <test>
+        <testName>STOR_VSS_Backup_Disable_Enable_VSS</testName>
+        <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+        <files>remote-scripts/ica/utils.sh</files>
+        <testScript>setupscripts\STOR_VSS_Backup_Disable_Enable_VSS.ps1</testScript>
+        <testParams>
+            <param>TC_COVERED=VSS-21</param>
+        </testParams>
+        <timeout>2400</timeout>
+        <OnError>Continue</OnError>
+    </test>
+
+.Parameter vmName
+    Name of the VM to backup
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Test data for this test case
+
+.Example
+
+    .\setupscripts\STOR_VSS_Backup_Disable_Enable_VSS.ps1 -hvServer localhost -vmName vm_name -testParams 'driveletter=D:;RootDir=path/to/testdir;sshKey=sshKey;ipv4=ipaddress'
+
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $False
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    "sshKey" { $sshKey = $fields[1].Trim() }
+    "ipv4" { $ipv4 = $fields[1].Trim() }
+    "rootdir" { $rootDir = $fields[1].Trim() }
+    "driveletter" { $driveletter = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+if ($null -eq $driveletter)
+{
+    "ERROR: Backup driveletter is not specified."
+    return $False
+}
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+#
+# Delete any summary.log from a previous test run, then create a new file
+#
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+# Source STOR_VSS_Utils.ps1 for common VSS functions
+if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {
+	. .\setupScripts\STOR_VSS_Utils.ps1
+	"Info: Sourced STOR_VSS_Utils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\STOR_VSS_Utils.ps1"
+	return $false
+}
+# set the backup type array, if set VSSD as disabled, it
+# exectes offline backup, if VSSD is enabled and
+# hypervvssd is running, it executes online backup.
+$backupTypes = @("offline","online")
+
+# checkVSSD uses to set integration service,
+# also uses to define whether need to check
+# hypervvssd running status during runSetup
+$checkVSSD= @($false,$true)
+
+# If the kernel version is smaller than 3.10.0-383,
+# it does not take effect after un-check then
+# check VSS service unless restart VM.
+#$supportkernel = "3.10.0.383"
+$supportkernel = "3.10.0.999"
+$supportStatus = GetVMFeatureSupportStatus $ipv4 $sshKey $supportkernel
+
+for ($i = 0; $i -le 1; $i++ )
+{
+   # stop vm then set integration service
+   if (-not $supportStatus[-1])
+   {
+       # need to stop-vm to set integration service
+       Stop-VM -Name $vmName -ComputerName $hvServer -Force
+   }
+
+   # set service status based on checkVSSD
+   $sts = SetIntegrationService $vmName $hvServer "VSS" $checkVSSD[$i]
+
+   if (-not $sts[-1])
+   {
+       Write-Output "ERROR: ${vmName} failed to set IntegrationService" >> $summaryLog
+       return $False
+   }
+
+   #  restart the VM to make VSS service change take effect
+   if (-not $supportStatus[-1])
+   {
+       $timeout = 300
+       $sts = Start-VM -Name $vmName -ComputerName $hvServer
+       if (-not (WaitForVMToStartKVP $vmName $hvServer $timeout ))
+       {
+           Write-Output "ERROR: ${vmName} failed to start" >> $summaryLog
+           return $False
+       }
+       	Start-Sleep -s 3
+   }
+    ## run set up
+    $sts = runSetup $vmName $hvServer $driveletter $checkVSSD[$i]
+    if (-not $sts[-1])
+    {
+        return $False
+    }
+
+    $sts = startBackup $vmName $driveLetter
+    if (-not $sts[-1])
+    {
+        return $False
+    }
+    else
+    {
+        $backupLocation = $sts
+    }
+
+    # check the backup type, if VSS service is disable,
+    # it executes offline backup, otherwise, it executes
+    # online backup.
+    $sts = getBackupType
+
+    $temp = $backupTypes[$i]
+    if  ( $sts -ne $temp )
+    {
+        Write-output "Failed: Not get expected backup type"
+        return $False
+    }
+    else
+    {
+        Write-output "Info: get expected backup type $temp"
+    }
+    runCleanup $backupLocation
+}
+return $True

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
@@ -155,8 +155,7 @@ $checkVSSD= @($false,$true)
 # If the kernel version is smaller than 3.10.0-383,
 # it does not take effect after un-check then
 # check VSS service unless restart VM.
-#$supportkernel = "3.10.0.383"
-$supportkernel = "3.10.0.999"
+$supportkernel = "3.10.0.383"
 $supportStatus = GetVMFeatureSupportStatus $ipv4 $sshKey $supportkernel
 
 for ($i = 0; $i -le 1; $i++ )

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Stop_VSSD.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Stop_VSSD.ps1
@@ -1,0 +1,203 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    This script tests VSS backup functionality.
+
+.Description
+    This script will stop hypervvssd daemons then do backup. For older hyperv-daemons version, it will get backup error, for latest version, it will do offline backup.
+
+    A typical XML definition for this test case would look similar
+    to the following:
+
+    <test>
+        <testName>STOR_VSS_Backup_Stop_VSSD</testName>
+        <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+        <testScript>setupscripts\STOR_VSS_Backup_Stop_VSSD.ps1</testScript>
+        <testParams>
+            <param>TC_COVERED=VSS-22</param>
+        </testParams>
+        <timeout>2400</timeout>
+        <OnError>Continue</OnError>
+    </test>
+
+.Parameter vmName
+    Name of the VM to backup
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Test data for this test case
+
+.Example
+
+    .\setupscripts\STOR_VSS_Backup_Stop_VSSD.ps1 -hvServer localhost -vmName vm_name -testParams 'driveletter=D:;RootDir=path/to/testdir;sshKey=sshKey;ipv4=ipaddress'
+
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+# Check input arguments
+if ($vmName -eq $null)
+{
+    "ERROR: VM name is null"
+    return $False
+}
+
+# Check input params
+$params = $testParams.Split(";")
+
+foreach ($p in $params)
+{
+  $fields = $p.Split("=")
+
+  switch ($fields[0].Trim())
+    {
+    "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+    "sshKey" { $sshKey = $fields[1].Trim() }
+    "ipv4" { $ipv4 = $fields[1].Trim() }
+    "rootdir" { $rootDir = $fields[1].Trim() }
+    "driveletter" { $driveletter = $fields[1].Trim() }
+     default  {}
+    }
+}
+
+if ($null -eq $sshKey)
+{
+    "ERROR: Test parameter sshKey was not specified"
+    return $False
+}
+
+if ($null -eq $ipv4)
+{
+    "ERROR: Test parameter ipv4 was not specified"
+    return $False
+}
+
+if ($null -eq $rootdir)
+{
+    "ERROR: Test parameter rootdir was not specified"
+    return $False
+}
+
+if ($null -eq $driveletter)
+{
+    "ERROR: Backup driveletter is not specified."
+    return $False
+}
+
+# Change the working directory to where we need to be
+cd $rootDir
+
+#
+# Delete any summary.log from a previous test run, then create a new file
+#
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+# Source STOR_VSS_Utils.ps1 for common VSS functions
+if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {
+	. .\setupScripts\STOR_VSS_Utils.ps1
+	"Info: Sourced STOR_VSS_Utils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\STOR_VSS_Utils.ps1"
+	return $false
+}
+## run set up
+$sts = runSetup $vmName $hvServer $driveletter
+if (-not $sts[-1])
+{
+    return $False
+}
+
+# Stop hypervvssd daemons
+$retVal = SendCommandToVM $ipv4 $sshKey "service hypervvssd stop"
+if ($retVal -eq $False)
+{
+    "Error: Failed to stop the hypervvssd server!"
+    return $false
+}
+Start-Sleep -s 1
+# After stop hypervvssd,if hyperv-daemons version is smaller than 0.0.30,it gets error when do backup, otherwise it executes offline backup.
+$supportHypervDaemons = "hyperv-daemons-0-0.30.20171211git.el7"
+$supportStatus = GetHypervDaemonsSupportStatus $ipv4 $sshKey $supportHypervDaemons
+
+$stsBackUp = startBackup $vmName $driveLetter
+
+if ( -not $supportStatus)
+{   # when stop hypervvssd, backup gets failure
+    if ( $stsBackUp[-1])
+     {
+         "ERROR: Backup still could complete even not support" >> $summaryLog
+         return $False
+     }
+     else
+     {
+         "Info: Get failed backup as expected when hypervvssd stopped" >> $summaryLog
+     }
+}
+else
+{  # execute offline backup when stop hyperv-vssd
+    if (-not $stsBackUp[-1])
+    {
+        "Failed: Failed to do offline backup"
+        return $False
+    }
+    else
+    {
+        $backupLocation = $stsBackUp
+        # if stop hypervvssd, vm does offline backup
+        $bkType = getBackupType
+        if  ( $bkType -ne "offline" )
+        {
+            "Failed: Not get expected offline backup type"  >> $summaryLog
+            return $False
+        }
+        else
+        {
+            "Info: Get expected offline backup type" >> $summaryLog
+        }
+        runCleanup $backupLocation
+    }
+}
+
+"Info: Test successful"
+return $True

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
@@ -216,19 +216,28 @@ function checkResults([string] $vmName, [string] $hvServer)
         $logMessage = "INFO: no selinux avc deny log in audit logs"
         Write-Output $logMessage
     }
-
-	$sts= CheckFile "/root/1"
-	if (-not $sts[-1])
-    {
-        $logMessage = "ERROR: No /root/1 file after restore "
-        Write-Output $logMessage
-		$logMessage >> $summaryLog
-        return $False
-    }
+	# only check restore file when ip available
+	#$ipv4 = GetIPv4 $vmName $hvServer
+	$stsipv4 = Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue
+	if ($stsipv4.PingSucceeded)
+	{
+		$sts= CheckFile "/root/1"
+		if (-not $sts[-1])
+		{
+			$logMessage = "ERROR: No /root/1 file after restore "
+			Write-Output $logMessage
+			$logMessage >> $summaryLog
+			return $False
+		}
+		else
+		{
+			$logMessage = "INFO: there is /root/1 file after restore"
+			Write-Output $logMessage
+		}
+	}
 	else
 	{
-		$logMessage = "INFO: there is /root/1 file after restore"
-        Write-Output $logMessage
+		Write-Output "INFO: Ignore checking file /root/1 when no network"
 	}
 
 	# Now Check the boot logs in VM to verify if there is no Recovering journals in it .

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
@@ -29,14 +29,13 @@
     commonly used by PowerShell scripts in VSS tests.
 #>
 
-
-function runSetup([string] $vmName, [string] $hvServer, [string] $driveletter) 
-{	
+function runSetup([string] $vmName, [string] $hvServer, [string] $driveletter, [boolean] $check_vssd = $True)
+{
 	$sts = Test-Path $driveletter
 	if (-not $sts)
 	{
 		Write-Output "Error: Drive ${driveletter} does not exist"
-		return $False	
+		return $False
 	}
 	Write-Output "Info: Removing old backups"
 	try { Remove-WBBackupSet -Force -WarningAction SilentlyContinue }
@@ -59,33 +58,32 @@ function runSetup([string] $vmName, [string] $hvServer, [string] $driveletter)
 			return $False
 		}
 	}
-
-	# Check to see Linux VM is running VSS backup daemon
-	$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"		 
-	if (-not $sts[-1])		
-    {
-		Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog		
-		Write-Output "ERROR: Running $remoteScript script failed on VM!"		
-		return $False		
+	if ($check_vssd)
+	{
+		# Check to see Linux VM is running VSS backup daemon
+		$sts = RunRemoteScript "STOR_VSS_Check_VSS_Daemon.sh"
+		if (-not $sts[-1])
+		{
+			Write-Output "ERROR executing $remoteScript on VM. Exiting test case!" >> $summaryLog
+			Write-Output "ERROR: Running $remoteScript script failed on VM!"
+			return $False
+		}
+			Write-Output "Info: VSS Daemon is running" >> $summaryLog
 	}
-	
 
-	Write-Output "Info: VSS Daemon is running" >> $summaryLog
+	# Create a file on the VM before backup
+ 	$sts = CreateFile "/root/1"
+ 	if (-not $sts[-1])
+	{
+		Write-Output "ERROR: Cannot create test file"
+		return $False
+ 	}
 
-	# Create a file on the VM before backup		
- 	$sts = CreateFile "/root/1"		
- 	if (-not $sts[-1])		
-	{		
- 	  Write-Output "ERROR: Cannot create test file"		
-     	return $False		
- 	}		
- 
  	Write-Output "File created on VM: $vmname" >> $summaryLog
 	return $True
 }
 
-
-function startBackup([string] $vmName, [string] $driveletter) 
+function startBackup([string] $vmName, [string] $driveletter)
 {
     # Remove Existing Backup Policy
 	try { Remove-WBPolicy -all -force }
@@ -94,7 +92,7 @@ function startBackup([string] $vmName, [string] $driveletter)
 	# Set up a new Backup Policy
 	$policy = New-WBPolicy
 
-	# Set the backup backup location
+	# Set the backup location
 	$backupLocation = New-WBBackupTarget -VolumePath $driveletter
 
 	# Define VSS WBBackup type
@@ -127,15 +125,15 @@ function startBackup([string] $vmName, [string] $driveletter)
 	# Let's wait a few Seconds
 	Start-Sleep -Seconds 70
 
-	# Delete file on the VM	
+	# Delete file on the VM
 	$vmState = $(Get-VM -name $vmName -ComputerName $hvServer).state
-    if (-not $vmState) {			
-		$sts = DeleteFile		
-		if (-not $sts[-1])		
-		{		
+    if (-not $vmState) {
+		$sts = DeleteFile
+		if (-not $sts[-1])
+		{
 			Write-Output "ERROR: Cannot delete test file!" >> $summaryLog
-			return $False		
-		}		
+			return $False
+		}
 		Write-Output "File deleted on VM: $vmname" >> $summaryLog
 	}
 	return $backupLocation
@@ -161,7 +159,7 @@ function restoreBackup([string] $backupLocation)
 	return $True
 }
 
-function checkResults([string] $vmName, [string] $hvServer) 
+function checkResults([string] $vmName, [string] $hvServer)
 {
    # Review the results
 	$RestoreTime = (New-Timespan -Start (Get-WBJob -Previous 1).StartTime -End (Get-WBJob -Previous 1).EndTime).Minutes
@@ -181,14 +179,13 @@ function checkResults([string] $vmName, [string] $hvServer)
 	if (-not $vm.state) {
 		Write-Output "Waiting for vm to turn off"
 		Start-Sleep -Seconds 60
-		
+
 		if ( $vm.state -ne "Off" )
 		{
 			Write-Output "ERROR: VM is not in OFF state, current state is " + $vm.state >> $summaryLog
 			return $False
 		}
 	}
-	
 
 	# Now Start the VM
 	$timeout = 300
@@ -204,6 +201,36 @@ function checkResults([string] $vmName, [string] $hvServer)
 	}
 
 	Start-Sleep -s 60
+
+	# Now Check the boot logs in VM to verify if there is no Recovering journals in it .
+
+	$sts= GetSelinuxAVCLog
+	if ($sts[-1])
+    {
+        $logMessage = "ERROR: There is selinux avc denied log in audit log: Failed"
+        Write-Output $logMessage >> $summaryLog
+        return $False
+    }
+    else
+    {
+        $logMessage = "INFO: no selinux avc deny log in audit logs"
+        Write-Output $logMessage
+    }
+
+	$sts= CheckFile "/root/1"
+	if (-not $sts[-1])
+    {
+        $logMessage = "ERROR: No /root/1 file after restore "
+        Write-Output $logMessage
+		$logMessage >> $summaryLog
+        return $False
+    }
+	else
+	{
+		$logMessage = "INFO: there is /root/1 file after restore"
+        Write-Output $logMessage
+	}
+
 	# Now Check the boot logs in VM to verify if there is no Recovering journals in it .
 	$sts=CheckRecoveringJ
     if ($sts[-1])
@@ -225,10 +252,39 @@ function checkResults([string] $vmName, [string] $hvServer)
     }
 }
 
-function runCleanup([string] $backupLocation) 
+function runCleanup([string] $backupLocation)
 {
     # Remove Created Backup
     Write-Output "Removing old backups from $backupLocation"
     try { Remove-WBBackupSet -BackupTarget $backupLocation -Force -WarningAction SilentlyContinue }
     Catch { Write-Output "No existing backup's to remove"}
+}
+
+function getBackupType()
+{
+	# check the latest successful job backup type, "online" or "offline"
+	$backupType = $null
+	$sts = Get-WBJob -Previous 1
+	if ($sts.JobState -ne "Completed" -or $sts.HResult -ne 0)
+	{
+		Write-Output "ERROR: VSS Backup failed " >> $summaryLog
+		return $backupType
+	}
+
+	$contents = get-content $sts.SuccessLogPath
+	foreach ($line in $contents )
+	{
+		if ( $line -match "Caption" -and $line -match "online")
+		{
+			Write-Output "VSS Backup type is online" >> $summaryLog
+			$backupType = "online"
+
+		}
+		elseif ($line -match "Caption" -and $line -match "offline")
+		{
+			Write-Output "VSS Backup type is offline" >> $summaryLog
+			$backupType = "offline"
+		}
+	}
+	return $backupType
 }

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1999,3 +1999,35 @@ function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$su
 	}
 	return $true
 }
+
+function GetHypervDaemonsSupportStatus([String] $ipv4, [String] $sshKey, [String]$supportHypervDaemons)
+{
+    <#
+    .Synopsis
+        Check Hyperv-daemons supports one feature or not.
+    .Description
+        Check hyperv-daemons supports one feature or not by comparing curent hyperv-daemons version with feature supported version.
+        If the current version is lower than feature supported version, return false, otherwise return true.
+    .Parameter ipv4
+        IPv4 address of the Linux VM.
+    .Parameter sshKey
+        SSH key used to connect to the Linux VM
+    .Parameter supportHypervDaemons
+        Hyperv-daemons version starts to support this feature, e.g. supportHypervDaemons = "hyperv-daemons-0-0.30.20171211git.el7"
+    .Example
+        GetHypervDaemonsSupportStatus $ipv4 $sshKey $supportHypervDaemons
+    #>
+	$currentHypervDaemons = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "rpm -qa | grep -i hyperv-daemons | head -n 1"
+	if( $? -eq $false){
+		write-output "WARNING: Could not get hyperv-vssd version".
+	}
+
+	$sHD =$supportHypervDaemons.replace("-",".").split(".")
+	$cHD =$currentHypervDaemons.replace("-",".").split(".")
+    for ($i=2; $i -le 4; $i++) {
+    	if ($cHD[$i] -lt $sHD[$i] ) {
+    			return $false
+    	}
+    }
+	return $true
+}

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1969,7 +1969,7 @@ function GetSelinuxAVCLog([String] $ipv4, [String] $sshKey)
     return $False
 }
 
-function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$supportkernel)
+function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$supportKernel)
 {
     <#
     .Synopsis

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1889,9 +1889,9 @@ function SetIntegrationService([string] $vmName, [string] $hvServer, [string] $s
 {
     <#
     .Synopsis
-        Set the Integraiton Service status.
+        Set the Integration Service status.
     .Description
-        Set the Integraiton Service status based on service name and expected service status.
+        Set the Integration Service status based on service name and expected service status.
     .Parameter vmName
         Name of the VM
     .Parameter hvServer
@@ -1997,37 +1997,5 @@ function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$su
 			return $false
 		}
 	}
-	return $true
-}
-
-function GetHypervDaemonsSupportStatus([String] $ipv4, [String] $sshKey, [String]$supportHypervDaemons)
-{
-    <#
-    .Synopsis
-        Check Hyperv-daemons supports one feature or not.
-    .Description
-        Check hyperv-daemons supports one feature or not by comparing curent hyperv-daemons version with feature supported version.
-        If the current version is lower than feature supported version, return false, otherwise return true.
-    .Parameter ipv4
-        IPv4 address of the Linux VM.
-    .Parameter sshKey
-        SSH key used to connect to the Linux VM
-    .Parameter supportHypervDaemons
-        Hyperv-daemons version starts to support this feature, e.g. supportHypervDaemons = "hyperv-daemons-0-0.30.20171211git.el7"
-    .Example
-        GetHypervDaemonsSupportStatus $ipv4 $sshKey $supportHypervDaemons
-    #>
-	$currentHypervDaemons = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "rpm -qa | grep -i hyperv-daemons | head -n 1"
-	if( $? -eq $false){
-		write-output "WARNING: Could not get hyperv-vssd version".
-	}
-
-	$sHD =$supportHypervDaemons.replace("-",".").split(".")
-	$cHD =$currentHypervDaemons.replace("-",".").split(".")
-    for ($i=2; $i -le 4; $i++) {
-    	if ($cHD[$i] -lt $sHD[$i] ) {
-    			return $false
-    	}
-    }
 	return $true
 }

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1307,6 +1307,7 @@ function CheckRecoveringJ()
     return $retValue
 }
 
+
 #######################################################################
 # Create a file on the VM.
 #######################################################################
@@ -1605,6 +1606,8 @@ function GetNumaSupportStatus([string] $kernel)
     return $true
 }
 
+
+
 #####################################################################
 #
 # GetHostBuildNumber
@@ -1879,4 +1882,120 @@ function CreateController([string] $vmName, [string] $server, [string] $controll
         "Info : Controller successfully added"
     }
     return $True
+}
+
+
+function SetIntegrationService([string] $vmName, [string] $hvServer, [string] $serviceName, [boolean] $serviceStatus)
+{
+    <#
+    .Synopsis
+        Set the Integraiton Service status.
+    .Description
+        Set the Integraiton Service status based on service name and expected service status.
+    .Parameter vmName
+        Name of the VM
+    .Parameter hvServer
+        Name of the server hosting the VM
+    .Parameter serviceName
+        Service name, e.g. VSS, Guest Service Interface
+    .Parameter serviceStatus
+        Expected servcie status, $true is enabled, $false is disabled
+    .Example
+        SetIntegrationService $vmName $hvServer $serviceName $true
+    #>
+    if (@("Guest Service Interface", "Time Synchronization", "Heartbeat", "Key-Value Pair Exchange", "Shutdown","VSS") -notcontains $serviceName)
+    {
+        "Error: Unknown service type: $serviceName"
+        return $false
+    }
+
+    "Info: Set the Integrated Services $serviceName as $serviceStatus"
+    if ($serviceStatus -eq $false)
+    {
+        Disable-VMIntegrationService -ComputerName $hvServer -VMName $vmName -Name $serviceName
+    }
+    else
+    {
+        Enable-VMIntegrationService -ComputerName $hvServer -VMName $vmName -Name $serviceName
+    }
+
+    $status = Get-VMIntegrationService -ComputerName $hvServer -VMName $vmName -Name $serviceName
+    if ($status.Enabled -ne $serviceStatus)
+    {
+        "Error: The $serviceName service could not be set as $serviceStatus"
+        return $False
+    }
+    return $True
+}
+
+function GetSelinuxAVCLog([String] $ipv4, [String] $sshKey)
+{
+    <#
+    .Synopsis
+        Check selinux audit.log in Linux VM for avc denied log.
+    .Description
+        Check audit.log in Linux VM for avc denied log.
+        If get avc denied log for hyperv daemons, return $true, else return $false.
+    .Parameter ipv4
+        IPv4 address of the Linux VM.
+    .Parameter sshKey
+        SSH key used to connect to the Linux VM
+    .Example
+        GetSelinuxAVCLog $ipv4 $sshKey
+    #>
+    $filename = ".\audit.log"
+    $text_hv = "hyperv"
+    $text_avc = "type=avc"
+    echo y | .\bin\pscp -i ssh\${sshKey}  root@${ipv4}:/var/log/audit.log $filename
+
+    if (-not $?) {
+        Write-Output "ERROR: Unable to copy audit.log from the VM"
+        return $False
+    }
+
+    $file = Get-Content $filename
+    if (-not $file) {
+        Write-Error -Message "Error: Unable to read file" -Category InvalidArgument -ErrorAction SilentlyContinue
+        return $null
+    }
+
+     foreach ($line in $file) {
+        if ($line -match $text_hv -and $line -match $text_avc){
+            write-output "Warning: get the avc denied log: $line"
+            return $True
+        }
+    }
+    del $filename
+    return $False
+}
+
+function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$supportkernel)
+{
+    <#
+    .Synopsis
+        Check vm supports one feature or not.
+    .Description
+        Check vm supports one feature or not based on comare curent kernel version with feature supported kernel version. If the current version is lower than feature supported version, return false, otherwise return true
+    .Parameter ipv4
+        IPv4 address of the Linux VM.
+    .Parameter sshKey
+        SSH key used to connect to the Linux VM
+    .Parameter supportkernel
+        the kernel version number starts to support this feature, e.g. supportkernel = "3.10.0.383"
+    .Example
+        GetVMFeatureSupportStatus $ipv4 $sshKey $supportkernel
+    #>
+	$currentKernel = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "uname -r"
+	if( $? -eq $false){
+		write-output "WARNING: Could not get kernel version".
+	}
+	$sKernel = $supportKernel.split(".")
+	$cKernel = $currentKernel.replace("-",".").split(".")
+
+	for ($i=0; $i -le 3; $i++) {
+		if ($ckernel[$i] -lt $sKernel[$i] ) {
+			return $false
+		}
+	}
+	return $true
 }

--- a/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
+++ b/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
@@ -51,7 +51,9 @@
                 <suiteTest>STOR_VSS_BackupRestore_DiskStress</suiteTest>
                 <suiteTest>STOR_VSS_BackupRestore_Mount_Multi_Paths</suiteTest>
                 <suiteTest>STOR_VSS_BackupRestore_Mount_Squashfs</suiteTest>
-                <testName>STOR_VSS_Backup_Disable_Enable_VSS</testName>
+                <suiteTest>STOR_VSS_Backup_Disable_Enable_VSS</suiteTest>
+                <suiteTest>STOR_VSS_Backup_Change_Hypervvssd</suiteTest>
+
                 <!-- Live backup operations can fail silently if the VM has an
                 attached iSCSI device or direct-attached storage (pass-through disk)
                 <suiteTest>STOR_VSS_BackupRestore_PassTru</suiteTest> -->
@@ -287,9 +289,10 @@
         </test>
 
         <test>
-            <testName>STOR_VSS_Backup_Stop_VSSD</testName>
+            <testName>STOR_VSS_Backup_Change_Hypervvssd</testName>
             <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
-            <testScript>setupscripts\STOR_VSS_Backup_Stop_VSSD.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh</files>
+            <testScript>setupscripts\STOR_VSS_Backup_Change_Hypervvssd.ps1</testScript>
             <testParams>
                 <param>TC_COVERED=VSS-22</param>
             </testParams>

--- a/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
+++ b/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
@@ -286,6 +286,17 @@
             <OnError>Continue</OnError>
         </test>
 
+        <test>
+            <testName>STOR_VSS_Backup_Stop_VSSD</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <testScript>setupscripts\STOR_VSS_Backup_Stop_VSSD.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=VSS-22</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
     </testCases>
 
     <VMs>

--- a/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
+++ b/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
@@ -51,6 +51,7 @@
                 <suiteTest>STOR_VSS_BackupRestore_DiskStress</suiteTest>
                 <suiteTest>STOR_VSS_BackupRestore_Mount_Multi_Paths</suiteTest>
                 <suiteTest>STOR_VSS_BackupRestore_Mount_Squashfs</suiteTest>
+                <testName>STOR_VSS_Backup_Disable_Enable_VSS</testName>
                 <!-- Live backup operations can fail silently if the VM has an
                 attached iSCSI device or direct-attached storage (pass-through disk)
                 <suiteTest>STOR_VSS_BackupRestore_PassTru</suiteTest> -->
@@ -272,6 +273,19 @@
             <timeout>3000</timeout>
             <OnError>Continue</OnError>
         </test>
+
+        <test>
+            <testName>STOR_VSS_Backup_Disable_Enable_VSS</testName>
+            <setupScript>setupscripts\RevertSnapshot.ps1</setupScript>
+            <files>remote-scripts/ica/utils.sh</files>
+            <testScript>setupscripts\STOR_VSS_Backup_Disable_Enable_VSS.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=VSS-21</param>
+            </testParams>
+            <timeout>2400</timeout>
+            <OnError>Continue</OnError>
+        </test>
+
     </testCases>
 
     <VMs>


### PR DESCRIPTION
Add one case about backup when vss is disabled and enabled in the "integration service", if VSS is disabled, it should do offline backup, otherwise do online backup.

Note: Refer to bug https://bugzilla.redhat.com/show_bug.cgi?id=1074407,  after kernel version kernel-3.10.0-383.el7, the check or un-check VSS could take effect without vm reboot.

Case Description: 
Check  'Backup(volume snapshot)' after un-check 'Backup(volume snapshot)' integration services from Hyper-V Manager and do backup after un-check and check

Test Steps:
1. Right click your VM in Hyper-V Manager, select ""Settings"", change to
 ""Integration Services"" and un-check ""Backup (volume snapshot)"""
2. Backup VM from server host
3. Change to ""Integration Services"" from Hyper-V Manager settings and check
 ""Backup (volume snapshot)"""
4. Repeat step 2
Note: for RHEL6, refer to not fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1121888 , all the integration servers after check/uncheck, need to reboot VM to make the option take effect."

Expected Result:
After step 2, The online backup should be failed, and host should display offline backup log:
 "Copying files for "$VM_name"(Offline)... xx% done. "
 Check VM backup log "Caption: Offline\$VM_name"
 After step 4, The backup should be success,Host should display:
 "Copying files for "$VM_name"(Online)... xx% done. "
 Check VM backup log "Caption: Online\$VM_name"