### PR TITLE
Dynamic Memory - New TCs, code cleanup & improvements

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_CONFIGURE_MEMORY.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_CONFIGURE_MEMORY.ps1
@@ -172,6 +172,7 @@ foreach ($p in $params)
 
     elseif($temp[0].Trim() -eq "maxMem")
     {
+      $maxMem_xmlValue = $temp[1].Trim()
       $tPmaxMem = ConvertToMemSize $temp[1].Trim() $hvServer
 
       if ($tPmaxMem -le 0)
@@ -181,12 +182,11 @@ foreach ($p in $params)
       }
 
       "maxMem: $tPmaxMem"
-
     }
 
     elseif($temp[0].Trim() -eq "startupMem")
     {
-
+      $startupMem_xmlValue = $temp[1].Trim()
       $tPstartupMem = ConvertToMemSize $temp[1].Trim() $hvServer
 
       if ($tPstartupMem -le 0)
@@ -196,7 +196,6 @@ foreach ($p in $params)
       }
 
       "startupMem: $tPstartupMem"
-
     }
 
     elseif($temp[0].Trim() -eq "memWeight")
@@ -210,8 +209,8 @@ foreach ($p in $params)
       }
 
       "memWeight: $tPmemWeight"
-	}
-
+	  }
+ 
     # check if we have all variables set
     if ( $vmName -and ($tpEnabled -eq $false -or $tpEnabled -eq $true) -and $tPstartupMem -and ([int64]$tPmemWeight -ge [int64]0) )
     {
@@ -255,6 +254,10 @@ foreach ($p in $params)
 		}
 	  } elseif ($tpEnabled)
       {
+        if ($maxMem_xmlValue -eq $startupMem_xmlValue) 
+        {
+          $tPstartupMem = $tPmaxMem
+        }
         Set-VMMemory -vmName $vmName -ComputerName $hvServer -DynamicMemoryEnabled $tpEnabled `
                       -MinimumBytes $tPminMem -MaximumBytes $tPmaxMem -StartupBytes $tPstartupMem `
                       -Priority $tPmemWeight

--- a/WS2012R2/lisa/setupscripts/DM_CleanShutdown.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_CleanShutdown.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that a VM that looses memory shuts down gracefully.
@@ -64,16 +63,13 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
 Set-PSDebug -Strict
-
 
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -104,9 +100,6 @@ $sshKey = $null
 # IP Address of first VM
 $ipv4 = $null
 
-# IP Address of second VM
-$vm2ipv4 = $null
-
 # Name of first VM
 $vm1Name = $null
 
@@ -126,36 +119,36 @@ Set-Variable defaultTries -option Constant -value 3
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 # iterator for vmName= parameters. Only 2 are taken into consideration
@@ -172,130 +165,92 @@ foreach ($p in $params)
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
-
+      "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmNames.count -lt 2)
 {
-  "Error: two VMs are necessary for the DM_CleanShutdown test."
-  return $false
+    "Error: two VMs are necessary for the DM_CleanShutdown test." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm1Name = $vmNames[0]
 $vm2Name = $vmNames[1]
-
 if ($vm1Name -notlike $vmName)
 {
-  if ($vm2Name -like $vmName)
-  {
-    # switch vm1Name with vm2Name
-    $vm1Name = $vmNames[1]
-    $vm2Name = $vmNames[0]
-  }
-  else
-  {
-    "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml."
-    return $false
-  }
+    if ($vm2Name -like $vmName)
+    {
+        # switch vm1Name with vm2Name
+        $vm1Name = $vmNames[1]
+        $vm2Name = $vmNames[0]
+    }
+    else
+    {
+        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
+        return $false
+    }
 }
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm2)
 {
-  "Error: VM $vm2Name does not exist"
-  return $false
+    "Error: VM $vm2Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # sleep 1 minute for VM to start reporting demand
 $sleepPeriod = 60
-
 while ($sleepPeriod -gt 0)
 {
-  # get VM1's Memory
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+    # get VM1's Memory
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
-  {
-    break
-  }
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  $sleepPeriod -= 5
-  start-sleep -s 5
+    $sleepPeriod -= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0)
 {
-  "Error: $vm1Name Assigned memory is 0"
-  return $false
+    "Error: $vm1Name Assigned memory is 0" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($vm1BeforeDemand -le 0)
 {
-  "Error: $vm1Name Memory demand is 0"
-  return $false
+    "Error: $vm1Name Memory demand is 0" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 "VM1 $vm1Name before assigned memory : $vm1BeforeAssigned"
 "VM1 $vm1Name before memory demand: $vm1BeforeDemand"
-
 #
 # LIS Started VM1, so start VM2
 #
-Start-sleep -s 20
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-
-  [int]$i = 0
-  # try to start VM2
-  for ($i=0; $i -lt $tries; $i++)
-  {
-
-    Start-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-    if (-not $?)
-    {
-      "Warning: Unable to start VM ${vm2Name} on attempt $i"
-    }
-    else
-    {
-      $i = 0
-      break
-    }
-
-    Start-sleep -s 30
-  }
-
-  if ($i -ge $tries)
-  {
-    "Error: Unable to start VM2 after $tries attempts"
-    return $false
-  }
-
-}
-
-# just to make sure vm2 started
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-  "Error: $vm2Names never started."
-  return $false
-}
-
+Start-Sleep -s 20
+StartDependencyVM $vm2Name $hvServer $tries
 WaitForVMToReportDemand $vm1Name $hvServer $timeout
 
 # get VM1's Memory
@@ -304,16 +259,16 @@ WaitForVMToReportDemand $vm1Name $hvServer $timeout
 
 if ($vm1AfterAssigned -le 0)
 {
-  "Error: $vm1Name Assigned memory is 0 after $vm2Name started"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name Assigned memory is 0 after $vm2Name started" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($vm1AfterDemand -le 0)
 {
-  "Error: $vm1Name Memory demand is 0 after $vm2Name started"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name Memory demand is 0 after $vm2Name started" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 "VM1 $vm1Name after assigned memory : $vm1AfterAssigned"
@@ -330,20 +285,19 @@ if ($vm1AfterDemand -le 0)
 # Assigned memory needs to have lowered after VM2 starts.
 if ($vm1AssignedDelta -le 0)
 {
-  "Error: $vm1Name did not lower its assigned Memory after vm2 started."
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name did not lower its assigned Memory after vm2 started." | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 $timeout = 120 #seconds
 
 Stop-VM -vmName $vm1Name -ComputerName $hvServer -force
-
 if (-not $?)
 {
-  "Error: $vm1Name did not shutdown via Hyper-V"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name did not shutdown via Hyper-V" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 # vm1 shut down gracefully via Hyper-V, so shutdown vm2

--- a/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that the assigned memory never exceeds the VMs Maximum Memory setting.
@@ -66,120 +65,11 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
-# we need a scriptblock in order to pass this function to start-job
-$scriptBlock = {
-  # function for starting stresstestapp
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir, [int]$timeoutStress, [int64]$memMB)
-  {
-
-  # because function is called as job, setup rootDir and source TCUtils again
-  if (Test-Path $rootDir)
-  {
-    Set-Location -Path $rootDir
-    if (-not $?)
-    {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-    }
-    "Changed working directory to $rootDir"
-  }
-  else
-  {
-    "Error: RootDir = $rootDir is not a valid path"
-    return $false
-  }
-
-  # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1")
-  {
-    . .\setupScripts\TCUtils.ps1
-    "Sourced TCUtils.ps1"
-  }
-  else
-  {
-    "Error: Could not find setupScripts\TCUtils.ps1"
-    return $false
-  }
-
-
-      $cmdToVM = @"
-#!/bin/bash
-        if [ ! -e /proc/meminfo ]; then
-          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
-          exit 100
-        fi
-
-        rm ~/HotAddErrors.log -f
-        dos2unix check_traces.sh
-        chmod +x check_traces.sh
-        ./check_traces.sh ~/HotAddErrors.log &
-
-        __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
-        __totalMem=`$((__totalMem/1024))
-        echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
-        declare -i __chunks
-        declare -i __threads
-        declare -i duration
-        declare -i timeout
-        __chunks=128
-        __threads=`$(($memMB/__chunks))
-        if [ $timeoutStress -eq 1 ]; then
-          timeout=4000000
-          duration=`$((5*__threads))
-        else
-          timeout=10000000
-          duration=`$((9*__threads))
-        fi
-        echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1
-        echo "Other info: chunks: `$__chunks , memory: $memMB" >> /root/HotAdd.log 2>&1
-        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
-        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
-        wait
-        exit 0
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "ConsumeMem.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal[-1])
-    {
-      return $false
-    }
-
-    # execute command as job
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-
-  }
-}
-
-
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -210,9 +100,6 @@ $sshKey = $null
 # IP Address of first VM
 $ipv4 = $null
 
-# IP Address of second VM
-$vm2ipv4 = $null
-
 # Name of first VM
 $vm1Name = $null
 
@@ -232,36 +119,36 @@ Set-Variable defaultTries -option Constant -value 3
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -271,136 +158,85 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
-      "ipv4"    { $ipv4    = $fields[1].Trim() }
-      "sshKey"  { $sshKey  = $fields[1].Trim() }
-      "tries"  { $tries  = $fields[1].Trim() }
+        "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+        "ipv4"    { $ipv4    = $fields[1].Trim() }
+        "sshKey"  { $sshKey  = $fields[1].Trim() }
+        "tries"  { $tries  = $fields[1].Trim() }
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script."
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmNames.count -lt 2)
 {
-  "Error: two VMs are necessary for the Maximum Memory Honored test."
-  return $false
+    "Error: two VMs are necessary for the Maximum Memory Honored test."
+    return $false
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 $vm1Name = $vmNames[0]
 $vm2Name = $vmNames[1]
-
 if ($vm1Name -notlike $vmName)
 {
-  if ($vm2Name -like $vmName)
-  {
-    # switch vm1Name with vm2Name
-    $vm1Name = $vmNames[1]
-    $vm2Name = $vmNames[0]
-
-  }
-  else
-  {
-    "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml."
-    return $false
-  }
-}
-
-$vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
-if (-not $vm1)
-{
-  "Error: VM $vm1Name does not exist"
-  return $false
-}
-
-$vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
-if (-not $vm2)
-{
-  "Error: VM $vm2Name does not exist"
-  return $false
-}
-
-
-#
-# LIS Started VM1, so start VM2
-#
-
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-
-  [int]$i = 0
-  # try to start VM2
-  for ($i=0; $i -lt $tries; $i++)
-  {
-
-    Start-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-    if (-not $?)
+    if ($vm2Name -like $vmName)
     {
-      "Warning: Unable to start VM ${vm2Name} on attempt $i"
+        # switch vm1Name with vm2Name
+        $vm1Name = $vmNames[1]
+        $vm2Name = $vmNames[0]
     }
     else
     {
-      $i = 0
-      break
+        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
+        return $false
     }
-
-    Start-sleep -s 30
-  }
-
-  if ($i -ge $tries)
-  {
-    "Error: Unable to start VM2 after $tries attempts"
-    return $false
-  }
-
 }
 
-# just to make sure vm2 started
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
+$vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
+if (-not $vm1)
 {
-  "Error: $vm2Names never started."
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+$vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
+if (-not $vm2)
+{
+    "Error: VM $vm2Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # Check if stress-ng is installed
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng"
-
 if (-not $retVal)
 {
-    "stress-ng is not installed! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
 
 "stress-ng is installed! Will begin running memory stress tests shortly."
+$timeoutStress = 0
 
-# Check kernel version
-$sts = check_kernel
-
-if (-not $sts) {
-  "ERROR: Could not check kernel version"
-  $retVal = $False
-}
-elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
-  $timeoutStress = 8
-}
-else {
-  "Kernel version: ${sts}"
-  $timeoutStress = 1
-}
+#
+# LIS Started VM1, so start VM2
+#
+$timeout = 120
+StartDependencyVM $vm2Name $hvServer $tries
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 
 # get memory stats from vm1 and vm2
 # wait up to 2 min for it
@@ -409,133 +245,117 @@ $sleepPeriod = 120 #seconds
 # get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+    [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/1MB)
+    [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/1MB)
 
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
-  [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/1MB)
-  [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/1MB)
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
-  {
-    break
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm2BeforeAssigned -le 0 -or $vm2BeforeDemand -le 0)
 {
-  "Error: vm1 or vm2 reported 0 memory (assigned or demand)."
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $False
+    "Error: vm1 or vm2 reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $False
 }
 
 "Memory stats after both $vm1Name and $vm2Name started reporting "
 "  ${vm1Name}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
 "  ${vm2Name}: assigned - $vm2BeforeAssigned | demand - $vm2BeforeDemand"
 
-# get vm2 IP
-$vm2ipv4 = GetIPv4 $vm2Name $hvServer
-
-# wait for ssh to start on vm2
-$timeout = 30 #seconds
-if (-not (WaitForVMToStartSSH $vm2ipv4 $timeout))
-{
-    "Error: VM ${vm2Name} never started ssh"
-    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-    return $False
-}
-
-# Calculate the amount of memory to be consumed on VM1 and VM2 with stresstestapp
+# Calculate the amount of memory to be consumed on VM1 and VM2 with stress-ng
 [int64]$vm1ConsumeMem = (Get-VMMemory -VM $vm1).Maximum
 
 # transform to MB
 $vm1ConsumeMem /= 1MB
+$duration = 420
 
 # Send Command to consume
-$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem} -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem)
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem, $duration) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem $duration} -InitializationScript $DM_scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem,$duration)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
-# sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 180
-# get memory stats for vm1 after stresstestapp starts
+# sleep a few seconds so all stress-ng processes start and the memory assigned/demand gets updated
+Start-Sleep -s 400
+# get memory stats for vm1 after stress-ng starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
 [int64]$vm2Assigned = ($vm2.MemoryAssigned/1MB)
 [int64]$vm2Demand = ($vm2.MemoryDemand/1MB)
 
-"Memory stats after $vm1Name started stresstestapp"
+"Memory stats after $vm1Name started stress-ng"
 "  ${vm1Name}: assigned - $vm1Assigned | demand - $vm1Demand"
 "  ${vm2Name}: assigned - $vm2Assigned | demand - $vm2Demand"
 
 if ($vm1Demand -le $vm1BeforeDemand -or $vm1Assigned -le $vm1BeforeAssigned)
 {
-  "Error: Memory Demand or Assignation on $vm1Name did not increase after starting stresstestapp"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: Memory Demand or Assignation on $vm1Name did not increase after starting stress-ng" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($vm2Assigned -ge $vm2BeforeAssigned)
 {
-  "Error: Memory Demand on $vm2Name did not decrease after starting stresstestapp"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: Memory Demand on $vm2Name did not decrease after starting stress-ng" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
-
 
 # Wait for jobs to finish now and make sure they exited successfully
 $timeout = 240
 $firstJobStatus = $false
 while ($timeout -gt 0)
 {
-
-  if ($job1.Status -like "Completed")
-  {
-    $firstJobStatus = $true
-    $retVal = Receive-Job $job1
-    if (-not $retVal[-1])
+    if ($job1.Status -like "Completed")
     {
-      "Error: Consume Memory script returned false on VM1 $vm1Name"
-      return $false
+        $firstJobStatus = $true
+        $retVal = Receive-Job $job1
+        if (-not $retVal[-1])
+        {
+            "Error: Consume Memory script returned false on VM1 $vm1Name" | Tee-Object -Append -file $summaryLog
+            return $false
+        }
+        $diff = $totalTimeout - $timeout
+        "Job finished in $diff seconds."
     }
-    $diff = $totalTimeout - $timeout
-    "Job finished in $diff seconds."
-  }
 
-  if ($firstJobStatus)
-  {
-    break
-  }
+    if ($firstJobStatus)
+    {
+        break
+    }
 
-  $timeout -= 1
-  start-sleep -s 1
-
+    $timeout -= 1
+    Start-Sleep -s 1
 }
 
-start-sleep -s 20
+Start-Sleep -s 20
 # stop vm2
 Stop-VM -VMName $vm2name -ComputerName $hvServer -force
 
 # Verify if errors occured on guest
 $isAlive = WaitForVMToStartKVP $vm1Name $hvServer 10
 if (-not $isAlive){
-  "Error: VM is unresponsive after running the memory stress test"
-  return $false
+    "Error: VM is unresponsive after running the memory stress test" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $errorsOnGuest = echo y | bin\plink -i ssh\${sshKey} root@$ipv4 "cat HotAddErrors.log"
 if (-not  [string]::IsNullOrEmpty($errorsOnGuest)){
-  $errorsOnGuest
-  return $false
+    $errorsOnGuest
+    return $false
 }
 
 # Everything ok
-"Memory Hot Add/Remove completed successfully "
+Write-Output "Memory Hot Add/Remove completed successfully" | Tee-Object -Append -file $summaryLog
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
@@ -232,9 +232,14 @@ if ($timeoutStress -eq 0) {
     $duration = 0
     $chunk = 0
 }
-elseif ($timeoutStress -eq 1){
+elseif ($timeoutStress -eq 1) {
     $sleepTime = 60
     $duration = 120
+    $chunk = 1
+}
+elseif ($timeoutStress -eq 2) {
+    $sleepTime = 20
+    $duration = 40
     $chunk = 1
 }
 else {

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that demand changes with memory pressure inside the VM.
@@ -66,119 +65,11 @@
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
 
-# we need a scriptblock in order to pass this function to start-job
-$scriptBlock = {
-  # function for starting stresstestapp
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir, [int]$timeoutStress, [int64]$memMB)
-  {
-
-  # because function is called as job, setup rootDir and source TCUtils again
-  if (Test-Path $rootDir)
-  {
-    Set-Location -Path $rootDir
-    if (-not $?)
-    {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-    }
-    "Changed working directory to $rootDir"
-  }
-  else
-  {
-    "Error: RootDir = $rootDir is not a valid path"
-    return $false
-  }
-
-  # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1")
-  {
-    . .\setupScripts\TCUtils.ps1
-    "Sourced TCUtils.ps1"
-  }
-  else
-  {
-    "Error: Could not find setupScripts\TCUtils.ps1"
-    return $false
-  }
-
-
-      $cmdToVM = @"
-#!/bin/bash
-        if [ ! -e /proc/meminfo ]; then
-          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
-          exit 100
-        fi
-
-        rm ~/HotAddErrors.log -f
-        dos2unix check_traces.sh
-        chmod +x check_traces.sh
-        ./check_traces.sh ~/HotAddErrors.log &
-
-        __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
-        __totalMem=`$((__totalMem/1024))
-        echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
-        declare -i __chunks
-        declare -i __threads
-        declare -i duration
-        declare -i timeout
-        __chunks=128
-        __threads=`$(($memMB/__chunks))
-        if [ $timeoutStress -eq 1 ]; then
-          timeout=4000000
-          duration=`$((5*__threads))
-        else
-          timeout=10000000
-          duration=`$((9*__threads))
-        fi
-        echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1
-        echo "Other info: chunks: `$__chunks , memory: $memMB" >> /root/HotAdd.log 2>&1
-        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
-        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
-        wait
-        exit 0
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "ConsumeMem.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal[-1])
-    {
-      return $false
-    }
-
-    # execute command as job
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-
-  }
-}
-
-
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -212,46 +103,46 @@ $ipv4 = $null
 # Name of first VM
 $vm1Name = $null
 
-# number of tries
+# Number of tries
 [int]$tries = 0
 
-# default number of tries
+# Default number of tries
 Set-Variable defaultTries -option Constant -value 3
 
-# change working directory to root dir
+# Change working directory to root dir
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -261,120 +152,115 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vm1Name =$fields[1].Trim() }
-      "ipv4"    { $ipv4    = $fields[1].Trim() }
-      "sshKey"  { $sshKey  = $fields[1].Trim() }
-      "tries"  { $tries  = $fields[1].Trim() }
+        "vmName"  { $vm1Name =$fields[1].Trim() }
+        "ipv4"    { $ipv4    = $fields[1].Trim() }
+        "sshKey"  { $sshKey  = $fields[1].Trim() }
+        "tries"  { $tries  = $fields[1].Trim() }
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+        "Stress_Level" { $timeoutStress = $fields[1].Trim() }
     }
 
 }
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script."
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmName -notlike $vm1Name)
 {
-  "Error: the VMName testParam needs to be the same as the VMName from the global setting"
-  return $false
+    "Error: the VMName testParam needs to be the same as the VMName from the global setting"
+    return $false
 }
 
-
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist"
+    return $false
 }
 
 # Check if stress-ng is installed
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng"
-
 if (-not $retVal)
 {
-    "stress-ng is not installed! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
 
-"stress-ng is installed! Will begin running memory stress tests shortly."
-
-# Check kernel version
-$sts = check_kernel
-
-if (-not $sts) {
-  "ERROR: Could not check kernel version"
-  $retVal = $False
-}
-elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
-  $timeoutStress = 8
-}
-else {
-  "Kernel version: ${sts}"
-  $timeoutStress = 1
-}
-
-# get memory stats from vm1
-# wait up to 2 min for it
-start-sleep -s 40
-
+Start-Sleep -s 40
 $sleepPeriod = 120 #seconds
