### PR TITLE
Fixed CopyLargeFile test

### DIFF
--- a/WS2012R2/lisa/xml/NET_Tests_IPv6.xml
+++ b/WS2012R2/lisa/xml/NET_Tests_IPv6.xml
@@ -197,7 +197,6 @@
             <testParams>
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-12</param>
-                <param>MAC=001600112233</param>
                 <param>ZERO_FILE=yes</param>
                 <param>FILE_SIZE_GB=2</param>
                 <param>TestIPV6=yes</param>


### PR DESCRIPTION
Removed the MAC address parameter from the XML file in order to use the random generated one.