### PR TITLE
Heartbeat_PausedCritical TC fix

### DIFF
--- a/WS2012R2/lisa/setupscripts/Core_Heartbeat_PausedCritical.ps1
+++ b/WS2012R2/lisa/setupscripts/Core_Heartbeat_PausedCritical.ps1
@@ -137,6 +137,12 @@ $VHDSize = (Get-VHD -Path $ParentVHD -ComputerName $hvServer).FileSize
 [uint64]$newsize = [math]::round($VHDSize /1Gb, 1)
 $newsize = ($newsize * 1GB) + 1GB
 
+Get-Partition -DriveLetter $driveletter[0] -ErrorAction SilentlyContinue
+if ($?)
+{
+    Dismount-VHD -Path $vhdpath -ComputerName $hvServer -ErrorAction SilentlyContinue 
+}
+
 if ( Test-Path $vhdpath )
 {
     Write-Host "Deleting existing VHD $vhdpath"


### PR DESCRIPTION
In case the host had already a partition with the same name, the script
would exit with an error. Added a check for this. If a partition exists,
the script now will dismount the vhd file and then will proceed with the
testing.