### PR TITLE
Update Network related script to support fedora test

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NET_Corruption.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_Corruption.sh
@@ -26,6 +26,7 @@ function InstallNetcat
     LogMsg "Installing netcat"
     SetTestStateRunning
     if [[ "$os_VENDOR" == "Red Hat" ]] || \
+    [[ "$os_VENDOR" == "Fedora" ]] || \
     [[ "$os_VENDOR" == "CentOS" ]]; then
         yum install nc -y
     elif [ "$os_VENDOR" == "SUSE LINUX" ]; then
@@ -66,7 +67,7 @@ function ConfigInterface
     # Disable tcp segmentation offload
     ethtool -K eth1 tso off
     ethtool -K eth1 gso off
-    
+
     return 0
 }
 
@@ -80,6 +81,7 @@ function AddNIC
     LogMsg "os_VENDOR=$os_VENDOR"
     SetTestStateRunning
     if [[ "$os_VENDOR" == "Red Hat" ]] || \
+    [[ "$os_VENDOR" == "Fedora" ]] || \
     [[ "$os_VENDOR" == "CentOS" ]]; then
         LogMsg "Info : Creating ifcfg-${ifName}"
         cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-${ifName}

--- a/WS2012R2/lisa/remote-scripts/ica/NET_VerifyHotAddMultiNIC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_VerifyHotAddMultiNIC.sh
@@ -39,6 +39,7 @@ function AddedNic
     #
     echo "os_VENDOR=$os_VENDOR"
     if [[ "$os_VENDOR" == "Red Hat" ]] || \
+       [[ "$os_VENDOR" == "Fedora" ]] || \
        [[ "$os_VENDOR" == "CentOS" ]]; then
             echo "Info : Creating ifcfg-${ethName}"
             cp /etc/sysconfig/network-scripts/ifcfg-eth0 /etc/sysconfig/network-scripts/ifcfg-${ethName}
@@ -90,8 +91,9 @@ function RemovedNic
 
     # Clean up files & check linux log for errors
     if [[ "$os_VENDOR" == "Red Hat" ]] || \
+       [[ "$os_VENDOR" == "Fedora" ]] || \
        [[ "$os_VENDOR" == "CentOS" ]]; then
-            echo "Info: Cleaning up RHEL/CentOS"
+            echo "Info: Cleaning up RHEL/CentOS/Fedora"
             rm -f /etc/sysconfig/network-scripts/ifcfg-${ethName}
             cat /var/log/messages | grep "unable to close device (ret -110)"
             if [ $? -eq 0 ]; then

--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -807,7 +807,7 @@ CreateVlanConfig()
 
 	GetDistro
 	case $DISTRO in
-		redhat*|centos*)
+		redhat*|centos*|fedora*)
 			__file_path="/etc/sysconfig/network-scripts/ifcfg-$__interface"
 			if [ -e "$__file_path" ]; then
 				LogMsg "CreateVlanConfig: warning, $__file_path already exists."

--- a/WS2012R2/lisa/setupscripts/NET_HotAddMultiNIC.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_HotAddMultiNIC.ps1
@@ -3,11 +3,11 @@
 # Linux on Hyper-V and Azure Test Code, ver. 1.0.0
 # Copyright (c) Microsoft Corporation
 #
-# All rights reserved. 
+# All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the ""License"");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0  
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
 # OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
@@ -108,9 +108,9 @@ try
         {
             continue   # Just ignore the parameter
         }
-    
+
         $val = $tokens[1].Trim()