-
-# get VM1 and VM2's Memory
+# Get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
 
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
-  {
-    break
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
   }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
-}
 
 if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 {
-  "Error: vm1 $vm1Name reported 0 memory (assigned or demand)."
-  return $False
+    "Error: vm1 $vm1Name reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    return $False
 }
 
 "Memory stats after $vm1Name started reporting "
 "  ${vm1Name}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
 
-# Calculate the amount of memory to be consumed on VM1 and VM2 with stresstestapp
+# Set the amount of sleep time needed
+if ($timeoutStress -eq 0) {
+    $sleepTime = 200
+    $duration = 0
+    $chunk = 0
+}
+elseif ($timeoutStress -eq 1){
+    $sleepTime = 60
+    $duration = 120
+    $chunk = 1
+}
+else {
+    $sleepTime = 20
+    $duration = 40
+    $chunk = 1
+}
+
+# Calculate the amount of memory to be consumed on VM1 and VM2 with stress-ng
 [int64]$vm1ConsumeMem = (Get-VMMemory -VM $vm1).Maximum
 
-# transform to MB
+# Transform to MB
 $vm1ConsumeMem /= 1MB
 
 # Send Command to consume
-$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem} -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem)
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem, $duration, $chunk) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem $duration $chunk} -InitializationScript $DM_scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem, $duration, $chunk)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-
-  return $false
+    "Error: Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
-# sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
-start-sleep -s 120
-# get memory stats for vm1 after stress-ng starts
+# Wait for stress-ng to start and the memory assigned/demand gets updated
+Start-Sleep -s $sleepTime
+
+# Get memory stats for vm1 after stress-ng starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
 
@@ -383,55 +269,52 @@ start-sleep -s 120
 
 if ($vm1Demand -le $vm1BeforeDemand)
 {
-  "Error: Memory Demand did not increase after starting stress-ng"
-  return $false
+    "Error: Memory Demand did not increase after starting stress-ng" | Tee-Object -Append -file $summaryLog
+    return $false
 }
