### PR TITLE
Kdump add fedora

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Execute.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Execute.sh
@@ -87,7 +87,7 @@ Rhel()
                 sleep 5
             fi
         done
-        if  [ $timeout -ne 0 ]
+        if  [ $timeout -lt 0 ]
         then
             LogMsg "Kdump is active after reboot."
             UpdateSummary "Success: kdump service is active after reboot."

--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Results.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Results.sh
@@ -84,7 +84,7 @@ VerifyRemoteStatus()
 #
 GetDistro
 case $DISTRO in
-    centos* | redhat*)
+    centos* | redhat* | fedora*)
         if [[ $vm2ipv4 != "" ]]; then
             status=`ssh -i /root/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no root@${vm2ipv4} "find /mnt/var/crash/*/vmcore -type f -size +10M; echo $?"`
             VerifyRemoteStatus

--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_nfs_config.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_nfs_config.sh
@@ -156,7 +156,7 @@ ConfigUbuntu()
 GetDistro
 
 case $DISTRO in
-    centos* | redhat*)
+    centos* | redhat* | fedora*)
         ConfigRhel
     ;;
     ubuntu*)


### PR DESCRIPTION
1. Support fedora distro
2. Kdump_Config.sh
- Improve grub config file to use $(find /boot -name grub.cfg)
- Return Skipped if crashkernel=auto for fedora

3. Kdump_Execute.sh: For nfs, it needs more than 50 seconds to start kdump, so add while to check kdump service status is active
4. Kdump.ps1: If config script returns Skipped, then exit the case and print the skip log