-    
+
         switch($tokens[0].Trim().ToLower())
         {
         "ipv4"          { $ipv4        = $val }
@@ -247,7 +247,7 @@ try
     {
         Throw "Error: Unable to Hot Add NIC to VM '${vmName}' on server '${hvServer}'"
     }
-
+    start-sleep -s 3
     #
     # Run the NET_VerifyHotAddSyntheticNIC.sh on the SUT VM to verify the VM detected the hot add
     #

--- a/WS2012R2/lisa/setupscripts/NET_HotAddRemoveNIC.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_HotAddRemoveNIC.ps1
@@ -3,11 +3,11 @@
 # Linux on Hyper-V and Azure Test Code, ver. 1.0.0
 # Copyright (c) Microsoft Corporation
 #
-# All rights reserved. 
+# All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the ""License"");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0  
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
 # OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
@@ -40,8 +40,8 @@
                 Bring eth1 online and acquire a DHCP address
             if "removed"
                 Verify this is only one eth device.
-        Hot remove the NIC 
-        Check VM log for errors 
+        Hot remove the NIC
+        Check VM log for errors
 
     A sample LISA test case definition would look similar to the following:
 
@@ -110,9 +110,9 @@ try
         {
             continue   # Just ignore the parameter
         }
-    
+
         $val = $tokens[1].Trim()
-    
+
         switch($tokens[0].Trim().ToLower())
         {
         "ipv4"          { $ipv4        = $val }
@@ -220,7 +220,7 @@ try
         Write-Output "Info: This test requires Windows Server 2016 or higher" | Tee-Object -Append -file $summaryLog
         return $Skipped
     }
-    
+
     #
     # Verify the target VM does not have a Hot Add NIC.  If it does, then assume
     # there is a test configuration or setup issue, and fail the test.
@@ -249,7 +249,7 @@ try
     {
         Throw "Error: Unable to Hot Add NIC to VM '${vmName}' on server '${hvServer}'"
     }
-
+    start-sleep -s 3
     #
     # Run the NET_VerifyHotAddSyntheticNIC.sh on the SUT VM to verify the VM detected the hot add
     #

--- a/WS2012R2/lisa/setupscripts/NET_VLAN_TRUNKING.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_VLAN_TRUNKING.ps1
@@ -487,14 +487,14 @@ $isDynamic = $false
 $params = $testParams.Split(';')
 foreach ($p in $params) {
     $fields = $p.Split("=")
-    switch ($fields[0].Trim()) { 
+    switch ($fields[0].Trim()) {
         "NIC"
         {
             $nicArgs = $fields[1].Split(',')
             if ($nicArgs.Length -eq 3) {
                 $CurrentDir= "$pwd\"
-                $testfile = "macAddress.file" 
-                $pathToFile="$CurrentDir"+"$testfile" 
+                $testfile = "macAddress.file"
+                $pathToFile="$CurrentDir"+"$testfile"
                 $isDynamic = $true
             }
         }
@@ -571,7 +571,7 @@ foreach ($p in $params)
         }
 
         if ($isDynamic -eq $true){
-            $vm1MacAddress = $streamReader.ReadLine() 
+            $vm1MacAddress = $streamReader.ReadLine()
         }
         else {
             $retVal = isValidMAC $vm1MacAddress
@@ -580,7 +580,7 @@ foreach ($p in $params)
             {
                 "Invalid Mac Address $vm1MacAddress"
                 return $false
-            }  
+            }
         }
 
         #
@@ -601,7 +601,7 @@ foreach ($p in $params)
     }
 }
 
-if ($isDynamic -eq $true) 
+if ($isDynamic -eq $true)
 {
     $streamReader.close()
 }
@@ -641,10 +641,10 @@ Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append 
 #
 # Check if the distro version is unsupported
 #
-$sts = SendCommandToVM $ipv4 $sshKey "cat /etc/redhat-release | grep -v '7.\|6.[7-9]'"
+$sts = SendCommandToVM $ipv4 $sshKey "cat /etc/redhat-release | grep -v '7.\|6.[7-9]\|Fedora'"
 if ($sts[-1]){
     Write-Output "VLAN Trunking is not supported on RHEL/CentOS 6.x and below" | Tee-Object -Append -file $summaryLog
-    return $Skipped    
+    return $Skipped
 }
 
 #set the parameter for the snapshot
@@ -1196,7 +1196,7 @@ if (-not $retVal)
 
     Set-VMNetworkAdapterVlan -VMNetworkAdapter $vm1Nic -Untagged
     Set-VMNetworkAdapterVlan -VMNetworkAdapter $vm2Nic -Untagged
-	
+
     RemoveVlanInterfaceConfig $vm2ipv4 $sshKey $vm2MacAddress $vlanID
 
     Stop-VM -VMName $vm2name -ComputerName $hvServer -force


### PR DESCRIPTION
Mainly fix fedora test error in network cases:
ChangeNetTypeGuest,CopyBothWayss,VlanTagging,VlanTrunking,Network_Hang_Vxlan,TCP_Corruption,HotAddMultiNIC,HotAddRemoveNic,HotAddRemoveMaxNic by add "Fedora" distribution and add sleep time.