-
 
 # Wait for jobs to finish now and make sure they exited successfully
 $timeout = 240
 $firstJobStatus = $false
 while ($timeout -gt 0)
 {
-
-  if ($job1.Status -like "Completed")
-  {
-    $firstJobStatus = $true
-    $retVal = Receive-Job $job1
-    if (-not $retVal[-1])
+    if ($job1.Status -like "Completed")
     {
-      "Error: Consume Memory script returned false on VM1 $vm1Name"
-      return $false
+        $firstJobStatus = $true
+        $retVal = Receive-Job $job1
+        if (-not $retVal[-1])
+        {
+          "Error: Consume Memory script returned false on VM1 $vm1Name" | Tee-Object -Append -file $summaryLog
+          return $false
+        }
+        $diff = $totalTimeout - $timeout
+        "Job finished in $diff seconds."
     }
-    $diff = $totalTimeout - $timeout
-    "Job finished in $diff seconds."
-  }
 
-  if ($firstJobStatus)
-  {
-    break
-  }
+    if ($firstJobStatus)
+    {
+        break
+    }
 
-  $timeout -= 1
-  start-sleep -s 1
-
+    $timeout -= 1
+    Start-Sleep -s 1
 }
 
 # Verify if errors occured on guest
 $isAlive = WaitForVMToStartKVP $vm1Name $hvServer 10
 if (-not $isAlive){
-  "Error: VM is unresponsive after running the memory stress test"
-  return $false
+    "Error: VM is unresponsive after running the memory stress test" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $errorsOnGuest = echo y | bin\plink -i ssh\${sshKey} root@$ipv4 "cat HotAddErrors.log"
 if (-not  [string]::IsNullOrEmpty($errorsOnGuest)){
-  $errorsOnGuest
-  return $false
+    $errorsOnGuest | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
-start-sleep -s 20
-# get memory stats after stress-ng finished
+Start-Sleep -s 20
+# Get memory stats after stress-ng finished
 [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB)
 
@@ -440,9 +323,9 @@ start-sleep -s 20
 
 if ($vm1AfterDemand -ge $vm1Demand)
 {
-  "Error: Demand did not go down after stress-ng finished."
-  return $false
+    "Error: Demand did not go down after stress-ng finished." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
-"Memory Hot Add (using stress-ng) completed successfully!"
+"Memory Hot Add (using stress-ng) completed successfully!" | Tee-Object -Append -file $summaryLog
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_stressapptest.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_stressapptest.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that demand changes with memory pressure inside the VM.
@@ -68,45 +67,43 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 
 # we need a scriptblock in order to pass this function to start-job
 $scriptBlock = {
-  # function for starting stresstestapp
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir, [int]$timeoutStress)
-  {
-
-  # because function is called as job, setup rootDir and source TCUtils again
-  if (Test-Path $rootDir)
-  {
-    Set-Location -Path $rootDir
-    if (-not $?)
+    # function for starting stresstestapp
+    function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir, [int]$timeoutStress)
     {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-    }
-    "Changed working directory to $rootDir"
-  }
-  else
-  {
-    "Error: RootDir = $rootDir is not a valid path"
-    return $false
-  }
+      # because function is called as job, setup rootDir and source TCUtils again
+      if (Test-Path $rootDir)
+      {
+          Set-Location -Path $rootDir
+          if (-not $?)
+          {
+              "Error: Could not change directory to $rootDir !"
+              return $false
+          }
+          "Changed working directory to $rootDir"
+      }
+      else
+      {
+          "Error: RootDir = $rootDir is not a valid path"
+          return $false
+      }
 
-  # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1")
-  {
-    . .\setupScripts\TCUtils.ps1
-    "Sourced TCUtils.ps1"
-  }
-  else
-  {
-    "Error: Could not find setupScripts\TCUtils.ps1"
-    return $false
-  }
-
+      # Source TCUitls.ps1 for getipv4 and other functions
+      if (Test-Path ".\setupScripts\TCUtils.ps1")
+      {
+          . .\setupScripts\TCUtils.ps1
+          "Sourced TCUtils.ps1"
+      }
+      else
+      {
+          "Error: Could not find setupScripts\TCUtils.ps1"
+          return $false
+      }
 
       $cmdToVM = @"
 #!/bin/bash
         if [ ! -e /proc/meminfo ]; then
-          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
-          exit 100
+            echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
+            exit 100
         fi
 
         rm ~/HotAddErrors.log -f
@@ -118,65 +115,57 @@ $scriptBlock = {
         __totalMem=`$((__totalMem/1024))
         echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
         __chunks=128
-        declare -i __iterations
-        declare -i duration
-        if [ $timeoutStress -eq 1 ]; then
-          duration=10
-        else
-          duration=$timeoutStress*10/2
-        fi
-        __iterations=100+`$duration
-        echo "Going to start `$__iterations instance(s) of stresstestapp with a duration of `$duration and a timeout of $timeoutStress each consuming 128MB memory" >> /root/HotAdd.log 2>&1
+        __duration=280
+        __iterations=28
+        echo "Going to start `$__iterations instance(s) of stresstestapp with a __duration of `$__duration and a timeout of $timeoutStress each consuming 128MB memory" >> /root/HotAdd.log 2>&1
         for ((i=0; i < `$__iterations; i++)); do
-          stressapptest -M `$__chunks -s `$duration &
-          sleep $timeoutStress
+            stressapptest -M `$__chunks -s `$__duration &
+            __duration=`$((`$__duration - 10))
+            sleep $timeoutStress
         done
         echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
         wait
         exit 0
 "@
 
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "ConsumeMem.sh"
+      #"pingVMs: sendig command to vm: $cmdToVM"
+      $filename = "ConsumeMem.sh"
 
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-      Remove-Item ".\${filename}"
-    }
+      # check for file
+      if (Test-Path ".\${filename}")
+      {
+          Remove-Item ".\${filename}"
+      }
 
-    Add-Content $filename "$cmdToVM"
+      Add-Content $filename "$cmdToVM"
 
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+      # send file
+      $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
 
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-      Remove-Item ".\${filename}"
-    }
+      # delete file unless the Leave_trail param was set to yes.
+      if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
+      {
+          Remove-Item ".\${filename}"
+      }
 
-    # check the return Value of SendFileToVM
-    if (-not $retVal[-1])
-    {
-      return $false
-    }
+      # check the return Value of SendFileToVM
+      if (-not $retVal[-1])
+      {
+          return $false
+      }
 
-    # execute command as job
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+      # execute command as job
+      $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
 
-    return $retVal
-
+      return $retVal
   }
 }
-
 
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -220,36 +209,36 @@ Set-Variable defaultTries -option Constant -value 3
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
-$rootDir = $Matches[1]
 
+$rootDir = $Matches[1]
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -263,93 +252,75 @@ foreach ($p in $params)
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
+      "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script."
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmName -notlike $vm1Name)
 {
-  "Error: the VMName testParam needs to be the same as the VMName from the global setting"
-  return $false
+    "Error: the VMName testParam needs to be the same as the VMName from the global setting"
+    return $false
 }
 
-
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # Check if stressapptest is installed
 "Checking if Stressapptest is installed"
 
 $retVal = check_app "stressapptest"
-
 if (-not $retVal)
 {
-    "Stressapptest is not installed! Please install it before running the memory stress tests."
+    "Stressapptest is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
 
 "Stressapptest is installed! Will begin running memory stress tests shortly."
 
-# Check kernel version
-$sts = check_kernel
-
-if (-not $sts) {
-  "ERROR: Could not check kernel version"
-  $retVal = $False
-}
-elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stressapp processes."
-  $timeoutStress = 8
-}
-else {
-  "Kernel version: ${sts}"
-  $timeoutStress = 1
-}
-
+$timeoutStress = 10
 # get memory stats from vm1
 # wait up to 2 min for it
-start-sleep -s 30
+Start-Sleep -s 30
 
 $sleepPeriod = 120 #seconds
-
 # get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
 
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
-  {
-    break
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 {
-  "Error: vm1 $vm1Name reported 0 memory (assigned or demand)."
-  return $False
+    "Error: vm1 $vm1Name reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    return $False
 }
 
 "Memory stats after $vm1Name started reporting "
@@ -359,13 +330,12 @@ if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 $job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress) ConsumeMemory $ip $sshKey $rootDir $timeoutStress } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-
-  return $false
+    "Error: Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
-# sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 100
+# sleep a few seconds so stresstestapp processes start and the memory assigned/demand gets updated
+Start-Sleep -s 100
 # get memory stats for vm1 after stresstestapp starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
@@ -375,54 +345,51 @@ start-sleep -s 100
 
 if ($vm1Demand -le $vm1BeforeDemand)
 {
-  "Error: Memory Demand did not increase after starting stresstestapp"
-  return $false
+    "Error: Memory Demand did not increase after starting stresstestapp" | Tee-Object -Append -file $summaryLog
+    return $false
 }
-
 
 # Wait for jobs to finish now and make sure they exited successfully
 $timeout = 240
 $firstJobStatus = $false
 while ($timeout -gt 0)
 {
-
-  if ($job1.Status -like "Completed")
-  {
-    $firstJobStatus = $true
-    $retVal = Receive-Job $job1
-    if (-not $retVal[-1])
+    if ($job1.Status -like "Completed")
     {
-      "Error: Consume Memory script returned false on VM1 $vm1Name"
-      return $false
+        $firstJobStatus = $true
+        $retVal = Receive-Job $job1
+        if (-not $retVal[-1])
+        {
+            "Error: Consume Memory script returned false on VM1 $vm1Name" | Tee-Object -Append -file $summaryLog
+            return $false
+        }
+        $diff = $totalTimeout - $timeout
+        "Job finished in $diff seconds."
     }
-    $diff = $totalTimeout - $timeout
-    "Job finished in $diff seconds."
-  }
 
-  if ($firstJobStatus)
-  {
-    break
-  }
+    if ($firstJobStatus)
+    {
+        break
+    }
 
-  $timeout -= 1
-  start-sleep -s 1
-
+    $timeout -= 1
+    Start-Sleep -s 1
 }
 
 # Verify if errors occured on guest
 $isAlive = WaitForVMToStartKVP $vm1Name $hvServer 10
 if (-not $isAlive){
-  "Error: VM is unresponsive after running the memory stress test"
-  return $false
+    "Error: VM is unresponsive after running the memory stress test" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $errorsOnGuest = echo y | bin\plink -i ssh\${sshKey} root@$ipv4 "cat HotAddErrors.log"
 if (-not  [string]::IsNullOrEmpty($errorsOnGuest)){
-  $errorsOnGuest
-  return $false
+    $errorsOnGuest
+    return $false
 }
 
-start-sleep -s 20
+Start-Sleep -s 20
 # get memory stats after stresstestapp finished
 [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1AfterDemand = ($vm1.MemoryDemand/1MB)
@@ -432,10 +399,10 @@ start-sleep -s 20
 
 if ($vm1AfterDemand -ge $vm1Demand)
 {
-  "Error: Demand did not go down after stresstestapp finished."
-  return $false
+    "Error: Demand did not go down after stresstestapp finished." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # Everything ok
-"Memory Hot Add completed successfully!"
+"Memory Hot Add (using stressapptest) completed successfully!"
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that the assigned memory never exceeds the VMs Maximum Memory setting.
@@ -66,120 +65,11 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
-# we need a scriptblock in order to pass this function to start-job
-$scriptBlock = {
-  # function which $memMB MB of memory on VM with IP $conIpv4 with stresstestapp
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir,[int64]$memMB,[int64]$chunckSize,[int]$duration,[int]$timeoutStress)
-  {
-
-  # because function is called as job, setup rootDir and source TCUtils again
-  if (Test-Path $rootDir)
-  {
-    Set-Location -Path $rootDir
-    if (-not $?)
-    {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-    }
-    "Changed working directory to $rootDir"
-  }
-  else
-  {
-    "Error: RootDir = $rootDir is not a valid path"
-    return $false
-  }
-
-  # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1")
-  {
-    . .\setupScripts\TCUtils.ps1
-    "Sourced TCUtils.ps1"
-  }
-  else
-  {
-    "Error: Could not find setupScripts\TCUtils.ps1"
-    return $false
-  }
-
-
-      $cmdToVM = @"
-#!/bin/bash
-        if [ ! -e /proc/meminfo ]; then
-          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
-          exit 100
-        fi
-
-        rm ~/HotAddErrors.log -f
-        dos2unix check_traces.sh
-        chmod +x check_traces.sh
-        ./check_traces.sh ~/HotAddErrors.log &
-
-        __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
-        __totalMem=`$((__totalMem/1024))
-        echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
-        declare -i __chunks
-        declare -i __threads
-        declare -i duration
-        declare -i timeout
-        __chunks=128
-        __threads=`$(($memMB/__chunks))
-        if [ $timeoutStress -eq 1 ]; then
-          timeout=4000000
-          duration=`$((5*__threads))
-        else
-          timeout=10000000
-          duration=`$((9*__threads))
-        fi
-        echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1
-        echo "Other info: chunks: `$__chunks , memory: $memMB" >> /root/HotAdd.log 2>&1
-        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
-        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
-        wait
-        exit 0
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "ConsumeMemOn${conIpv4}.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal[-1])
-    {
-      return $false
-    }
-
-    # execute command as job
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-
-  }
-}
-
-
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -232,36 +122,36 @@ Set-Variable defaultTries -option Constant -value 3
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -275,25 +165,29 @@ foreach ($p in $params)
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
+      "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmNames.count -lt 2)
 {
-  "Error: two VMs are necessary for the Maximum Memory Honored test."
-  return $false
+    "Error: two VMs are necessary for the Maximum Memory Honored test." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm1Name = $vmNames[0]
@@ -301,76 +195,31 @@ $vm2Name = $vmNames[1]
 
 if ($vm1Name -notlike $vmName)
 {
-  if ($vm2Name -like $vmName)
-  {
-    # switch vm1Name with vm2Name
-    $vm1Name = $vmNames[1]
-    $vm2Name = $vmNames[0]
-
-  }
-  else
-  {
-    "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml."
-    return $false
-  }
-}
-
-$vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
-if (-not $vm1)
-{
-  "Error: VM $vm1Name does not exist"
-  return $false
-}
-
-$vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
-if (-not $vm2)
-{
-  "Error: VM $vm2Name does not exist"
-  return $false
-}
-
-
-#
-# LIS Started VM1, so start VM2
-#
-
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-
-  [int]$i = 0
-  # try to start VM2
-  for ($i=0; $i -lt $tries; $i++)
-  {
-
-    Start-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-    if (-not $?)
+    if ($vm2Name -like $vmName)
     {
-      "Warning: Unable to start VM ${vm2Name} on attempt $i"
+        # switch vm1Name with vm2Name
+        $vm1Name = $vmNames[1]
+        $vm2Name = $vmNames[0]
     }
     else
     {
-      $i = 0
-      break
+        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
+        return $false
     }
-
-    Start-sleep -s 30
-  }
-
-  if ($i -ge $tries)
-  {
-    "Error: Unable to start VM2 after $tries attempts"
-    return $false
-  }
-
 }
 
-# just to make sure vm2 started
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
+$vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
+if (-not $vm1)
 {
-  "Error: $vm2Names never started."
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
+}
+
+$vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
+if (-not $vm2)
+{
+    "Error: VM $vm2Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # Check if stress-ng is installed
@@ -380,28 +229,21 @@ $retVal = check_app "stress-ng"
 
 if (-not $retVal)
 {
-    "stress-ng is not installed! Please install it before running the memory stress tests."
+    "Error: stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
 
 "stress-ng is installed! Will begin running memory stress tests shortly."
 
-# Check kernel version
-$sts = check_kernel
+#
+# LIS Started VM1, so start VM2
+#
+$timeout = 120
+StartDependencyVM $vm2Name $hvServer $tries
+WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+$vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
-if (-not $sts) {
-  "ERROR: Could not check kernel version"
-  $retVal = $False
-}
-elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
-  $timeoutStress = 8
-}
-else {
-  "Kernel version: ${sts}"
-  $timeoutStress = 1
-}
-
+$timeoutStress = 0
 # get memory stats from vm1 and vm2
 # wait up to 2 min for it
 
@@ -409,46 +251,30 @@ $sleepPeriod = 120 #seconds
 # get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+    [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/1MB)
+    [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/1MB)
 
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
-  [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/1MB)
-  [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/1MB)
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
-  {
-    break
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0 -or $vm2BeforeAssigned -le 0 -or $vm2BeforeDemand -le 0)
 {
-  "Error: vm1 or vm2 reported 0 memory (assigned or demand)."
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $False
+    "Error: vm1 or vm2 reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $False
 }
 
 "Memory stats after both $vm1Name and $vm2Name started reporting "
 "  ${vm1Name}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
 "  ${vm2Name}: assigned - $vm2BeforeAssigned | demand - $vm2BeforeDemand"
-
-# get vm2 IP
-$vm2ipv4 = GetIPv4 $vm2Name $hvServer
-
-# wait for ssh to start on vm2
-$timeout = 30 #seconds
-if (-not (WaitForVMToStartSSH $vm2ipv4 $timeout))
-{
-    "Error: VM ${vm2Name} never started ssh"
-    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-    return $False
-}
-
-
 
 # Calculate the amount of memory to be consumed on VM2 with stresstestapp
 [int64]$vm2ConsumeMem = (Get-VMMemory -VM $vm2).Maximum
@@ -458,27 +284,26 @@ $vm2ConsumeMem = ($vm2ConsumeMem / 4) * 3
 $vm2ConsumeMem /= 1MB
 
 # standard chunks passed to stresstestapp
-[int64]$vm2Chunks = 256 #MB
-[int]$vm2Duration = 60 #seconds
+[int64]$chunks = 512 #MB
+[int]$vm2Duration = 420 #seconds
 
 
-$job = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $memMB, $memChunks, $duration, $timeoutStress) ConsumeMemory $ip $sshKey $rootDir $memMB $memChunks $duration $timeoutStress} -InitializationScript $scriptBlock -ArgumentList($vm2ipv4,$sshKey,$rootDir,$vm2ConsumeMem,$vm2Chunks,$vm2Duration,$timeoutStress)
+$job = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm2ConsumeMem, $vm2Duration, $chunks) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm2ConsumeMem $vm2Duration $chunks } -InitializationScript $DM_scriptBlock -ArgumentList($vm2ipv4,$sshKey,$rootDir,$timeoutStress,$vm2ConsumeMem,$vm2Duration,$chunks)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
 # sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 10
-# get memory stats for vm1 and vm2
+Start-Sleep -s 10
 
+# get memory stats for vm1 and vm2
 [int64[]]$vm1Assigned = @()
 [int64[]]$vm1Demand = @()
 [int64[]]$vm2Assigned = @()
 [int64[]]$vm2Demand = @()
-
 [int64]$samples = 0
 
 # Wait for jobs to finish now and make sure they exited successfully
@@ -486,50 +311,48 @@ $totalTimeout = $timeout = 1200
 $jobState = $false
 while ($timeout -gt 0)
 {
-  if ($job.State -like "Completed" -and -not $jobState)
-  {
-    $jobState = $true
-    $retVal = Receive-Job $job
-    if (-not $retVal[-1])
+    if ($job.State -like "Completed" -and -not $jobState)
     {
-      "Error: Consume Memory script returned false on VM2 $vm2Name"
-      Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-      return $false
+        $jobState = $true
+        $retVal = Receive-Job $job
+        if (-not $retVal[-1])
+        {
+            "Error: Consume Memory script returned false on VM2 $vm2Name" | Tee-Object -Append -file $summaryLog
+            Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+            return $false
+        }
+        $diff = $totalTimeout - $timeout
+        "Job2 finished in $diff seconds."
     }
-    $diff = $totalTimeout - $timeout
-    "Job2 finished in $diff seconds."
-  }
 
-  if ($jobState)
-  {
-    break
-  }
+    if ($jobState)
+    {
+        break
+    }
 
-  if (-not ($jobState))
-  {
-    $vm2Assigned = $vm2Assigned + ($vm2.MemoryAssigned/1MB)
-    $vm2Demand = $vm2Demand + ($vm2.MemoryDemand/1MB)
+    if (-not ($jobState))
+    {
+        $vm2Assigned = $vm2Assigned + ($vm2.MemoryAssigned/1MB)
+        $vm2Demand = $vm2Demand + ($vm2.MemoryDemand/1MB)
+        $samples += 1
+    }
 
-    $samples += 1
-  }
-
-  $timeout -= 1
-  start-sleep -s 1
-
+    $timeout -= 1
+    Start-Sleep -s 1
 }
 
 if (-not $jobState)
 {
-  "Error: consume memory script did not finish in $totalTimeout seconds"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: consume memory script did not finish in $totalTimeout seconds" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($samples -le 0)
 {
-  "Error: No data has been sampled."
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: No data has been sampled." | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
 "Got $samples samples"
@@ -542,17 +365,15 @@ $vm1bigger = $vm2bigger = 0
 # count the number of times vm1 had higher assigned memory
 for ($i = 0; $i -lt $samples; $i++)
 {
-  if ($vm2Assigned[$i] -gt $vm2MaxMem)
-  {
-    "Error: $vm2Name assigned memory exceeded the maximum memory set"
-    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-    return $false
-  }
+    if ($vm2Assigned[$i] -gt $vm2MaxMem)
+    {
+        "Error: $vm2Name assigned memory exceeded the maximum memory set" | Tee-Object -Append -file $summaryLog
+        Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+        return $false
+    }
 }
 
 # stop vm2
 Stop-VM -VMName $vm2name -ComputerName $hvServer -force
 
-# Everything ok
-"Success!"
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_MinMemHonor.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_MinMemHonor.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that the ssigned memory never drops below the VMs Minimum Memory setting.
@@ -65,14 +64,11 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
-
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -103,9 +99,6 @@ $sshKey = $null
 # IP Address of first VM
 $ipv4 = $null
 
-# IP Address of second VM
-$vm2ipv4 = $null
-
 # Name of first VM
 $vm1Name = $null
 
@@ -125,36 +118,36 @@ Set-Variable defaultTries -option Constant -value 8
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -168,103 +161,69 @@ foreach ($p in $params)
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
+      "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmNames.count -lt 2)
 {
-  "Error: two VMs are necessary for the Minimum Memory Honored test."
-  return $false
+    "Error: two VMs are necessary for the Minimum Memory Honored test." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm1Name = $vmNames[0]
 $vm2Name = $vmNames[1]
-
 if ($vm1Name -notlike $vmName)
 {
-  if ($vm2Name -like $vmName)
-  {
-    # switch vm1Name with vm2Name
-    $vm1Name = $vmNames[1]
-    $vm2Name = $vmNames[0]
-
-  }
-  else
-  {
-    "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml."
-    return $false
-  }
+    if ($vm2Name -like $vmName)
+    {
+        # switch vm1Name with vm2Name
+        $vm1Name = $vmNames[1]
+        $vm2Name = $vmNames[0]
+    }
+    else
+    {
+        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
+        return $false
+    }
 }
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm2)
 {
-  "Error: VM $vm2Name does not exist"
-  return $false
+    "Error: VM $vm2Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
-
 
 #
 # LIS Started VM1, so start VM2
 #
+$timeout = 120
+StartDependencyVM $vm2Name $hvServer $tries
+WaitForVMToStartKVP $vm2Name $hvServer $timeout 
 
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-
-  [int]$i = 0
-  # try to start VM2
-  for ($i=0; $i -lt $tries; $i++)
-  {
-
-    Start-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-    if (-not $?)
-    {
-      "Warning: Unable to start VM ${vm2Name} on attempt $i"
-    }
-    else
-    {
-      $i = 0
-      break
-    }
-
-    Start-sleep -s 30
-  }
-
-  if ($i -ge $tries)
-  {
-    "Error: Unable to start VM2 after $tries attempts"
-    return $false
-  }
-
-}
-
-# just to make sure vm2 started
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-  "Error: $vm2Names never started."
-  return $false
-}
 # Get VM's minimum memory setting
 [int64]$vm1MinMem = ($vm1.MemoryMinimum/1MB)
 
@@ -277,55 +236,39 @@ $sleepPeriod = 120 #seconds
 # get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
+    [int64]$vm2Assigned = ($vm2.MemoryAssigned/1MB)
+    [int64]$vm2Demand = ($vm2.MemoryDemand/1MB)
 
-  [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
-  [int64]$vm2Assigned = ($vm2.MemoryAssigned/1MB)
-  [int64]$vm2Demand = ($vm2.MemoryDemand/1MB)
+    if ($vm1Assigned -gt 0 -and $vm1Demand -gt 0 -and $vm2Assigned -gt 0 -and $vm2Demand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1Assigned -gt 0 -and $vm1Demand -gt 0 -and $vm2Assigned -gt 0 -and $vm2Demand -gt 0)
-  {
-    break
-  }
+    if ($vm1Assigned -lt $vm1MinMem)
+    {
+        "Error: $vm1Name assigned memory drops below minimum memory set, $vm1MinMem MB" | Tee-Object -Append -file $summaryLog
+        Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+        return $false
+    }
 
-  if ($vm1Assigned -lt $vm1MinMem)
-  {
-    "Error: $vm1Name assigned memory drops below minimum memory set, $vm1MinMem MB"
-    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-    return $false
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    start-sleep -s 5
 }
 
 if ($vm1Assigned -le 0 -or $vm1Demand -le 0 -or $vm2Assigned -le 0 -or $vm2Demand -le 0)
 {
-  "Error: vm1 or vm2 reported 0 memory (assigned or demand)."
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $False
+    "Error: vm1 or vm2 reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $False
 }
 
 "Memory stats after both $vm1Name and $vm2Name started reporting "
 "  ${vm1Name}: assigned - $vm1Assigned | demand - $vm1Demand"
 "  ${vm2Name}: assigned - $vm2Assigned | demand - $vm2Demand"
 
-# get vm2 IP
-$vm2ipv4 = GetIPv4 $vm2Name $hvServer
-
-# wait for ssh to start on vm2
-$timeout = 30 #seconds
-if (-not (WaitForVMToStartSSH $vm2ipv4 $timeout))
-{
-    "Error: VM ${vm2Name} never started ssh"
-    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-    return $False
-}
-
 # stop vm2
 Stop-VM -VMName $vm2name -ComputerName $hvServer -force
 
-# Everything ok
-"Success!"
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_PressureChangesDemand.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_PressureChangesDemand.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that demand changes with memory pressure inside the VM.
@@ -65,120 +64,12 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
 Set-PSDebug -Strict
-
-# we need a scriptblock in order to pass this function to start-job
-$scriptBlock = {
-  # function which $memMB MB of memory on VM with IP $conIpv4 with stresstestapp
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir,[int]$timeoutStress)
-  {
-
-  # because function is called as job, setup rootDir and source TCUtils again
-  if (Test-Path $rootDir)
-  {
-    Set-Location -Path $rootDir
-    if (-not $?)
-    {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-    }
-    "Changed working directory to $rootDir"
-  }
-  else
-  {
-    "Error: RootDir = $rootDir is not a valid path"
-    return $false
-  }
-
-  # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1")
-  {
-    . .\setupScripts\TCUtils.ps1
-    "Sourced TCUtils.ps1"
-  }
-  else
-  {
-    "Error: Could not find setupScripts\TCUtils.ps1"
-    return $false
-  }
-
-
-      $cmdToVM = @"
-#!/bin/bash
-        if [ ! -e /proc/meminfo ]; then
-          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
-          exit 100
-        fi
-
-        rm ~/HotAddErrors.log -f
-        dos2unix check_traces.sh
-        chmod +x check_traces.sh
-        ./check_traces.sh ~/HotAddErrors.log &
-
-        __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
-        __totalMem=`$((__totalMem/1024))
-        echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
-        __chunks=128
-        __threads=16
-        declare -i __iterations
-        declare -i duration
-        declare -i timeout
-        if [ $timeoutStress -eq 1 ]; then
-          duration=120
-          timeout=4000000
-        else
-          duration=180
-          timeout=10000000
-        fi
-        echo "Going to start `$__iterations instance(s) of stresstestapp with a duration of `$duration and a timeout of $timeoutStress each consuming 128MB memory" >> /root/HotAdd.log 2>&1
-        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
-        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
-        wait
-        exit 0
-"@
-
-    #"pingVMs: sendig command to vm: $cmdToVM"
-    $filename = "ConsumeMem.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal[-1])
-    {
-      return $false
-    }
-
-    # execute command as job
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-
-  }
-}
-
-
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -222,36 +113,36 @@ Set-Variable defaultTries -option Constant -value 3
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -261,69 +152,54 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vm1Name =$fields[1].Trim() }
-      "ipv4"    { $ipv4    = $fields[1].Trim() }
-      "sshKey"  { $sshKey  = $fields[1].Trim() }
-      "tries"  { $tries  = $fields[1].Trim() }
+        "vmName"  { $vm1Name =$fields[1].Trim() }
+        "ipv4"    { $ipv4    = $fields[1].Trim() }
+        "sshKey"  { $sshKey  = $fields[1].Trim() }
+        "tries"  { $tries  = $fields[1].Trim() }
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmName -notlike $vm1Name)
 {
-  "Error: the VMName testParam needs to be the same as the VMName from the global setting"
-  return $false
+    "Error: the VMName testParam needs to be the same as the VMName from the global setting" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # Check if stress-ng is installed
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng"
-
 if (-not $retVal)
 {
-    "stress-ng is not installed! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
-
 "stress-ng is installed! Will begin running memory stress tests shortly."
 
-# Check kernel version
-$sts = check_kernel
-
-if (-not $sts) {
-  "ERROR: Could not check kernel version"
-  $retVal = $False
-}
-elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
-  $timeoutStress = 8
-}
-else {
-  "Kernel version: ${sts}"
-  $timeoutStress = 1
-}
-
-
+$timeoutStress = 0
 # get memory stats from vm1
 # wait up to 2 min for it
 
@@ -331,102 +207,92 @@ $sleepPeriod = 120 #seconds
 # get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
 
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/1MB)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/1MB)
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
-  {
-    break
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 {
-  "Error: vm1 $vm1Name reported 0 memory (assigned or demand)."
-  return $False
+    "Error: vm1 $vm1Name reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    return $False
 }
 
 "Memory stats after $vm1Name started reporting "
 "  ${vm1Name}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
 
-# Calculate the amount of memory to be consumed on VM1 and VM2 with stresstestapp
 [int64]$vm1ConsumeMem = (Get-VMMemory -VM $vm1).Maximum
-# only consume 75% of max memory
-$vm1ConsumeMem = ($vm1ConsumeMem / 4) * 3
-# transform to MB
 $vm1ConsumeMem /= 1MB
+
 # Send Command to consume
-$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress) ConsumeMemory $ip $sshKey $rootDir $timeoutStress } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress)
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem } -InitializationScript $DM_scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-
-  return $false
+    "Error: Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
-# sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 50
-# get memory stats for vm1 after stresstestapp starts
+Start-Sleep -s 120
+# get memory stats for vm1 after stress-ng starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/1MB)
 [int64]$vm1Demand = ($vm1.MemoryDemand/1MB)
 
-"Memory stats after $vm1Name started stresstestapp"
+"Memory stats after $vm1Name started stress-ng"
 "  ${vm1Name}: assigned - $vm1Assigned | demand - $vm1Demand"
 
 if ($vm1Demand -le $vm1BeforeDemand)
 {
-  "Error: Memory Demand did not increase after starting stresstestapp"
-  return $false
+    "Error: Memory Demand did not increase after starting stress-ng" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
-
 # Wait for jobs to finish now and make sure they exited successfully
-$timeout = 600
+$timeout = 300
 $firstJobStatus = $false
 while ($timeout -gt 0)
 {
-
-  if ($job1.Status -like "Completed")
-  {
-    $firstJobStatus = $true
-    $retVal = Receive-Job $job1
-    if (-not $retVal[-1])
+    if ($job1.Status -like "Completed")
     {
-      "Error: Consume Memory script returned false on VM1 $vm1Name"
-      return $false
+        $firstJobStatus = $true
+        $retVal = Receive-Job $job1
+        if (-not $retVal[-1])
+        {
+            "Error: Consume Memory script returned false on VM1 $vm1Name" | Tee-Object -Append -file $summaryLog
+            return $false
+        }
+        $diff = $totalTimeout - $timeout
+        "Job finished in $diff seconds."
     }
-    $diff = $totalTimeout - $timeout
-    "Job finished in $diff seconds."
-  }
 
-  if ($firstJobStatus)
-  {
-    break
-  }
+    if ($firstJobStatus)
+    {
+        break
+    }
 
-  $timeout -= 1
-  start-sleep -s 1
-
+    $timeout -= 1
+    Start-Sleep -s 1
 }
 
 # Verify if errors occured on guest
 $isAlive = WaitForVMToStartKVP $vm1Name $hvServer 10
 if (-not $isAlive){
-  "Error: VM is unresponsive after running the memory stress test"
-  return $false
+    "Error: VM is unresponsive after running the memory stress test" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $errorsOnGuest = echo y | bin\plink -i ssh\${sshKey} root@$ipv4 "cat HotAddErrors.log"
 if (-not  [string]::IsNullOrEmpty($errorsOnGuest)){
-  $errorsOnGuest
-  return $false
+    $errorsOnGuest
+    return $false
 }
 
 # Everything ok
-"Success: Memory Demand changed with pressure on Linux guest"
+"Success: Memory Demand changed with pressure on Linux guest" | Tee-Object -Append -file $summaryLog
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that a VM with low memory pressure looses memory when another VM has a high memory demand.
@@ -67,122 +66,12 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
 Set-PSDebug -Strict
-
-# we need a scriptblock in order to pass this function to start-job
-$scriptBlock = {
-  # function which $memMB MB of memory on VM with IP $conIpv4 with stresstestapp
-  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir,[int64]$memMB,[int64]$chunckSize,[int]$duration,[int]$timeoutStress)
-  {
-
-  # because function is called as job, setup rootDir and source TCUtils again
-  if (Test-Path $rootDir)
-  {
-    Set-Location -Path $rootDir
-    if (-not $?)
-    {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-    }
-    "Changed working directory to $rootDir"
-  }
-  else
-  {
-    "Error: RootDir = $rootDir is not a valid path"
-    return $false
-  }
-
-  # Source TCUitls.ps1 for getipv4 and other functions
-  if (Test-Path ".\setupScripts\TCUtils.ps1")
-  {
-    . .\setupScripts\TCUtils.ps1
-    "Sourced TCUtils.ps1"
-  }
-  else
-  {
-    "Error: Could not find setupScripts\TCUtils.ps1"
-    return $false
-  }
-
-
-      $cmdToVM = @"
-#!/bin/bash
-        if [ ! -e /proc/meminfo ]; then
-          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
-          exit 100
-        fi
-
-        rm ~/HotAddErrors.log -f
-        dos2unix check_traces.sh
-        chmod +x check_traces.sh
-        ./check_traces.sh ~/HotAddErrors.log &
-
-        __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
-        __totalMem=`$((__totalMem/1024))
-        echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
-        declare -i __chunks
-        declare -i __threads
-        declare -i duration
-        declare -i timeout
-        __chunks=512
-        __threads=`$(($memMB/__chunks))
-        if [ $timeoutStress -eq 1 ]; then
-          timeout=4000000
-          duration=`$((3*__threads))
-        else
-          timeout=10000000
-          duration=`$((7*__threads))
-        fi
-        echo "Going to start `$__threads instance(s) of stresstestapp with a duration of `$duration and a timeout of `$timeout each consuming 128MB memory" >> /root/HotAdd.log 2>&1
-        echo "Other info: chunks: `$__chunks , memory: $memMB" >> /root/HotAdd.log 2>&1
-        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
-        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
-        wait
-        exit 0
-"@
-
-    #"pingVMs: sending command to vm: $cmdToVM"
-    $filename = "ConsumeMemOn${conIpv4}.sh"
-
-    # check for file
-    if (Test-Path ".\${filename}")
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    Add-Content $filename "$cmdToVM"
-
-    # send file
-    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${filename}"
-
-    # delete file unless the Leave_trail param was set to yes.
-    if ([string]::Compare($leaveTrail, "yes", $true) -ne 0)
-    {
-      Remove-Item ".\${filename}"
-    }
-
-    # check the return Value of SendFileToVM
-    if (-not $retVal[-1])
-    {
-      return $false
-    }
-
-    # execute command as job
-    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
-
-    return $retVal
-
-  }
-}
-
-
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -235,36 +124,36 @@ Set-Variable defaultTries -option Constant -value 10
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 $params = $testParams.Split(";")
@@ -274,264 +163,187 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
-      "ipv4"    { $ipv4    = $fields[1].Trim() }
-      "sshKey"  { $sshKey  = $fields[1].Trim() }
-      "tries"  { $tries  = $fields[1].Trim() }
+        "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+        "ipv4"    { $ipv4    = $fields[1].Trim() }
+        "sshKey"  { $sshKey  = $fields[1].Trim() }
+        "tries"  { $tries  = $fields[1].Trim() }
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 if (-not $sshKey)
 {
-  "Error: Please pass the sshKey to the script."
-  return $false
+    "Error: Please pass the sshKey to the script." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmNames.count -lt 3)
 {
-  "Error: three VMs are necessary for the StartupLowCompete test."
-  return $false
+    "Error: three VMs are necessary for the StartupLowCompete test." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm1Name = $vmNames[0]
 $vm2Name = $vmNames[1]
 $vm3Name = $vmNames[2]
-
 if ($vm1Name -notlike $vmName)
 {
-  if ($vm2Name -like $vmName)
-  {
-    # switch vm1Name with vm2Name
-    $vm1Name = $vmNames[1]
-    $vm2Name = $vmNames[0]
+    if ($vm2Name -like $vmName)
+    {
+        # switch vm1Name with vm2Name
+        $vm1Name = $vmNames[1]
+        $vm2Name = $vmNames[0]
 
-  }
-  elseif ($vm3Name -like $vmName)
-  {
-    # switch vm1Name with vm3Name
-    $vm1Name = $vmNames[2]
-    $vm3Name = $vmNames[0]
-  }
-  else
-  {
-    "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml."
-    return $false
-  }
+    }
+    elseif ($vm3Name -like $vmName)
+    {
+        # switch vm1Name with vm3Name
+        $vm1Name = $vmNames[2]
+        $vm3Name = $vmNames[0]
+    }
+    else
+    {
+        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
+        return $false
+    }
 }
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm2)
 {
-  "Error: VM $vm2Name does not exist"
-  return $false
+    "Error: VM $vm2Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm3 = Get-VM -Name $vm3Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm3)
 {
-  "Error: VM $vm3Name does not exist"
-  return $false
+    "Error: VM $vm3Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # determine which is vm2 and whih is vm3 based on memory weight
-
 $vm2MemWeight = (Get-VMMemory -VM $vm2).Priority
-
 if (-not $?)
 {
-  "Error: Unable to get $vm2Name memory weight."
-  return $false
+    "Error: Unable to get $vm2Name memory weight." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm3MemWeight = (Get-VMMemory -VM $vm3).Priority
-
 if (-not $?)
 {
-  "Error: Unable to get $vm3Name memory weight."
-  return $false
+    "Error: Unable to get $vm3Name memory weight." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($vm3MemWeight -eq $vm2MemWeight)
 {
-  "Error: $vm3Name must have a higher memory weight than $vm2Name"
-  return $false
+    "Error: $vm3Name must have a higher memory weight than $vm2Name" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($vm3MemWeight -lt $vm2MemWeight)
 {
-  # switch vm2 with vm3
-  $aux = $vm2Name
-  $vm2Name = $vm3Name
-  $vm3Name = $aux
+    # switch vm2 with vm3
+    $aux = $vm2Name
+    $vm2Name = $vm3Name
+    $vm3Name = $aux
 
-  $vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
+    $vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 
-  if (-not $vm2)
-  {
-    "Error: VM $vm2Name does not exist anymore"
-    return $false
-  }
-
-  $vm3 = Get-VM -Name $vm3Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
-  if (-not $vm3)
-  {
-    "Error: VM $vm3Name does not exist anymore"
-    return $false
-  }
-
-}
-
-#
-# LIS Started VM1, so start VM2
-#
-
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-
-  [int]$i = 0
-  # try to start VM2
-  for ($i=0; $i -lt $tries; $i++)
-  {
-
-    Start-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-    if (-not $?)
+    if (-not $vm2)
     {
-      "Warning: Unable to start VM ${vm2Name} on attempt $i"
-    }
-    else
-    {
-      $i = 0
-      break
+        "Error: VM $vm2Name does not exist anymore" | Tee-Object -Append -file $summaryLog
+        return $false
     }
 
-    Start-sleep -s 30
-  }
+    $vm3 = Get-VM -Name $vm3Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 
-  if ($i -ge $tries)
-  {
-    "Error: Unable to start VM2 after $tries attempts"
-    return $false
-  }
-
+    if (-not $vm3)
+    {
+        "Error: VM $vm3Name does not exist anymore" | Tee-Object -Append -file $summaryLog
+        return $false
+    }
 }
-
-# just to make sure vm2 started
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-  "Error: $vm2Names never started."
-  return $false
-}
-
 
 # Check if stress-ng is installed
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng"
-
 if (-not $retVal)
 {
-    "stress-ng is not installed! Please install it before running the memory stress tests."
+    "stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
-
 "stress-ng is installed! Will begin running memory stress tests shortly."
 
-# Check kernel version
-$sts = check_kernel
+#
+# LIS Started VM1, so start VM2
+#
+$timeout = 120
+StartDependencyVM $vm2Name $hvServer $tries
+WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+$vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
-if (-not $sts) {
-  "ERROR: Could not check kernel version"
-  $retVal = $False
-}
-elseif ($sts -like '2.6*') {
-  "Info: 2.6.x kernel version detected. Higher timeout is used between stress-ng processes."
-  $timeoutStress = 8
-}
-else {
-  "Kernel version: ${sts}"
-  $timeoutStress = 1
-}
-
-
-# get memory stats from vm1 and vm2
-# wait up to 2 min for it
-
+$timeoutStress = 1
 $sleepPeriod = 120 #seconds
 # get VM1 and VM2's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/[int64]1048576)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/[int64]1048576)
+    [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/[int64]1048576)
+    [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/[int64]1048576)
 
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/[int64]1048576)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/[int64]1048576)
-  [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/[int64]1048576)
-  [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/[int64]1048576)
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0 -and $vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
-  {
-    break
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0 -or $vm1BeforeDemand -le 0)
 {
-  "Error: vm1 or vm2 reported 0 memory (assigned or demand)."
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $False
+    "Error: vm1 or vm2 reported 0 memory (assigned or demand)." | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $False
 }
 
 "Memory stats after both $vm1Name and $vm2Name started reporting "
 "  ${vm1Name}: assigned - $vm1BeforeAssigned | demand - $vm1BeforeDemand"
 "  ${vm2Name}: assigned - $vm2BeforeAssigned | demand - $vm2BeforeDemand"
 
-# get vm2 IP
-$vm2ipv4 = GetIPv4 $vm2Name $hvServer
-
 # Check if stress-ng is installed
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng" $vm2ipv4
-
 if (-not $retVal)
 {
-    "stress-ng is not installed on $vm2Name! Please install it before running the memory stress tests."
+    "stress-ng is not installed on $vm2Name! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
-
 "stress-ng is installed on $vm2Name! Will begin running memory stress tests shortly."
 
-# wait for ssh to start on vm2
-$timeout = 30 #seconds
-if (-not (WaitForVMToStartSSH $vm2ipv4 $timeout))
-{
-    "Error: VM ${vm2Name} never started ssh"
-    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-    return $False
-}
-
-
-
-# Calculate the amount of memory to be consumed on VM1 and VM2 with stresstestapp
+# Calculate the amount of memory to be consumed on VM1 and VM2 with stress-ng
 [int64]$vm1ConsumeMem = (Get-VMMemory -VM $vm1).Maximum
 [int64]$vm2ConsumeMem = (Get-VMMemory -VM $vm2).Maximum
 # only consume 75% of max memory
@@ -541,64 +353,44 @@ $vm2ConsumeMem = ($vm2ConsumeMem / 4) * 3
 $vm1ConsumeMem /= 1MB
 $vm2ConsumeMem /= 1MB
 
-# standard chunks passed to stresstestapp
-[int64]$vm1Chunks = 256 #MB
-[int64]$vm2Chunks = 256 #MB
-[int]$vm1Duration = 60 #seconds
-[int]$vm2Duration = 90 #seconds
+# standard chunks passed to stress-ng
+[int64]$chunks = 512 #MB
+[int]$vm1Duration = 400 #seconds
+[int]$vm2Duration = 380 #seconds
 
 # Send Command to consume
-$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $memMB, $memChunks, $duration, $timeoutStress) ConsumeMemory $ip $sshKey $rootDir $memMB $memChunks $duration $timeoutStress } -InitializationScript $scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$vm1ConsumeMem,$vm1Chunks,$vm1Duration,$timeoutStress)
+$job1 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm1ConsumeMem, $vm1Duration, $chunks) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm1ConsumeMem $vm1Duration $chunks } -InitializationScript $DM_scriptBlock -ArgumentList($ipv4,$sshKey,$rootDir,$timeoutStress,$vm1ConsumeMem,$vm1Duration,$chunks)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
-$job2 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $memMB, $memChunks, $duration, $timeoutStress) ConsumeMemory $ip $sshKey $rootDir $memMB $memChunks $duration $timeoutStress} -InitializationScript $scriptBlock -ArgumentList($vm2ipv4,$sshKey,$rootDir,$vm2ConsumeMem,$vm2Chunks,$vm2Duration,$timeoutStress)
+$job2 = Start-Job -ScriptBlock { param($ip, $sshKey, $rootDir, $timeoutStress, $vm2ConsumeMem, $vm2Duration, $chunks) ConsumeMemory $ip $sshKey $rootDir $timeoutStress $vm2ConsumeMem $vm2Duration $chunks } -InitializationScript $DM_scriptBlock -ArgumentList($vm2ipv4,$sshKey,$rootDir,$timeoutStress,$vm2ConsumeMem,$vm2Duration,$chunks)
 if (-not $?)
 {
-  "Error: Unable to start job for creating pressure on $vm1Name"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
+    "Error: Unable to start job for creating pressure on $vm2Name" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    return $false
 }
 
-# sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
-start-sleep -s 120
+# sleep a few seconds so all stress-ng processes start and the memory assigned/demand gets updated
+Start-Sleep -s 240
 # get memory stats for vm1 and vm2 just before vm3 starts
 [int64]$vm1Assigned = ($vm1.MemoryAssigned/[int64]1048576)
 [int64]$vm1Demand = ($vm1.MemoryDemand/[int64]1048576)
 [int64]$vm2Assigned = ($vm2.MemoryAssigned/[int64]1048576)
 [int64]$vm2Demand = ($vm2.MemoryDemand/[int64]1048576)
 
-"Memory stats after $vm1Name and $vm2Name started stresstestapp, but before $vm3Name starts: "
+"Memory stats after $vm1Name and $vm2Name started stress-ng, but before $vm3Name starts: "
 "  ${vm1Name}: assigned - $vm1Assigned | demand - $vm1Demand"
 "  ${vm2Name}: assigned - $vm2Assigned | demand - $vm2Demand"
 
-# try to start VM3
-for ($i=0; $i -lt $tries; $i++)
-{
-  Start-VM -Name $vm3Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-  if (-not $?)
-  {
-    "Warning: Unable to start VM ${vm3Name} on attempt $i"
-  }
-  else
-  {
-    $i = 0
-    break
-  }
-
-  Start-sleep -s 10
-}
-
-if ($i -ge $tries)
-{
-  "Error: Unable to start VM3 after $tries attempts"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  return $false
-}
+# Try to start VM3
+$timeout = 120
+StartDependencyVM $vm3Name $hvServer $tries
+WaitForVMToStartKVP $vm3Name $hvServer $timeout
 
 Start-sleep -s 60
 # get memory stats after vm3 started
