### PR TITLE
Minor change kdump private key name from sshkey to ssh_private_key

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Results.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Results.sh
@@ -86,7 +86,7 @@ GetDistro
 case $DISTRO in
     centos* | redhat*)
         if [[ $vm2ipv4 != "" ]]; then
-            status=`ssh -i /root/.ssh/${ssh_key} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/var/crash/*/vmcore -type f -size +10M; echo $?"`
+            status=`ssh -i /root/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/var/crash/*/vmcore -type f -size +10M; echo $?"`
             VerifyRemoteStatus
         else
             CheckVmcore
@@ -94,7 +94,7 @@ case $DISTRO in
     ;;
     ubuntu*)
         if [[ $vm2ipv4 != "" ]]; then
-            status=`ssh -i /root/.ssh/${ssh_key} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/* -type f -size +10M; echo $?"`
+            status=`ssh -i /root/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/* -type f -size +10M; echo $?"`
             VerifyRemoteStatus
         else
             if ! [[ $(find /var/crash/2* -type f -size +10M) ]]; then
@@ -111,7 +111,7 @@ case $DISTRO in
     ;;
   suse*)
         if [[ $vm2ipv4 != "" ]]; then
-            status=`ssh -i /root/.ssh/${ssh_key} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/* -type f -size +10M; echo $?"`
+            status=`ssh -i /root/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/* -type f -size +10M; echo $?"`
             VerifyRemoteStatus
         else
             CheckVmcore

--- a/WS2012R2/lisa/xml/Kdump_Tests.xml
+++ b/WS2012R2/lisa/xml/Kdump_Tests.xml
@@ -191,7 +191,7 @@
             <ipv4></ipv4>
             <sshKey>linux_id_rsa.ppk</sshKey>
             <testParams>
-                <param>ssh_key=linux_id_rsa</param>
+                <param>SSH_PRIVATE_KEY=linux_id_rsa</param>
                 <param>SnapshotName=ICABase</param>
                 <param>VM2NAME=VM2NAME</param>
             </testParams>


### PR DESCRIPTION
Locally we use the same xml for all the cases, for this private key, in Network_Tests.xml, the private key is SSH_PRIVATE_KEY, in the kdump_tests.xml, it use ssh_key, so make them keep consistent.