### PR TITLE
Fixed Get-Module cmdlet

### DIFF
--- a/WS2012R2/lisa/setupscripts/SR-IOV_GetMLNXInfo.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_GetMLNXInfo.ps1
@@ -55,7 +55,7 @@ if (Test-Path $summaryLog) {
     del $summaryLog
 }
 
-$checkModule = Get-Module | Select-String -Pattern MLNXProvider -quiet
+$checkModule = Get-Module -ListAvailable | Select-String -Pattern MLNXProvider -quiet
 if ($checkModule) {
     Import-Module MLNXProvider
 } else {


### PR DESCRIPTION
The MLNX module does not appear if it is not imported before running
the Import-Module cmdlet. Fixed usign ListAvailable parameter.