@@ -607,62 +399,66 @@ Start-sleep -s 60
 [int64]$vm2AfterAssigned = ($vm2.MemoryAssigned/[int64]1048576)
 [int64]$vm2AfterDemand = ($vm2.MemoryDemand/[int64]1048576)
 
-"Memory stats after $vm1Name and $vm2Name started stresstestapp and after $vm3Name started: "
+"Memory stats after $vm1Name and $vm2Name started stress-ng and after $vm3Name started: "
 "  ${vm1Name}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
 "  ${vm2Name}: assigned - $vm2AfterAssigned | demand - $vm2AfterDemand"
 
 # Wait for jobs to finish now and make sure they exited successfully
-$totalTimeout = $timeout = 2000
+$totalTimeout = $timeout = 120
 $timeout = 0
 $firstJobState = $false
 $secondJobState = $false
 $min = 0
 while ($true)
 {
-
-  if ($job1.State -like "Completed" -and -not $firstJobState)
-  {
-    $firstJobState = $true
-    $retVal = Receive-Job $job1
-    if (-not $retVal[-1])
+    if ($job1.State -like "Completed" -and -not $firstJobState)
     {
-      "Error: Consume Memory script returned false on VM1 $vm1Name"
-      Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-      Stop-VM -VMName $vm3name -ComputerName $hvServer -force
-      return $false
+        $firstJobState = $true
+        $retVal = Receive-Job $job1
+        if (-not $retVal[-1])
+        {
+            "Error: Consume Memory script returned false on VM1 $vm1Name" | Tee-Object -Append -file $summaryLog
+            Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+            Stop-VM -VMName $vm3name -ComputerName $hvServer -force
+            return $false
+        }
+
+        "Job1 finished in $min minutes."
     }
 
-    "Job1 finished in $min minutes."
-  }
-
-  if ($job2.State -like "Completed" -and -not $secondJobState)
-  {
-    $secondJobState = $true
-    $retVal = Receive-Job $job1
-    if (-not $retVal[-1])
+    if ($job2.State -like "Completed" -and -not $secondJobState)
     {
-      "Error: Consume Memory script returned false on VM2 $vm2Name"
-      Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-      Stop-VM -VMName $vm3name -ComputerName $hvServer -force
-      return $false
+        $secondJobState = $true
+        $retVal = Receive-Job $job2
+        if (-not $retVal[-1])
+        {
+            "Error: Consume Memory script returned false on VM2 $vm2Name" | Tee-Object -Append -file $summaryLog
+            Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+            Stop-VM -VMName $vm3name -ComputerName $hvServer -force
+            return $falses
+        }
+        $diff = $totalTimeout - $timeout
+        "Job2 finished in $min minutes."
     }
-    $diff = $totalTimeout - $timeout
-    "Job2 finished in $min minutes."
-  }
 
-  if ($firstJobState -and $secondJobState)
-  {
-    break
-  }
+    if ($firstJobState -and $secondJobState)
+    {
+        break
+    }
 
-  if ($timeout%60 -eq 0)
-  {
-   "$min minutes passed"
-  $min += 1
-  }
+    if ($timeout%60 -eq 0)
+    {
+       "$min minutes passed"
+        $min += 1
+    }
 
-  $timeout += 5
-  start-sleep -s 5
+    if ($totalTimeout -le 0)
+    {
+        break
+    }
+    $timeout += 5
+    $totalTimeout -= 5
+    Start-Sleep -s 5
 }
 
 [int64]$vm1DeltaAssigned = [int64]$vm1Assigned - [int64]$vm1AfterAssigned
