### PR TITLE
Update InjectIPconstants default server as 8.8.4.4 and support parameter

### DIFF
--- a/WS2012R2/lisa/setupscripts/InjectIPconstants.ps1
+++ b/WS2012R2/lisa/setupscripts/InjectIPconstants.ps1
@@ -138,7 +138,7 @@ $switchs = $False
 $AddressFamily = "IPv4"
 $testMAC = "no"
 # default remote ping server
-$remote_Server = "8.8.8.4"
+$remote_Server = "8.8.4.4"
 $params = $testParams.Split(";")
 foreach ($p in $params)
 {

--- a/WS2012R2/lisa/setupscripts/InjectIPconstants.ps1
+++ b/WS2012R2/lisa/setupscripts/InjectIPconstants.ps1
@@ -137,7 +137,8 @@ $nic = $False
 $switchs = $False
 $AddressFamily = "IPv4"
 $testMAC = "no"
-
+# default remote ping server
+$remote_Server = "8.8.8.4"
 $params = $testParams.Split(";")
 foreach ($p in $params)
 {
@@ -151,6 +152,7 @@ foreach ($p in $params)
     "SWITCH"        { $switchs = $fields[1].Trim() }
     "NIC"           { $nic     = $fields[1].Trim() }
     "TestMAC"       { $testMAC     = $fields[1].Trim() }
+    "Remote_Server" { $remote_Server = $fields[1].Trim() }
     default         {}  # unknown param - just ignore it
     }
 }
@@ -182,7 +184,7 @@ if($switchs){
 }
 
 if($AddressFamily -eq "IPv4"){
-    $externalIP = "8.8.4.4"
+    $externalIP = $remote_Server
     $privateIP = "10.10.10.5"
 }else{
     $externalIP = "2001:4860:4860::8888"
@@ -242,18 +244,18 @@ $cmd+="echo `"PING_FAIL2=$($PING_FAIL2)`" >> ~/constants.sh;";
 if ($testMAC -eq "yes"){
     # Get the MAC that was generated
     $CurrentDir= "$pwd\"
-    $testfile = "macAddress.file" 
-    $pathToFile="$CurrentDir"+"$testfile" 
+    $testfile = "macAddress.file"
+    $pathToFile="$CurrentDir"+"$testfile"
     $streamReader = [System.IO.StreamReader] $pathToFile
     $macAddress = $streamReader.ReadLine()
-    $streamReader.close() 
+    $streamReader.close()
 
     for ($i = 2 ; $i -le 14 ; $i += 3) {
         $macAddress = $macAddress.insert($i,':')
     }
 
     # Send the MAC address to the VM
-    $cmd+="echo `"MAC=$($macAddress)`" >> ~/constants.sh;";    
+    $cmd+="echo `"MAC=$($macAddress)`" >> ~/constants.sh;";
 }
 
 "PING_SUCC=$PING_SUCC"

--- a/WS2012R2/lisa/xml/NET_Tests.xml
+++ b/WS2012R2/lisa/xml/NET_Tests.xml
@@ -80,6 +80,7 @@ permissions and limitations under the License.
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-02,NET-07</param>
                 <param>TestMAC=yes</param>
+                <param>REMOTE_SERVER=8.8.4.4</param>
                 <!-- <param>GATEWAY=192.168.0.1</param> -->
             </testParams>
             <testScript>NET_TEST_NETWORK.sh</testScript>
@@ -96,6 +97,7 @@ permissions and limitations under the License.
             <testParams>
                 <param>NIC=NetworkAdapter,Internal,Internal</param>
                 <param>TC_COVERED=NET-03</param>
+                <param>REMOTE_SERVER=8.8.4.4</param>
             </testParams>
             <testScript>NET_TEST_NETWORK.sh</testScript>
             <files>remote-scripts/ica/NET_TEST_NETWORK.sh,remote-scripts/ica/utils.sh</files>
@@ -136,6 +138,7 @@ permissions and limitations under the License.
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>TC_COVERED=NET-05</param>
+                <param>REMOTE_SERVER=8.8.4.4</param>
                 <!-- <param>GATEWAY=192.168.0.1</param> -->
             </testParams>
             <testScript>NET_TEST_NETWORK.sh</testScript>
@@ -205,6 +208,7 @@ permissions and limitations under the License.
             <testParams>
                 <param>NIC=NetworkAdapter,External,External</param>
                 <param>SWITCH=NetworkAdapter,Internal,Internal</param>
+                <param>REMOTE_SERVER=8.8.4.4</param>
                 <param>TC_COVERED=NET-09</param>
             </testParams>
             <timeout>800</timeout>


### PR DESCRIPTION
add one parameter about remote_sever to support change remote server ip, 8.8.4.4 could not ping successfully sometimes in Beijing, if not set the parameter, default is 8.8.4.4.