### PR TITLE
stateEngine.ps1: Fix bug about the vm's state can not go into postTes…

### DIFF
--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -3574,6 +3574,15 @@ function DoPS1TestCompleted ([System.Xml.XmlElement] $vm, [XML] $xmlData)
         del $summaryLog
     }
 
-    UpdateState $vm $DetermineReboot
+    # UpdateState $vm $DetermineReboot
+    $testData = GetTestData $currentTest $xmlData
+    if ( $($testData.postTest) )
+    {
+        UpdateState $vm $RunPostTestScript
+    }
+    else
+    {
+        UpdateState $vm $DetermineReboot
+    }
 }
 0


### PR DESCRIPTION
Fix bug: when test script mode is powershell with PostTest, can not run post test script.