@@ -677,10 +473,10 @@ while ($true)
 # check that at least one of the first two VMs has lower assigned memory as a result of VM3 starting
 if ($vm1DeltaAssigned -le 0 -and $vm2DeltaAssigned -le 0)
 {
-  "Error: Neither $vm1Name, nor $vm2Name didn't lower their assigned memory in response to $vm3Name starting"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  Stop-VM -VMName $vm3name -ComputerName $hvServer -force
-  return $false
+    "Error: Neither $vm1Name, nor $vm2Name didn't lower their assigned memory in response to $vm3Name starting" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    Stop-VM -VMName $vm3name -ComputerName $hvServer -force
+    return $false
 }
 
 [int64]$vm1EndAssigned = ($vm1.MemoryAssigned/[int64]1048576)
@@ -692,26 +488,24 @@ $sleepPeriod = 120 #seconds
 # get VM3's Memory
 while ($sleepPeriod -gt 0)
 {
+    [int64]$vm3EndAssigned = ($vm3.MemoryAssigned/[int64]1048576)
+    [int64]$vm3EndDemand = ($vm3.MemoryDemand/[int64]1048576)
 
-  [int64]$vm3EndAssigned = ($vm3.MemoryAssigned/[int64]1048576)
-  [int64]$vm3EndDemand = ($vm3.MemoryDemand/[int64]1048576)
+    if ($vm3EndAssigned -gt 0 -and $vm3EndDemand -gt 0)
+    {
+        break
+    }
 
-  if ($vm3EndAssigned -gt 0 -and $vm3EndDemand -gt 0)
-  {
-    break
-  }
-
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1EndAssigned -le 0 -or $vm1EndDemand -le 0 -or $vm2EndAssigned -le 0 -or $vm2EndDemand -le 0 -or $vm3EndAssigned -le 0 -or $vm3EndDemand -le 0)
 {
-  "Error: One of the VMs reports 0 memory (assigned or demand) after vm3 $vm3Name started"
-  Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-  Stop-VM -VMName $vm3name -ComputerName $hvServer -force
-  return $false
+    "Error: One of the VMs reports 0 memory (assigned or demand) after vm3 $vm3Name started" | Tee-Object -Append -file $summaryLog
+    Stop-VM -VMName $vm2name -ComputerName $hvServer -force
+    Stop-VM -VMName $vm3name -ComputerName $hvServer -force
+    return $false
 }
 
 # stop vm2 and vm3
