### PR TITLE
Fix kdump case single core always abort by use start-process

### DIFF
--- a/WS2012R2/lisa/setupscripts/Kdump.ps1
+++ b/WS2012R2/lisa/setupscripts/Kdump.ps1
@@ -225,6 +225,11 @@ else {
         "Kdump will be triggered on VCPU 3 of 4"
         $retVal = SendCommandToVM $ipv4 $sshKey "taskset -c 2 echo c > /proc/sysrq-trigger 2>/dev/null &"
     }
+    elseif ($vcpu -eq 1){
+        # if vcpu=1, direclly use plink to trigger kdump, command fails to exit, so use start-process
+        $tmpCmd = "echo c > /proc/sysrq-trigger 2>/dev/null &"
+         Start-Process bin\plink -ArgumentList "-i ssh\${sshKey} root@${ipv4} ${tmpCmd}" -NoNewWindow
+    }
     else {
         $retVal = SendCommandToVM $ipv4 $sshKey "echo c > /proc/sysrq-trigger 2>/dev/null &"
     }


### PR DESCRIPTION
when execute Crash_single_core, it always abort after trigger kdump, but the kdump_results cannot be executed. It is caused that "plink.exe 'echo c > proc/sysrq-trigger 2>/dev/null &'" could not exit.  In other words, if run this command in powershell terminal,  it stucks in the terminal, if press "enter", it will exit with error "lost network connect".

This change is use Start-Process and no "Wait" parameter.