@@ -721,16 +515,16 @@ Stop-VM -VMName $vm3name -ComputerName $hvServer -force
 # Verify if errors occured on guest
 $isAlive = WaitForVMToStartKVP $vm1Name $hvServer 10
 if (-not $isAlive){
-  "Error: VM is unresponsive after running the memory stress test"
-  return $false
+    "Error: VM is unresponsive after running the memory stress test" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $errorsOnGuest = echo y | bin\plink -i ssh\${sshKey} root@$ipv4 "cat HotAddErrors.log"
 if (-not  [string]::IsNullOrEmpty($errorsOnGuest)){
-  $errorsOnGuest
-  return $false
+    $errorsOnGuest
+    return $false
 }
 
 # Everything ok
-"Success: Memory was removed from a low priority VM with minimal memory pressure to a VM with high memory pressure!"
+Write-Output "Success: Memory was removed from a low priority VM with minimal memory pressure to a VM with high memory pressure!" | Tee-Object -Append -file $summaryLog
 return $true

--- a/WS2012R2/lisa/setupscripts/DM_StartupLowCompete.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_StartupLowCompete.ps1
@@ -19,7 +19,6 @@
 #
 #####################################################################
 
-
 <#
 .Synopsis
  Verify that a VM with low memory pressure looses memory when another VM has a high memory demand.
@@ -66,16 +65,13 @@
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)
-
 Set-PSDebug -Strict
-
 
 #######################################################################
 #
 # Main script body
 #
 #######################################################################
-
 #
 # Check input arguments
 #
@@ -106,9 +102,6 @@ $sshKey = $null
 # IP Address of first VM
 $ipv4 = $null
 
-# IP Address of second VM
-$vm2ipv4 = $null
-
 # Name of first VM
 $vm1Name = $null
 
@@ -128,36 +121,36 @@ Set-Variable defaultTries -option Constant -value 8
 $testParams -match "RootDir=([^;]+)"
 if (-not $?)
 {
-  "Mandatory param RootDir=Path; not found!"
-  return $false
+    "Mandatory param RootDir=Path; not found!"
+    return $false
 }
 $rootDir = $Matches[1]
 
 if (Test-Path $rootDir)
 {
-  Set-Location -Path $rootDir
-  if (-not $?)
-  {
-    "Error: Could not change directory to $rootDir !"
-    return $false
-  }
-  "Changed working directory to $rootDir"
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+        "Error: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
 }
 else
 {
-  "Error: RootDir = $rootDir is not a valid path"
-  return $false
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
 }
 
 # Source TCUitls.ps1 for getipv4 and other functions
 if (Test-Path ".\setupScripts\TCUtils.ps1")
 {
-  . .\setupScripts\TCUtils.ps1
+    . .\setupScripts\TCUtils.ps1
 }
 else
 {
-  "Error: Could not find setupScripts\TCUtils.ps1"
-  return $false
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
 }
 
 # iterator for vmName= parameters. Only 2 are taken into consideration
@@ -174,84 +167,83 @@ foreach ($p in $params)
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
-
+      "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
     }
-
 }
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 if ($tries -le 0)
 {
-  $tries = $defaultTries
+    $tries = $defaultTries
 }
 
 if ($vmNames.count -lt 2)
 {
-  "Error: two VMs are necessary for the StartupLowCompete test."
-  return $false
+    "Error: two VMs are necessary for the StartupLowCompete test." | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm1Name = $vmNames[0]
 $vm2Name = $vmNames[1]
-
 if ($vm1Name -notlike $vmName)
 {
-  if ($vm2Name -like $vmName)
-  {
-    # switch vm1Name with vm2Name
-    $vm1Name = $vmNames[1]
-    $vm2Name = $vmNames[0]
-  }
-  else
-  {
-    "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml."
-    return $false
-  }
+    if ($vm2Name -like $vmName)
+    {
+        # switch vm1Name with vm2Name
+        $vm1Name = $vmNames[1]
+        $vm2Name = $vmNames[0]
+    }
+    else
+    {
+        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
+        return $false
+    }
 }
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm1)
 {
-  "Error: VM $vm1Name does not exist"
-  return $false
+    "Error: VM $vm1Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 $vm2 = Get-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-
 if (-not $vm2)
 {
-  "Error: VM $vm2Name does not exist"
-  return $false
+    "Error: VM $vm2Name does not exist" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 # sleep 1 minute for VM to start reporting demand
 $sleepPeriod = 60
-
 while ($sleepPeriod -gt 0)
 {
-  # get VM1's Memory
-  [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/[int64]1048576)
-  [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/[int64]1048576)
+    # get VM1's Memory
+    [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/[int64]1048576)
+    [int64]$vm1BeforeDemand = ($vm1.MemoryDemand/[int64]1048576)
 
-  if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
-  {
-    break
-  }
+    if ($vm1BeforeAssigned -gt 0 -and $vm1BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  $sleepPeriod -= 5
-  start-sleep -s 5
+    $sleepPeriod -= 5
+    Start-Sleep -s 5
 }
 
 if ($vm1BeforeAssigned -le 0)
 {
-  "Error: $vm1Name Assigned memory is 0"
-  return $false
+    "Error: $vm1Name Assigned memory is 0" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 if ($vm1BeforeDemand -le 0)
 {
-  "Error: $vm1Name Memory demand is 0"
-  return $false
+    "Error: $vm1Name Memory demand is 0" | Tee-Object -Append -file $summaryLog
+    return $false
 }
 
 "VM1 $vm1Name before assigned memory : $vm1BeforeAssigned"
@@ -260,43 +252,9 @@ if ($vm1BeforeDemand -le 0)
 #
 # LIS Started VM1, so start VM2
 #
-
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-
-  [int]$i = 0
-  # try to start VM2
-  for ($i=0; $i -lt $tries; $i++)
-  {
-
-    Start-VM -Name $vm2Name -ComputerName $hvServer -ErrorAction SilentlyContinue
-    if (-not $?)
-    {
-      "Warning: Unable to start VM ${vm2Name} on attempt $i"
-    }
-    else
-    {
-      $i = 0
-      break
-    }
-
-    Start-sleep -s 30
-  }
-
-  if ($i -ge $tries)
-  {
-    "Error: Unable to start VM2 after $tries attempts"
-    return $false
-  }
-
-}
-
-# just to make sure vm2 started
-if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "Running" })
-{
-  "Error: $vm2Names never started."
-  return $false
-}
+$timeout = 120
+StartDependencyVM $vm2Name $hvServer $tries
+WaitForVMToStartKVP $vm2Name $hvServer $timeout 
 
 # get VM1's Memory
 [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/[int64]1048576)
@@ -304,16 +262,16 @@ if (Get-VM -Name $vm2Name -ComputerName $hvServer |  Where { $_.State -notlike "
 
 if ($vm1AfterAssigned -le 0)
 {
-  "Error: $vm1Name Assigned memory is 0 after $vm2Name started"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name Assigned memory is 0 after $vm2Name started" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($vm1AfterDemand -le 0)
 {
-  "Error: $vm1Name Memory demand is 0 after $vm2Name started"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name Memory demand is 0 after $vm2Name started"
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 "VM1 $vm1Name after assigned memory : $vm1AfterAssigned"
@@ -330,9 +288,9 @@ if ($vm1AfterDemand -le 0)
 # Assigned memory needs to have lowered after VM2 starts.
 if ($vm1AssignedDelta -le 0)
 {
-  "Error: $vm1Name did not lower its assigned Memory after vm2 started."
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name did not lower its assigned Memory after vm2 started." | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 # sleep another 2 minute trying to get VM2's memory demand
@@ -340,39 +298,37 @@ $sleepPeriod = 120 #seconds
 # get VM2's Memory
 while ($sleepPeriod -gt 0)
 {
-  [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/[int64]1048576)
-  [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/[int64]1048576)
+    [int64]$vm2BeforeAssigned = ($vm2.MemoryAssigned/[int64]1048576)
+    [int64]$vm2BeforeDemand = ($vm2.MemoryDemand/[int64]1048576)
 
-  if ($vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
-  {
-    break
-  }
+    if ($vm2BeforeAssigned -gt 0 -and $vm2BeforeDemand -gt 0)
+    {
+        break
+    }
 
-  $sleepPeriod-= 5
-  start-sleep -s 5
-
+    $sleepPeriod-= 5
+    Start-Sleep -s 5
 }
 
 if ($vm2BeforeAssigned -le 0)
 {
-  "Error: $vm2Name Assigned memory is 0"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm2Name Assigned memory is 0" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($vm2BeforeDemand -le 0)
 {
-  "Error: $vm2Name Memory demand is 0"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm2Name Memory demand is 0" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 "VM2 $vm2Name before assigned memory : $vm2BeforeAssigned"
 "VM2 $vm2Name before memory demand: $vm2BeforeDemand"
 
 # sleep 120 seconds to let VM2 stabilize
-
-start-sleep -s 120
+Start-Sleep -s 120
 
 # get VM2's Memory
 [int64]$vm2AfterAssigned = ($vm2.MemoryAssigned/[int64]1048576)
@@ -380,14 +336,14 @@ start-sleep -s 120
 
 if ($vm2AfterAssigned -le 0)
 {
-  "Error: $vm2Name Assigned memory is 0 after it stabilized"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm2Name Assigned memory is 0 after it stabilized" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($vm2AfterDemand -le 0)
 {
-  "Error: $vm2Name Memory demand is 0 after it stabilized"
+  "Error: $vm2Name Memory demand is 0 after it stabilized" | Tee-Object -Append -file $summaryLog
   Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
   return $false
 }
@@ -409,16 +365,16 @@ if ($vm2AfterDemand -le 0)
 
 if ($vm1EndAssigned -le 0)
 {
-  "Error: $vm1Name Assigned memory is 0 after vm2 stabilized"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name Assigned memory is 0 after vm2 stabilized" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 if ($vm1EndDemand -le 0)
 {
-  "Error: $vm1Name Memory demand is 0 after vm2 stabilized"
-  Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
-  return $false
+    "Error: $vm1Name Memory demand is 0 after vm2 stabilized" | Tee-Object -Append -file $summaryLog
+    Stop-VM -vmName $vm2Name -ComputerName $hvServer -force
+    return $false
 }
 
 "VM1 $vm1Name end assigned memory : $vm1EndAssigned"

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -2104,9 +2104,14 @@ $DM_scriptBlock = {
         elif [ $timeoutStress -eq 1 ]; then
             timeout=5000000
             duration=`$((5*__threads))
-        else
+        elif [ $timeoutStress -eq 2 ]; then
             timeout=1000000
             duration=`$__threads
+        else
+            timeout=1
+            duration=30
+            __threads=4
+            __chunks=2048
         fi
 
         if [ $duration -ne 0 ]; then

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1999,3 +1999,149 @@ function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$su
 	}
 	return $true
 }
+
+# Function for starting dependency VMs used by test scripts
+function StartDependencyVM([String] $dep_vmName, [String] $server, [int]$tries)
+{
+    if (Get-VM -Name $dep_vmName -ComputerName $server |  Where { $_.State -notlike "Running" })
+    {
+        [int]$i = 0
+        # Try to start dependency VM
+        for ($i=0; $i -lt $tries; $i++)
+        {
+            Start-VM -Name $dep_vmName -ComputerName $server -ErrorAction SilentlyContinue
+            if (-not $?)
+            {
+                "Warning: Unable to start VM $dep_vmName on attempt $i"
+            }
+            else
+            {
+                $i = 0
+                break
+            }
+
+            Start-Sleep -s 30
+        }
+
+        if ($i -ge $tries)
+        {
+            "Error: Unable to start VM $dep_vmName after $tries attempts" | Tee-Object -Append -file $summaryLog
+            return $false
+        }
+    }
+
+    # just to make sure vm2 started
+    if (Get-VM -Name $dep_vmName -ComputerName $server |  Where { $_.State -notlike "Running" })
+    {
+        "Error: $dep_vmName never started."
+        return $false
+    }
+}
+
+# ScriptBlock used for Dynamic Memory test cases
+$DM_scriptBlock = {
+  # function for starting stresstestapp
+  function ConsumeMemory([String]$conIpv4, [String]$sshKey, [String]$rootDir, [int]$timeoutStress, [int64]$memMB, [int]$duration, [int64]$chunk)
+  {
+
+  # because function is called as job, setup rootDir and source TCUtils again
+  if (Test-Path $rootDir)
+  {
+    Set-Location -Path $rootDir
+    if (-not $?)
+    {
+    "Error: Could not change directory to $rootDir !"
+    return $false
+    }
+    "Changed working directory to $rootDir"
+  }
+  else
+  {
+    "Error: RootDir = $rootDir is not a valid path"
+    return $false
+  }
+
+  # Source TCUitls.ps1 for getipv4 and other functions
+  if (Test-Path ".\setupScripts\TCUtils.ps1")
+  {
+    . .\setupScripts\TCUtils.ps1
+    "Sourced TCUtils.ps1"
+  }
+  else
+  {
+    "Error: Could not find setupScripts\TCUtils.ps1"
+    return $false
+  }
+
+      $cmdToVM = @"
+#!/bin/bash
+        if [ ! -e /proc/meminfo ]; then
+          echo ConsumeMemory: no meminfo found. Make sure /proc is mounted >> /root/HotAdd.log 2>&1
+          exit 100
+        fi
+
+        rm ~/HotAddErrors.log -f
+        dos2unix check_traces.sh
+        chmod +x check_traces.sh
+        ./check_traces.sh ~/HotAddErrors.log &
+
+        __totalMem=`$(cat /proc/meminfo | grep -i MemTotal | awk '{ print `$2 }')
+        __totalMem=`$((__totalMem/1024))
+        echo ConsumeMemory: Total Memory found `$__totalMem MB >> /root/HotAdd.log 2>&1
+        declare -i __chunks
+        declare -i __threads
+        declare -i duration
+        declare -i timeout
+        if [ $chunk -le 0 ]; then
+            __chunks=128
+        else
+            __chunks=512
+        fi   
+        __threads=`$(($memMB/__chunks))
+        if [ $timeoutStress -eq 0 ]; then
+            timeout=10000000
+            duration=`$((10*__threads))
+        elif [ $timeoutStress -eq 1 ]; then
+            timeout=5000000
+            duration=`$((5*__threads))
+        else
+            timeout=1000000
+            duration=`$__threads
+        fi
+
+        if [ $duration -ne 0 ]; then
+            duration=$duration
+        fi
+        echo "Stress-ng info: `$__threads threads :: `$__chunks MB chunk size :: `$((`$timeout/1000000)) seconds between chunks :: `$duration seconds total stress time" >> /root/HotAdd.log 2>&1
+        stress-ng -m `$__threads --vm-bytes `${__chunks}M -t `$duration --backoff `$timeout
+        echo "Waiting for jobs to finish" >> /root/HotAdd.log 2>&1
+        wait
+        exit 0
+"@
+
+    #"pingVMs: sendig command to vm: $cmdToVM"
+    $filename = "ConsumeMem.sh"
+
+    # check for file
+    if (Test-Path ".\${filename}")
+    {
+      Remove-Item ".\${filename}"
+    }
+
+    Add-Content $filename "$cmdToVM"
+
+    # send file
+    $retVal = SendFileToVM $conIpv4 $sshKey $filename "/root/${$filename}"
+
+    # check the return Value of SendFileToVM
+    if (-not $retVal[-1])
+    {
+      return $false
+    }
+
+    # execute command as job
+    $retVal = SendCommandToVM $conIpv4 $sshKey "cd /root && chmod u+x ${filename} && sed -i 's/\r//g' ${filename} && ./${filename}"
+
+    return $retVal
+  }
+}

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -35,7 +35,8 @@
 
 				<!-- Stress Hot Add tests -->
 				<suiteTest>Stress_HotAdd_5seconds</suiteTest>
-				<suiteTest>Stress_HotAdd_1second</suiteTest> 
+				<suiteTest>Stress_HotAdd_1second</suiteTest>
+				<suiteTest>Stress_Large_Chunk</suiteTest>
 
 				<!-- Dynamic Memory – Ballooning-->
 				<suiteTest>StartupLowCompete</suiteTest>
@@ -383,6 +384,29 @@
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=4GB</param>
+				<param>startupMem=1024MB</param>
+				<param>memWeight=100</param>
+				<param>staticMem=1024MB</param>
+			</testParams>
+			<testScript>setupScripts\DM_HotAdd_Stress_ng.ps1</testScript>
+			<files>remote-scripts/ica/check_traces.sh</files>
+			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
+			<timeout>1200</timeout>
+		</test>
+
+		<test>
+			<testName>Stress_Large_Chunk</testName>
+			<setupScript>
+				<file>setupscripts\RevertSnapshot.ps1</file>
+				<file>SetupScripts\DM_CONFIGURE_MEMORY.ps1</file>
+			</setupScript>
+			<testParams>
+				<param>TC_COVERED=DM-15</param>
+				<param>Stress_Level=3</param>
+				<param>vmName=VMName</param>
+				<param>enableDM=yes</param>
+				<param>minMem=1024MB</param>
+				<param>maxMem=8GB</param>
 				<param>startupMem=1024MB</param>
 				<param>memWeight=100</param>
 				<param>staticMem=1024MB</param>

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -22,15 +22,22 @@
 				<suiteTest>DM_loaded</suiteTest>
 				<suiteTest>HotAdd_Verify_udev</suiteTest>
 
-				<!-- Dynamic Memory – Hot Add -->
+				<!--Dynamic Memory – Hot Add--> 
+				<!-- Basic Hot Add tests -->
 				<suiteTest>HotAdd</suiteTest>
-				<suiteTest>HotAddStressapptest</suiteTest>
+				<suiteTest>HotAddStressapptest</suiteTest> 
+				<suiteTest>DemandPressure</suiteTest>
+
+				<!-- Complex Hot Add tests -->	
 				<suiteTest>HotRemove</suiteTest>
 				<suiteTest>StartupHighCompete</suiteTest>
-				<suiteTest>DemandPressure</suiteTest>
 				<suiteTest>HighPriority</suiteTest>
 
-				<!-- Dynamic Memory – Ballooning -->
+				<!-- Stress Hot Add tests -->
+				<suiteTest>Stress_HotAdd_5seconds</suiteTest>
+				<suiteTest>Stress_HotAdd_1second</suiteTest> 
+
+				<!-- Dynamic Memory – Ballooning-->
 				<suiteTest>StartupLowCompete</suiteTest>
 				<suiteTest>MinMemHonored</suiteTest>
 				<suiteTest>MaxMemHonored</suiteTest>
@@ -102,6 +109,7 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-04</param>
+				<param>Stress_Level=0</param>
 				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
@@ -341,6 +349,46 @@
 				<param>staticMem=1024MB</param>
 			</testParams>
 			<testScript>setupScripts\DM_CleanShutdown.ps1</testScript>
+			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
+			<timeout>1200</timeout>
+		</test>
+
+		<test>
+			<testName>Stress_HotAdd_5seconds</testName>
+			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
+			<testParams>
+				<param>TC_COVERED=DM-14</param>
+				<param>Stress_Level=1</param>
+				<param>vmName=VMName</param>
+				<param>enableDM=yes</param>
+				<param>minMem=1024MB</param>
+				<param>maxMem=4GB</param>
+				<param>startupMem=1024MB</param>
+				<param>memWeight=100</param>
+				<param>staticMem=1024MB</param>
+			</testParams>
+			<testScript>setupScripts\DM_HotAdd_Stress_ng.ps1</testScript>
+			<files>remote-scripts/ica/check_traces.sh</files>
+			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
+			<timeout>1200</timeout>
+		</test>
+
+		<test>
+			<testName>Stress_HotAdd_1second</testName>
+			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
+			<testParams>
+				<param>TC_COVERED=DM-15</param>
+				<param>Stress_Level=2</param>
+				<param>vmName=VMName</param>
+				<param>enableDM=yes</param>
+				<param>minMem=1024MB</param>
+				<param>maxMem=4GB</param>
+				<param>startupMem=1024MB</param>
+				<param>memWeight=100</param>
+				<param>staticMem=1024MB</param>
+			</testParams>
+			<testScript>setupScripts\DM_HotAdd_Stress_ng.ps1</testScript>
+			<files>remote-scripts/ica/check_traces.sh</files>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
 			<timeout>1200</timeout>
 		</test>


### PR DESCRIPTION
- Separate Hot Add tests into 3 categories:
   1. **Basic Hot Add tests** – Tests which use only one VM – Adding 128MB
chunks every 10 seconds. If these tests fail, then we know it’s an issue
with the test VM.
   2. **Complex Hot Add tests** – Tests which use 2 VMs – Adding 128MB chunks
every 10 seconds. These tests may fail due to other VMs
running/starting/stopping on the host or problems with the Dependency
VM.
   3. **Stress Hot Add tests** – 3 new TCs. One will add 512MB chunks every 5
seconds and other will add 512MB chunks every second. The last one will stress the
VM with 8GB of memory instantly. This will probably cause failures on WS2012 
and WS2012R2 but may pass on WS2016

- Fixed an issue where an error occured on DM_Configure_Memory.ps1 when
allocating memory to the VM

- Moved duplicate code to TCUtils.ps1

- Code cleanup