### PR TITLE
Perf utils update for transparent vf

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_client.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_client.sh
@@ -82,10 +82,16 @@ touch ~/summary.log
 
 # Convert eol
 dos2unix utils.sh
-
 # Source utils.sh
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+dos2unix perf_utils.sh
+# Source perf_utils.sh
+. perf_utils.sh || {
+    echo "Error: unable to source perf_utils.sh!"
     echo "TestAborted" > state.txt
     exit 2
 }
@@ -95,7 +101,6 @@ sleep 60
 
 # Source constants file and initialize most common variables
 UtilsInit
-
 # In case of error
 case $? in
     0)
@@ -131,9 +136,7 @@ case $? in
         ;;
 esac
 
-#
 # Make sure the required test parameters are defined
-#
 if [ "${IPERF_PACKAGE:="UNDEFINED"}" = "UNDEFINED" ]; then
     msg="Error: the IPERF_PACKAGE test parameter is missing"
     LogMsg "${msg}"
@@ -166,9 +169,15 @@ if [ "${IPERF3_SERVER_IP:="UNDEFINED"}" = "UNDEFINED" ]; then
 fi
 
 if [ "${IPERF3_PROTOCOL:="UNDEFINED"}" = "UNDEFINED" ]; then
+    IPERF3_PROTOCOL="TCP"
+    PROTOCOL=
     msg="Info: no IPERF3_PROTOCOL was specified, assuming default TCP"
     LogMsg "${msg}"
     echo "${msg}" >> ~/summary.log
+else
+    if [[ ${IPERF3_PROTOCOL} == "UDP" ]]; then
+        PROTOCOL="--udp"
+    fi
 fi
 
 if [ "${IPERF3_BUFFER:="UNDEFINED"}" = "UNDEFINED" ]; then
@@ -233,13 +242,8 @@ if [ "${IPERF3_TEST_CONNECTION_POOL:="UNDEFINED"}" = "UNDEFINED" ]; then
     echo "${msg}" >> ~/summary.log
 fi
 
-#Get test synthetic interface
-declare __iface_ignore
-
-# Parameter provided in constants file
 #   ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
 #   it is not touched during this test (no dhcp or static ip assigned to it)
-
 if [ "${ipv4:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
     LogMsg "$msg"
@@ -247,9 +251,7 @@ if [ "${ipv4:-UNDEFINED}" = "UNDEFINED" ]; then
     SetTestStateAborted
     exit 30
 else
-
     CheckIP "$ipv4"
-
     if [ 0 -ne $? ]; then
         msg="Test parameter ipv4 = $ipv4 is not a valid IP Address"
         LogMsg "$msg"
@@ -257,14 +259,14 @@ else
         SetTestStateAborted
         exit 10
     fi
-
-    # Get the interface associated with the given ipv4
-    __iface_ignore=$(ip -o addr show | grep "$ipv4" | cut -d ' ' -f2)
 fi
 
+#Get test synthetic interface
+declare __iface_ignore
+# Get the interface associated with the given ipv4
+__iface_ignore=$(ip -o addr show | grep "$ipv4" | cut -d ' ' -f2)
 # Retrieve synthetic network interfaces
 GetSynthNetInterfaces
-
 if [ 0 -ne $? ]; then
     msg="No synthetic network interfaces found"
     LogMsg "$msg"
@@ -272,10 +274,8 @@ if [ 0 -ne $? ]; then
     SetTestStateFailed
     exit 10
 fi
-
 # Remove interface if present
 SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__iface_ignore/})
-
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
     msg="The only synthetic interface is the one which LIS uses to send files/commands to the VM."
     LogMsg "$msg"
@@ -283,9 +283,70 @@ if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
     SetTestStateAborted
     exit 10
 fi
+# SRIOV setup (transparent VF)
+if [ "${SRIOV}" = "yes" ]; then
+    dos2unix SR-IOV_Utils.sh
+    # Source perf_utils.sh
+    . SR-IOV_Utils.sh || {
+        echo "ERROR: Unable to source SR-IOV_Utils.sh!"
+        echo "TestAborted" > state.txt
+        exit 2
+    }
+    # Check if the SR-IOV driver is in use
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    __vf_ignore='enP2p0s2'
+    SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__vf_ignore/})
+    scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ~/SR-IOV_Utils.sh ${REMOTE_USER}@[${STATIC_IP2}]:
+fi
+# Config static IP - with transparent-vf it is not necessary to run bondvf.sh
+if [[ "${SRIOV}" = "yes" ]] || [[ "${SRIOV}" = "no" ]]; then
+    #Config static ip on the client side.
+    config_staticip ${STATIC_IP} ${NETMASK}
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Function config_staticip failed."
+        LogMsg "ERROR: Function config_staticip failed."
+        UpdateTestState $ICA_TESTABORTED
+    fi
+fi
+# Config static IP - using bondvf.sh
+if [ "${SRIOV}" = "bond" ]; then
+    # Check if the SR-IOV driver is in use
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    # Run bondvf.sh platform specific script
+    RunBondingScript
+    bondCount=$?
+    if [ $bondCount -eq 99 ]; then
+        msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    else
+        LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"
+    fi
+    # Set static IP to the bond
+    perf_ConfigureBond ${STATIC_IP}
+    if [ $? -ne 0 ]; then
+        msg="ERROR: Could not set a static IP to the bond!"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ~/SR-IOV_Utils.sh ${REMOTE_USER}@[${STATIC_IP2}]:
+fi
 
 LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
-
 # Test interfaces
 declare -i __iterator
 for __iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
@@ -313,10 +374,15 @@ echo "test signal file      = ${TEST_SIGNAL_FILE}"
 echo "test run log folder       = ${TEST_RUN_LOG_FOLDER}"
 echo "iperf3 test connection pool   = ${IPERF3_TEST_CONNECTION_POOL}"
 
-#
-# Check for internet protocol version
-#
+#Apling performance parameters
+setup_sysctl "$(declare -p sysctl_udp_params)"
+if [ $? -ne 0 ]; then
+    echo "Unable to add performance parameters."
+    LogMsg "Unable to add performance parameters."
+    UpdateTestState $ICA_TESTABORTED
+fi
 
+# Check for internet protocol version
 CheckIPV6 "$STATIC_IP"
 if [[ $? -eq 0 ]]; then
     CheckIPV6 "$IPERF3_SERVER_IP"
@@ -333,74 +399,47 @@ else
     ipVersion="-4"
 fi
 
-#
-# Extract the files from the IPerf tar package
-#
-tar -xzf ./${IPERF_PACKAGE}
-if [ $? -ne 0 ]; then
-    msg="Error: Unable extract ${IPERF_PACKAGE}"
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-    UpdateTestState $ICA_TESTFAILED
-    exit 70
-fi
-
-#
-# Get the root directory of the tarball
-#
-rootDir=`tar -tzf ${IPERF_PACKAGE} | sed -e 's@/.*@@' | uniq`
-if [ -z ${rootDir} ]; then
-    msg="Error: Unable to determine root directory if ${IPERF_PACKAGE} tarball"
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-    UpdateTestState $ICA_TESTFAILED
-    exit 80
-fi
-
-LogMsg "rootDir = ${rootDir}"
-cd ${rootDir}
-
+# Flushing firewall rules
 iptables -F
+if [ $? -ne 0 ]; then
+    msg="ERROR: Failed to flush iptables rules. Continuing"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+fi
 ip6tables -F
-#
-# Distro specific setup
-#
-GetDistro
+if [ $? -ne 0 ]; then
+    msg="ERROR: Failed to flush ip6tables rules. Continuing"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+fi
 
+#Check distro
+GetDistro
 case "$DISTRO" in
 debian*|ubuntu*)
-    LogMsg "Updating apt repositories"
-    apt-get update & wait
-
-    LogMsg "Installing sar on Ubuntu"
-    apt-get install sysstat -y
-    if [ $? -ne 0 ]; then
-        msg="Error: sysstat failed to install"
+    disable_firewall
+    if [[ $? -ne 0 ]]; then
+        msg="ERROR: Unable to disable firewall.Exiting"
         LogMsg "${msg}"
         echo "${msg}" >> ~/summary.log
         UpdateTestState $ICA_TESTFAILED
-        exit 85
+        exit 1
     fi
-    apt-get install zip build-essential -y
+    LogMsg "Installing dependency tools on Ubuntu"
+    apt-get update && apt-get install build-essential git sysstat dstat -y
     if [ $? -ne 0 ]; then
-        msg="Error: Build essential failed to install"
+        msg="ERROR: dependencies failed to install"
         LogMsg "${msg}"
         echo "${msg}" >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
-        exit 85
-    fi
-    service ufw status
-    if [ $? -ne 3 ]; then
-        LogMsg "Disabling firewall on Ubuntu"
-        service ufw stop
-        if [ $? -ne 0 ]; then
-                msg="Error: Failed to stop ufw"
-                LogMsg "${msg}"
-                echo "${msg}" >> ~/summary.log
-        fi
     fi
     ;;
 redhat_5|redhat_6|centos_6|centos_5)
+    yum install -y bc sysstat dstat
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check irqbalance status on RHEL 5/6.x."
     service irqbalance status
     if [ $? -eq 3 ]; then
@@ -413,6 +452,7 @@ redhat_5|redhat_6|centos_6|centos_5)
             UpdateTestState $ICA_TESTFAILED
             exit 1
         fi
+        service irqbalance status
     fi
     disable_firewall
     if [[ $? -ne 0 ]]; then
@@ -424,6 +464,12 @@ redhat_5|redhat_6|centos_6|centos_5)
     fi
     ;;
 redhat_7|centos_7)
+    yum install -y bc sysstat dstat
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check irqbalance status on RHEL 7.xx."
     systemctl status irqbalance
     if [ $? -eq 3 ]; then
@@ -436,119 +482,78 @@ redhat_7|centos_7)
             UpdateTestState $ICA_TESTFAILED
             exit 1
         fi
+        systemctl status irqbalance
     fi
-    LogMsg "Check iptables status on RHEL"
+    LogMsg "Check firewalld status on RHEL 7.xx."
     systemctl status firewalld
     if [ $? -ne 3 ]; then
-        LogMsg "Disabling firewall on Redhat 7"
-        systemctl disable firewalld
+        LogMsg "Disabling firewall on Redhat 7.x"
+        systemctl stop firewalld && systemctl disable firewalld
         if [ $? -ne 0 ]; then
-            msg="Error: Failed to stop firewalld"
+            msg="ERROR: Failed to turn off firewalld. Continuing"
+            LogMsg "${msg}"
+            echo "${msg}" >> ~/summary.log
+        fi
+    fi
+    disable_firewall
+    if [[ $? -ne 0 ]]; then
+        msg="ERROR: Unable to disable firewall.Exiting"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+        UpdateTestState $ICA_TESTFAILED
+        exit 1
+    fi
+    ;;
+suse_12)
+    zypper -n in dstat sysstat gcc
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
+    LogMsg "Check iptables status on SLES 12"
+    service SuSEfirewall2 status
+    if [ $? -ne 3 ]; then
+        service SuSEfirewall2 stop
+        if [ $? -ne 0 ]; then
+            msg="ERROR: Failed to stop iptables"
             LogMsg "${msg}"
             echo "${msg}" >> ~/summary.log
             UpdateTestState $ICA_TESTFAILED
             exit 85
         fi
-        systemctl stop firewalld
+        chkconfig SuSEfirewall2 off
         if [ $? -ne 0 ]; then
-            msg="Error: Failed to turn off firewalld. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-    fi
-
-    LogMsg "Check iptables status on RHEL7"
-    service iptables status
-    if [ $? -ne 3 ]; then
-        iptables -F;
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to flush iptables rules. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-        service iptables stop
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to stop iptables"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-        chkconfig iptables off
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to turn off iptables. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-    fi
-
-    LogMsg "Check ip6tables status on RHEL7"
-    service ip6tables status
-    if [ $? -ne 3 ]; then
-        ip6tables -F;
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to flush ip6tables rules. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-        service ip6tables stop
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to stop ip6tables"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-        chkconfig ip6tables off
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to turn off iptables. Continuing"
+            msg="ERROR: Failed to turn off iptables. Continuing"
             LogMsg "${msg}"
             echo "${msg}" >> ~/summary.log
         fi
     fi
     ;;
-
-    suse_12)
-        # Install gcc which is required to build iperf3
-        zypper --non-interactive install gcc
-
-        #Check if sysstat package is installed
-        command -v sar
-        if [ $? -ne 0 ]; then
-            msg="Error: Sysstat (sar) is not installed. Please install it before running the performance tests!"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-            UpdateTestState $ICA_TESTFAILED
-            exit 82
-        fi
-
-        LogMsg "Check iptables status on SLES"
-        service SuSEfirewall2 status
-        if [ $? -ne 3 ]; then
-            iptables -F;
-            if [ $? -ne 0 ]; then
-                msg="Error: Failed to flush iptables rules. Continuing"
-                LogMsg "${msg}"
-                echo "${msg}" >> ~/summary.log
-            fi
-            service SuSEfirewall2 stop
-            if [ $? -ne 0 ]; then
-                msg="Error: Failed to stop iptables"
-                LogMsg "${msg}"
-                echo "${msg}" >> ~/summary.log
-                UpdateTestState $ICA_TESTFAILED
-                exit 85
-            fi
-            chkconfig SuSEfirewall2 off
-            if [ $? -ne 0 ]; then
-                msg="Error: Failed to turn off iptables. Continuing"
-                LogMsg "${msg}"
-                echo "${msg}" >> ~/summary.log
-            fi
-        fi
-    ;;
-
 esac
 
-#
+# Extract the files from the IPerf tar package
+tar -xzf ./${IPERF_PACKAGE}
+if [ $? -ne 0 ]; then
+    msg="Error: Unable extract ${IPERF_PACKAGE}"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+    UpdateTestState $ICA_TESTFAILED
+    exit 70
+fi
+# Get the root directory of the tarball
+rootDir=`tar -tzf ${IPERF_PACKAGE} | sed -e 's@/.*@@' | uniq`
+if [ -z ${rootDir} ]; then
+    msg="Error: Unable to determine root directory if ${IPERF_PACKAGE} tarball"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+    UpdateTestState $ICA_TESTFAILED
+    exit 80
+fi
+
+LogMsg "rootDir = ${rootDir}"
+cd ${rootDir}
 # Build iperf
-#
 ./configure
 if [ $? -ne 0 ]; then
     msg="Error: ./configure failed"
@@ -557,7 +562,6 @@ if [ $? -ne 0 ]; then
     UpdateTestState $ICA_TESTFAILED
     exit 90
 fi
-
 make
 if [ $? -ne 0 ]; then
     msg="Error: Unable to build iperf"
@@ -566,7 +570,6 @@ if [ $? -ne 0 ]; then
     UpdateTestState $ICA_TESTFAILED
     exit 100
 fi
-
 make install
 if [ $? -ne 0 ]; then
     msg="Error: Unable to install iperf"
@@ -615,31 +618,8 @@ function get_tx_pkts(){
     echo $Tx_pkts
 }
 
-# set static IPs for test interfaces
-declare -i __iterator=0
-
-while [ $__iterator -lt ${#SYNTH_NET_INTERFACES[@]} ]; do
-
-    LogMsg "Trying to set an IP Address via static on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-    CreateIfupConfigFile "${SYNTH_NET_INTERFACES[$__iterator]}" "static" $STATIC_IP $NETMASK
-
-    if [ 0 -ne $? ]; then
-        msg="Unable to set address for ${SYNTH_NET_INTERFACES[$__iterator]} through static"
-        LogMsg "$msg"
-        UpdateSummary "$msg"
-        SetTestStateFailed
-        exit 10
-    fi
-
-    : $((__iterator++))
-
-done
-
-# Waiting for VM2 to boot
-sleep 30
-
 LogMsg "Copy files to server: ${STATIC_IP2}"
-scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ~/perf_iperf_server.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ~/perf_iperf_server.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
 if [ $? -ne 0 ]; then
     msg="Error: Unable to copy test scripts to target server machine: ${STATIC_IP2}. scp command failed."
     LogMsg "${msg}"
@@ -647,16 +627,14 @@ if [ $? -ne 0 ]; then
     UpdateTestState $ICA_TESTFAILED
     exit 130
 fi
-scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ~/${IPERF_PACKAGE} ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
-scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ~/constants.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
-scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ~/utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ~/${IPERF_PACKAGE} ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ~/constants.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ~/utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ~/perf_utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
 
-
-#
 # Start iPerf in server mode on the Target server side
-#
 LogMsg "Starting iPerf in server mode on ${STATIC_IP2}"
-ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "echo '~/perf_iperf_server.sh > iPerf3_Panorama_ServerSideScript.log' | at now"
+ssh -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "~/perf_iperf_server.sh > iPerf3_Panorama_ServerSideScript.log"
 if [ $? -ne 0 ]; then
     msg="Error: Unable to start iPerf3 server scripts on the target server machine"
     LogMsg "${msg}"
@@ -665,87 +643,67 @@ if [ $? -ne 0 ]; then
     exit 130
 fi
 
-#
-# Wait for server to be ready
-#
-wait_for_server=600
-server_state_file=serverstate.txt
-while [ $wait_for_server -gt 0 ]; do
-    # Try to copy and understand server state
-    scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:~/state.txt ~/${server_state_file}
-
-    if [ -f ~/${server_state_file} ];
-    then
-        server_state=$(head -n 1 ~/${server_state_file})
-        echo $server_state
-        rm -rf ~/${server_state_file}
-        if [ "$server_state" == "iPerf3Running" ];
-        then
-            break
-        fi
-    fi
-    sleep 5
-    wait_for_server=$(($wait_for_server - 5))
-done
-
-if [ $wait_for_server -eq 0 ] ;
-then
-    msg="Error: iperf3 server script has been triggered but not iperf3 are not in running state within ${wait_for_server} seconds."
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-    UpdateTestState $ICA_TESTFAILED
-    exit 135
-else
-    LogMsg "iPerf3 servers are ready."
-fi
-#
+sleep 10
 # Start iPerf3 client instances
-#
 LogMsg "Starting iPerf3 in client mode"
 
 previous_tx_bytes=$(get_tx_bytes)
 previous_tx_pkts=$(get_tx_pkts)
 
-i=0
 mkdir -p ./${TEST_RUN_LOG_FOLDER}
-while [ "x${IPERF3_TEST_CONNECTION_POOL[$i]}" != "x" ]
+for number_of_connections in "${IPERF3_TEST_CONNECTION_POOL[@]}"
 do
     port=8001
     echo "================================================="
-    echo "Running Test: ${IPERF3_TEST_CONNECTION_POOL[$i]}"
+    echo "Running Test: ${number_of_connections}"
     echo "================================================="
-
-    touch ${TEST_SIGNAL_FILE}
-    echo ${IPERF3_TEST_CONNECTION_POOL[$i]} > ${TEST_SIGNAL_FILE}
-    scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ${TEST_SIGNAL_FILE} $server_username@${STATIC_IP2}:
-    sleep 15
-
-    number_of_connections=${IPERF3_TEST_CONNECTION_POOL[$i]}
-    bash ./perf_capturer.sh $INDIVIDUAL_TEST_DURATION ${TEST_RUN_LOG_FOLDER}/$number_of_connections &
+    server_iperf_instances=$((number_of_connections/4+port))
+    for ((i=port; i<=server_iperf_instances; i++))
+    do
+        ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "/root/${rootDir}/src/iperf3 -s ${ipVersion} -p $i -i ${INDIVIDUAL_TEST_DURATION} -D"
+        sleep 1
+    done
 
     rm -rf the_generated_client.sh
     echo "./perf_run_parallelcommands.sh " > the_generated_client.sh
-
-    while [ $number_of_connections -gt $CONNECTIONS_PER_IPERF3 ]; do
-        number_of_connections=$(($number_of_connections-$CONNECTIONS_PER_IPERF3))
-        echo " \"/root/${rootDir}/src/iperf3 -u ${IPERF3_PROTOCOL} -c $IPERF3_SERVER_IP -p $port $ipVersion ${BANDWIDTH+-b ${BANDWIDTH}} -l ${IPERF3_BUFFER} -P $CONNECTIONS_PER_IPERF3 -t $INDIVIDUAL_TEST_DURATION --get-server-output -i ${INDIVIDUAL_TEST_DURATION} > /dev/null \" " >> the_generated_client.sh
+    remaining_connections=${number_of_connections}
+    while [ ${remaining_connections} -gt ${CONNECTIONS_PER_IPERF3} ]; do
+        remaining_connections=$((${remaining_connections}-${CONNECTIONS_PER_IPERF3}))
+        echo " \"/root/${rootDir}/src/iperf3 ${PROTOCOL} -c ${IPERF3_SERVER_IP} -p $port ${ipVersion} ${BANDWIDTH+-b ${BANDWIDTH}} -l ${IPERF3_BUFFER} -P ${CONNECTIONS_PER_IPERF3} -t ${INDIVIDUAL_TEST_DURATION} --get-server-output -i ${INDIVIDUAL_TEST_DURATION} > /dev/null \" " >> the_generated_client.sh
         port=$(($port + 1))
     done
 
-    if [ $number_of_connections -gt 0 ]
+    if [ ${remaining_connections} -gt 0 ]
     then
-        echo " \"/root/${rootDir}/src/iperf3 -u ${IPERF3_PROTOCOL} -c $IPERF3_SERVER_IP -p $port $ipVersion ${BANDWIDTH+-b ${BANDWIDTH}} -l ${IPERF3_BUFFER} -P $number_of_connections  -t $INDIVIDUAL_TEST_DURATION --get-server-output -i ${INDIVIDUAL_TEST_DURATION} > /dev/null \" " >> the_generated_client.sh
+        echo " \"/root/${rootDir}/src/iperf3 ${PROTOCOL} -c ${IPERF3_SERVER_IP} -p $port ${ipVersion} ${BANDWIDTH+-b ${BANDWIDTH}} -l ${IPERF3_BUFFER} -P ${remaining_connections} -t ${INDIVIDUAL_TEST_DURATION} --get-server-output -i ${INDIVIDUAL_TEST_DURATION} > /dev/null \" " >> the_generated_client.sh
     fi
 
     sed -i ':a;N;$!ba;s/\n/ /g'  ./the_generated_client.sh
     chmod 755 the_generated_client.sh
-
     cat ./the_generated_client.sh
-    ./the_generated_client.sh > ${TEST_RUN_LOG_FOLDER}/${IPERF3_TEST_CONNECTION_POOL[$i]}-iperf3.log
-    i=$(($i + 1))
 
-    echo "Clients test just finished. Sleep 10 seconds for next test..."
-    sleep 60
+    sar -n DEV 1 ${INDIVIDUAL_TEST_DURATION} > "${TEST_RUN_LOG_FOLDER}/sar-sender-${number_of_connections}.log" &
+    dstat -dam > "${TEST_RUN_LOG_FOLDER}/dstat-sender-${number_of_connections}.log" &
+    mpstat -P ALL 1 ${INDIVIDUAL_TEST_DURATION} > "${TEST_RUN_LOG_FOLDER}/mpstat-sender-${number_of_connections}.log" &
+
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "sar -n DEV 1 ${INDIVIDUAL_TEST_DURATION} > ${TEST_RUN_LOG_FOLDER}/sar-receiver-${number_of_connections}.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "dstat -dam > ${TEST_RUN_LOG_FOLDER}/dstat-receiver-${number_of_connections}.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "mpstat -P ALL 1 ${INDIVIDUAL_TEST_DURATION} > ${TEST_RUN_LOG_FOLDER}/mpstat-receiver-${number_of_connections}.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "for ((i=1;i<=${INDIVIDUAL_TEST_DURATION};i++)); do netstat -nat | grep ESTABLISHED | wc -l >> ./${TEST_RUN_LOG_FOLDER}/receiver-${number_of_connections}-connections.log; sleep 1; done"
+
+    ./the_generated_client.sh > ${TEST_RUN_LOG_FOLDER}/${number_of_connections}-iperf3.log
+    sleep 5
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "netstat -su > ${TEST_RUN_LOG_FOLDER}/receiver-${number_of_connections}-udp-tatistics.log"
+    pkill -f iperf3
+    pkill -f ESTABLISHED
+    pkill -x sar
+    pkill -x dstat
+    pkill -x mpstat
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -f iperf3"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x sar"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x dstat"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x mpstat"
+    sleep 55
 done
 current_tx_bytes=$(get_tx_bytes)
 current_tx_pkts=$(get_tx_pkts)
@@ -758,16 +716,21 @@ then
     rm -f iPerf3_Client_Logs.zip
 fi
 # Test Finished. Collect logs, zip client side logs
-sleep 60
+sleep 30
 
+ethtool -S eth1 > ${TEST_RUN_LOG_FOLDER}/sender-ethtool-eth1.log
+ethtool -S enP2p0s2 > ${TEST_RUN_LOG_FOLDER}/sender-ethtool-enP2p0s2.log
+ssh -i "$HOME"/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "ethtool -S eth1 > ~/${TEST_RUN_LOG_FOLDER}/receiver-ethtool-eth1.log"
+ssh -i "$HOME"/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "ethtool -S enP2p0s2 > ~/${TEST_RUN_LOG_FOLDER}/receiver-ethtool-enP2p0s2.log"
+scp -i "$HOME"/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:/root/${TEST_RUN_LOG_FOLDER}/*receiver* /root/${TEST_RUN_LOG_FOLDER}
 zip -r iPerf3_Client_Logs.zip ${TEST_RUN_LOG_FOLDER}/*
 
 # Get logs from server side
-ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "echo 'if [ -f iPerf3_Server_Logs.zip  ]; then rm -f iPerf3_Server_Logs.zip; fi' | at now"
-ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "echo 'zip -r ~/iPerf3_Server_Logs.zip ~/${TEST_RUN_LOG_FOLDER}' | at now"
-sleep 60
-scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no -r ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:~/iPerf3_Server_Logs.zip ~/iPerf3_Server_Logs.zip
-scp -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no -r ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:~/iPerf3_Panorama_ServerSideScript.log ~/iPerf3_Panorama_ServerSideScript.log
+ssh -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "echo 'if [ -f iPerf3_Server_Logs.zip  ]; then rm -f iPerf3_Server_Logs.zip; fi' | at now"
+ssh -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "echo 'zip -r ~/iPerf3_Server_Logs.zip ~/${TEST_RUN_LOG_FOLDER}/*' | at now"
+sleep 30
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no -r ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:~/iPerf3_Server_Logs.zip ~/iPerf3_Server_Logs.zip
+scp -i "$HOME"/.ssh/"${SSH_PRIVATE_KEY}" -o StrictHostKeyChecking=no -r ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:~/iPerf3_Panorama_ServerSideScript.log ~/iPerf3_Panorama_ServerSideScript.log
 
 UpdateSummary "Distribution: $DISTRO"
 UpdateSummary "Kernel: $(uname -r)"
@@ -775,19 +738,7 @@ UpdateSummary "Test Protocol: ${IPERF3_PROTOCOL}"
 UpdateSummary "Packet size: $avg_pkt_size"
 UpdateSummary "IPERF3_BUFFER: ${IPERF3_BUFFER}"
 
-
-#
-# If we made it here, everything worked
-#
-
-#Shut down dependency VM
-ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "reboot | at now"
-if [ $? -ne 0 ]; then
-    msg="Warning: Unable to shut down target server machine"
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-fi
-
 LogMsg "Test completed successfully"
 UpdateTestState $ICA_TESTCOMPLETED
 exit 0
+

--- a/WS2012R2/lisa/remote-scripts/ica/perf_iperf_server.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_iperf_server.sh
@@ -79,17 +79,22 @@ touch ~/summary.log
 
 # Convert eol
 dos2unix utils.sh
-
 # Source utils.sh
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
     echo "TestAborted" > state.txt
     exit 2
 }
+dos2unix perf_utils.sh
+# Source perf_utils.sh
+. perf_utils.sh || {
+    echo "Error: unable to source perf_utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
 
 # Source constants file and initialize most common variables
 UtilsInit
-
 # In case of error
 case $? in
     0)
@@ -125,9 +130,7 @@ case $? in
         ;;
 esac
 
-#
 # Make sure the required test parameters are defined
-#
 if [ "${IPERF_PACKAGE:="UNDEFINED"}" = "UNDEFINED" ]; then
     msg="Error: the IPERF_PACKAGE test parameter is missing"
     LogMsg "${msg}"
@@ -170,12 +173,9 @@ if [ "${TEST_RUN_LOG_FOLDER:="UNDEFINED"}" = "UNDEFINED" ]; then
     echo "${msg}" >> ~/summary.log
 fi
 
-#Get test synthetic interface
-declare __iface_ignore
-
 # Parameter provided in constants file
-#   ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
-#   it is not touched during this test (no dhcp or static ip assigned to it)
+# ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
+# it is not touched during this test (no dhcp or static ip assigned to it)
 
 if [ "${STATIC_IP2:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter STATIC_IP2 is not defined in constants file! Make sure you are using the latest LIS code."
@@ -184,9 +184,7 @@ if [ "${STATIC_IP2:-UNDEFINED}" = "UNDEFINED" ]; then
     SetTestStateAborted
     exit 30
 else
-
     CheckIP "$STATIC_IP2"
-
     if [ 0 -ne $? ]; then
         msg="Test parameter STATIC_IP2 = $STATIC_IP2 is not a valid IP Address"
         LogMsg "$msg"
@@ -194,14 +192,15 @@ else
         SetTestStateAborted
         exit 10
     fi
-
-    # Get the interface associated with the given ipv4
-    __iface_ignore=$(ip -o addr show | grep "$STATIC_IP2" | cut -d ' ' -f2)
 fi
 
+
+#Get test synthetic interface
+declare __iface_ignore
+# Get the interface associated with the given ipv4
+__iface_ignore=$(ip -o addr show | grep "$STATIC_IP2" | cut -d ' ' -f2)
 # Retrieve synthetic network interfaces
 GetSynthNetInterfaces
-
 if [ 0 -ne $? ]; then
     msg="No synthetic network interfaces found"
     LogMsg "$msg"
@@ -209,10 +208,8 @@ if [ 0 -ne $? ]; then
     SetTestStateFailed
     exit 10
 fi
-
 # Remove interface if present
 SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__iface_ignore/})
-
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
     msg="The only synthetic interface is the one which LIS uses to send files/commands to the VM."
     LogMsg "$msg"
@@ -221,8 +218,89 @@ if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
     exit 10
 fi
 
-LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
+# SRIOV setup (transparent VF)
+if [ "${SRIOV}" = "yes" ]; then
+    # Check if the SR-IOV driver is in use
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    __vf_ignore='enP2p0s2'
+    SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__vf_ignore/})
+fi
 
+# SRIOV setup (transparent VF)
+if [ "${SRIOV}" = "yes" ]; then
+    dos2unix SR-IOV_Utils.sh
+    # Source perf_utils.sh
+    . SR-IOV_Utils.sh || {
+        echo "ERROR: Unable to source SR-IOV_Utils.sh!"
+        echo "TestAborted" > state.txt
+        exit 2
+    }
+    # Check if the SR-IOV driver is in use
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    __vf_ignore='enP2p0s2'
+    SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__vf_ignore/})
+fi
+# Config static IP - with transparent-vf it is not necessary to run bondvf.sh
+if [[ "${SRIOV}" = "yes" ]] || [[ "${SRIOV}" = "no" ]]; then
+    #Config static ip on the client side.
+    config_staticip ${IPERF3_SERVER_IP} ${NETMASK}
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Function config_staticip failed."
+        LogMsg "ERROR: Function config_staticip failed."
+        UpdateTestState $ICA_TESTABORTED
+    fi
+fi
+# Config static IP - using bondvf.sh
+if [ "${SRIOV}" = "bond" ]; then
+    dos2unix SR-IOV_Utils.sh
+    # Source perf_utils.sh
+    . SR-IOV_Utils.sh || {
+        echo "ERROR: Unable to source SR-IOV_Utils.sh!"
+        echo "TestAborted" > state.txt
+        exit 2
+    }
+    # Check if the SR-IOV driver is in use
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    # Run bondvf.sh platform specific script
+    RunBondingScript
+    bondCount=$?
+    if [ $bondCount -eq 99 ]; then
+        msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    else
+        LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"
+    fi
+    # Set static IP to the bond
+    perf_ConfigureBond ${IPERF3_SERVER_IP}
+    if [ $? -ne 0 ]; then
+        msg="ERROR: Could not set a static IP to the bond!"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+fi
+
+LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
 # Test interfaces
 declare -i __iterator
 for __iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
@@ -236,8 +314,6 @@ for __iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
     fi
 done
 
-LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
-
 echo "iPerf package name		= ${IPERF_PACKAGE}"
 echo "iPerf protocol        = ${IPERF3_PROTOCOL}"
 echo "individual test duration (sec)	= ${INDIVIDUAL_TEST_DURATION}"
@@ -245,84 +321,55 @@ echo "connections per iperf3		= ${CONNECTIONS_PER_IPERF3}"
 echo "test signal file			= ${TEST_SIGNAL_FILE}"
 echo "test run log folder		= ${TEST_RUN_LOG_FOLDER}"
 
-#
-# Check for internet protocol version
-#
-CheckIPV6 "$IPERF3_SERVER_IP"
-if [[ $? -eq 0 ]]; then
-    ipVersion="-6"
-else
-    ipVersion="-4"
-fi
-
-#
-# Extract the files from the IPerf tar package
-#
-tar -xzf ./${IPERF_PACKAGE}
+#Apling performance parameters
+setup_sysctl "$(declare -p sysctl_udp_params)"
 if [ $? -ne 0 ]; then
-    msg="Error: Unable extract ${IPERF_PACKAGE}"
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-    UpdateTestState $ICA_TESTFAILED
-    exit 70
+    echo "Unable to add performance parameters."
+    LogMsg "Unable to add performance parameters."
+    UpdateTestState $ICA_TESTABORTED
 fi
 
-#
-# Get the root directory of the tarball
-#
-rootDir=`tar -tzf ${IPERF_PACKAGE} | sed -e 's@/.*@@' | uniq`
-if [ -z ${rootDir} ]; then
-    msg="Error: Unable to determine iperf3's root directory"
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-    UpdateTestState $ICA_TESTFAILED
-    exit 80
-fi
-
-LogMsg "rootDir = ${rootDir}"
-cd ${rootDir}
-
+# Flushing firewall rules
 iptables -F
+if [ $? -ne 0 ]; then
+    msg="ERROR: Failed to flush iptables rules. Continuing"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+fi
 ip6tables -F
-#
-# Distro specific setup
-#
-GetDistro
+if [ $? -ne 0 ]; then
+    msg="ERROR: Failed to flush ip6tables rules. Continuing"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+fi
 
+#Check distro
+GetDistro
 case "$DISTRO" in
 debian*|ubuntu*)
-    LogMsg "Updating apt repositories"
-    apt-get update & wait
-
-    LogMsg "Installing sar on Ubuntu"
-    apt-get install sysstat -y
-    if [ $? -ne 0 ]; then
-        msg="Error: sysstat failed to install"
+    disable_firewall
+    if [[ $? -ne 0 ]]; then
+        msg="ERROR: Unable to disable firewall.Exiting"
         LogMsg "${msg}"
         echo "${msg}" >> ~/summary.log
         UpdateTestState $ICA_TESTFAILED
-        exit 85
+        exit 1
     fi
-    apt-get install zip build-essential -y
+    LogMsg "Installing dependency tools on Ubuntu"
+    apt-get update && apt-get install build-essential git sysstat dstat -y
     if [ $? -ne 0 ]; then
-        msg="Error: Build essential failed to install"
+        msg="ERROR: dependencies failed to install"
         LogMsg "${msg}"
         echo "${msg}" >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
-        exit 85
-    fi
-    service ufw status
-    if [ $? -ne 3 ]; then
-        LogMsg "Disabling firewall on Ubuntu"
-        service ufw stop
-        if [ $? -ne 0 ]; then
-                msg="Error: Failed to stop ufw"
-                LogMsg "${msg}"
-                echo "${msg}" >> ~/summary.log
-        fi
     fi
     ;;
 redhat_5|redhat_6|centos_6|centos_5)
+    yum install -y bc sysstat dstat
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check irqbalance status on RHEL 5/6.x."
     service irqbalance status
     if [ $? -eq 3 ]; then
@@ -335,6 +382,7 @@ redhat_5|redhat_6|centos_6|centos_5)
             UpdateTestState $ICA_TESTFAILED
             exit 1
         fi
+        service irqbalance status
     fi
     disable_firewall
     if [[ $? -ne 0 ]]; then
@@ -346,6 +394,12 @@ redhat_5|redhat_6|centos_6|centos_5)
     fi
     ;;
 redhat_7|centos_7)
+    yum install -y bc sysstat dstat
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check irqbalance status on RHEL 7.xx."
     systemctl status irqbalance
     if [ $? -eq 3 ]; then
@@ -358,68 +412,41 @@ redhat_7|centos_7)
             UpdateTestState $ICA_TESTFAILED
             exit 1
         fi
+        systemctl status irqbalance
     fi
-    LogMsg "Check iptables status on RHEL"
-	systemctl status firewalld
+    LogMsg "Check firewalld status on RHEL 7.xx."
+    systemctl status firewalld
     if [ $? -ne 3 ]; then
-        LogMsg "Disabling firewall on Redhat 7"
-        systemctl disable firewalld
+        LogMsg "Disabling firewall on Redhat 7.x"
+        systemctl stop firewalld && systemctl disable firewalld
         if [ $? -ne 0 ]; then
-            msg="Error: Failed to stop firewalld"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-            UpdateTestState $ICA_TESTFAILED
-            exit 85
-        fi
-        systemctl stop firewalld
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to turn off firewalld. Continuing"
+            msg="ERROR: Failed to turn off firewalld. Continuing"
             LogMsg "${msg}"
             echo "${msg}" >> ~/summary.log
         fi
     fi
-
-    LogMsg "Check iptables status on RHEL7"
-    service iptables status
-    if [ $? -ne 3 ]; then
-        iptables -F;
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to flush iptables rules. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-        service iptables stop
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to stop iptables"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
-        chkconfig iptables off
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to turn off iptables. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
+    disable_firewall
+    if [[ $? -ne 0 ]]; then
+        msg="ERROR: Unable to disable firewall.Exiting"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+        UpdateTestState $ICA_TESTFAILED
+        exit 1
     fi
     ;;
 suse_12)
-	#
-	# Install gcc which is required to build iperf3
-	#
-	zypper --non-interactive install gcc
-
-    LogMsg "Check iptables status on RHEL7"
+    zypper -n in dstat sysstat gcc
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
+    LogMsg "Check iptables status on SLES 12"
     service SuSEfirewall2 status
     if [ $? -ne 3 ]; then
-        iptables -F;
-        if [ $? -ne 0 ]; then
-            msg="Error: Failed to flush iptables rules. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
         service SuSEfirewall2 stop
         if [ $? -ne 0 ]; then
-            msg="Error: Failed to stop iptables"
+            msg="ERROR: Failed to stop iptables"
             LogMsg "${msg}"
             echo "${msg}" >> ~/summary.log
             UpdateTestState $ICA_TESTFAILED
@@ -427,7 +454,7 @@ suse_12)
         fi
         chkconfig SuSEfirewall2 off
         if [ $? -ne 0 ]; then
-            msg="Error: Failed to turn off iptables. Continuing"
+            msg="ERROR: Failed to turn off iptables. Continuing"
             LogMsg "${msg}"
             echo "${msg}" >> ~/summary.log
         fi
@@ -435,9 +462,29 @@ suse_12)
     ;;
 esac
 
-#
+# Extract the files from the IPerf tar package
+tar -xzf ./${IPERF_PACKAGE}
+if [ $? -ne 0 ]; then
+    msg="Error: Unable extract ${IPERF_PACKAGE}"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+    UpdateTestState $ICA_TESTFAILED
+    exit 70
+fi
+
+# Get the root directory of the tarball
+rootDir=`tar -tzf ${IPERF_PACKAGE} | sed -e 's@/.*@@' | uniq`
+if [ -z ${rootDir} ]; then
+    msg="Error: Unable to determine iperf3's root directory"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+    UpdateTestState $ICA_TESTFAILED
+    exit 80
+fi
+
+LogMsg "rootDir = ${rootDir}"
+cd ${rootDir}
 # Build iperf
-#
 ./configure
 if [ $? -ne 0 ]; then
     msg="Error: ./configure failed"
@@ -477,77 +524,9 @@ fi
 # go back to test root folder
 cd ~
 
-# set static ips for test interfaces
-declare -i __iterator=0
-
-while [ $__iterator -lt ${#SYNTH_NET_INTERFACES[@]} ]; do
-
-    LogMsg "Trying to set an IP Address via static on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-
-    CreateIfupConfigFile "${SYNTH_NET_INTERFACES[$__iterator]}" "static" $IPERF3_SERVER_IP $NETMASK
-
-    if [ 0 -ne $? ]; then
-        msg="Unable to set address for ${SYNTH_NET_INTERFACES[$__iterator]} through static"
-        LogMsg "$msg"
-        UpdateSummary "$msg"
-        SetTestStateFailed
-        exit 10
-    fi
-
-    echo "TestInterface: ${SYNTH_NET_INTERFACES[$__iterator]}"
-    : $((__iterator++))
-
-done
-
-#
+mkdir ${TEST_RUN_LOG_FOLDER}
 # Start iPerf3 server instances
-#
 LogMsg "Starting iPerf3 in server mode"
 
 UpdateTestState $ICA_IPERF3RUNNING
 LogMsg "iperf3 server instances now are ready to run"
-
-mkdir ${TEST_RUN_LOG_FOLDER}
-#default the parameter
-number_of_connections=0
-touch ${TEST_SIGNAL_FILE}
-echo 0 > ${TEST_SIGNAL_FILE}
-
-time=0
-while true; do
-    #once received a reset/start signal from client side, do the test
-    if [ -f ${TEST_SIGNAL_FILE} ];
-    then
-        number_of_connections=$(head -n 1 ${TEST_SIGNAL_FILE})
-        rm -rf ${TEST_SIGNAL_FILE}
-        echo "Reset iperf3 server for test. Connections: ${number_of_connections} ..."
-        pkill -f iperf3
-        sleep 1
-
-        echo "Start new iperf3 instances..."
-        number_of_iperf_instances=$((number_of_connections/CONNECTIONS_PER_IPERF3+8001))
-
-        for ((i=8001; i<=$number_of_iperf_instances; i++))
-        do
-            /root/${rootDir}/src/iperf3 -s $ipVersion -p $i -i ${INDIVIDUAL_TEST_DURATION} -D
-            sleep 1
-        done
-        x=$(ps -aux | grep iperf | wc -l)
-        echo "ps -aux | grep iperf | wc -l: $x"
-
-        mkdir ./${TEST_RUN_LOG_FOLDER}/$number_of_connections
-
-        sar -n DEV 1 ${INDIVIDUAL_TEST_DURATION} 2>&1 > ./${TEST_RUN_LOG_FOLDER}/$number_of_connections/sar.log &
-    fi
-
-    top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}' >> ./${TEST_RUN_LOG_FOLDER}/$number_of_connections/top.log
-    #ifstat eth0 | grep eth0 | awk '{print $6}' >> ifstatlog.log
-    if [ $(($time % 10)) -eq 0 ];
-    then
-        echo $(netstat -nat | grep ESTABLISHED | wc -l) >> ./${TEST_RUN_LOG_FOLDER}/$number_of_connections/connections.log
-    fi
-
-    sleep 1
-    time=$(($time + 1))
-    echo "$time"
-done

--- a/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_client.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/perf_ntttcp_client.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ########################################################################
 #
 # Linux on Hyper-V and Azure Test Code, ver. 1.0.0
@@ -77,8 +76,6 @@ touch ~/summary.log
 
 # Convert eol
 dos2unix utils.sh
-dos2unix perf_utils.sh
-
 # Source utils.sh
 . utils.sh || {
     echo "ERROR: unable to source utils.sh!"
@@ -86,6 +83,7 @@ dos2unix perf_utils.sh
     exit 2
 }
 
+dos2unix perf_utils.sh
 # Source perf_utils.sh
 . perf_utils.sh || {
     echo "ERROR: unable to source perf_utils.sh!"
@@ -95,15 +93,6 @@ dos2unix perf_utils.sh
 
 # Source constants file and initialize most common variables
 UtilsInit
-
-#Apling performance parameters
-setup_sysctl
-if [ $? -ne 0 ]; then
-    echo "Unable to add performance parameters."
-    LogMsg "Unable to add performance parameters."
-    UpdateTestState $ICA_TESTABORTED
-fi
-
 # In case of ERROR
 case $? in
     0)
@@ -139,18 +128,6 @@ case $? in
         ;;
 esac
 
-#Create log folder
-if [ -d  $HOME/$log_folder ]; then
-    echo "File $log_folder exists: will be deleted."
-    LogMsg "File $log_folder exists." >> ~/summary.log
-    rm -rf $HOME/$log_folder
-fi
-
-mkdir $HOME/$log_folder
-eth_log="$HOME/$log_folder/eth_report.log"
-echo "#test_connections    throughput_gbps    average_packet_size" > $eth_log 
-
-#
 # Make sure the required test parameters are defined
 if [ "${STATIC_IP:="UNDEFINED"}" = "UNDEFINED" ]; then
     msg="ERROR: the STATIC_IP test parameter is missing"
@@ -190,12 +167,9 @@ if [ "${SERVER_OS_USERNAME:="UNDEFINED"}" = "UNDEFINED" ]; then
     echo "${msg}" >> ~/summary.log
 fi
 
-declare __iface_ignore
-
 # Parameter provided in constants file
-#   ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
-#   it is not touched during this test (no dhcp or static ip assigned to it)
-
+#  ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
+#  it is not touched during this test (no dhcp or static ip assigned to it)
 if [ "${ipv4:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
     LogMsg "$msg"
@@ -211,11 +185,12 @@ else
         SetTestStateAborted
         exit 10
     fi
-
-    # Get the interface associated with the given ipv4
-    __iface_ignore=$(ip -o addr show | grep "$ipv4" | cut -d ' ' -f2)
 fi
 
+#Get test synthetic interface
+declare __iface_ignore
+# Get the interface associated with the given ipv4
+__iface_ignore=$(ip -o addr show | grep "$ipv4" | cut -d ' ' -f2)
 # Retrieve synthetic network interfaces
 GetSynthNetInterfaces
 if [ 0 -ne $? ]; then
@@ -225,7 +200,6 @@ if [ 0 -ne $? ]; then
     SetTestStateFailed
     exit 10
 fi
-
 # Remove interface if present
 SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__iface_ignore/})
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
@@ -235,9 +209,21 @@ if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
     SetTestStateAborted
     exit 10
 fi
+# SRIOV setup (transparent VF)
+if [ "${SRIOV}" = "yes" ]; then
+    # Check if the SR-IOV driver is in use used from perf_utils
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    __vf_ignore='enP2p0s2'
+    SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__vf_ignore/})
+fi
 
 LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
-
 # Test interfaces
 declare -i __iterator
 for __iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
@@ -252,6 +238,47 @@ for __iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
 done
 LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
 
+# Config static IP - using bondvf.sh
+if [ "${SRIOV}" = "bond" ]; then
+    # Check if the SR-IOV driver is in use
+    VerifyVF
+    if [ $? -ne 0 ]; then
+        msg="ERROR: VF is not loaded! Make sure you are using compatible hardware"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+    # Run bondvf.sh platform specific script
+    RunBondingScript
+    bondCount=$?
+    if [ $bondCount -eq 99 ]; then
+        msg="ERROR: Running the bonding script failed. Please double check if it is present on the system"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    else
+        LogMsg "BondCount returned by SR-IOV_Utils: $bondCount"
+    fi
+    # Set static IP to the bond
+    perf_ConfigureBond ${STATIC_IP}
+    if [ $? -ne 0 ]; then
+        msg="ERROR: Could not set a static IP to the bond!"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+    fi
+fi
+
+# Config static IP - with transparent-vf it is not necessary to run bondvf.sh
+if [[ "${SRIOV}" = "yes" ]] || [[ "${SRIOV}" = "no" ]]; then
+    #Config static ip on the client side.
+    config_staticip ${STATIC_IP} ${NETMASK}
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Function config_staticip failed."
+        LogMsg "ERROR: Function config_staticip failed."
+        UpdateTestState $ICA_TESTABORTED
+    fi
+fi
 echo "Ntttcp client test interface ip           = ${STATIC_IP}"
 echo "Ntttcp server ip           = ${STATIC_IP2}"
 echo "Ntttcp server test interface ip        = ${SERVER_IP}"
@@ -261,7 +288,14 @@ echo "Max threads       = ${MAX_THREADS}"
 echo "user name on server       = ${SERVER_OS_USERNAME}"
 echo "Test Interface       = ${ETH_NAME}"
 
-#
+#Apling performance parameters
+setup_sysctl "$(declare -p sysctl_tcp_params)"
+if [ $? -ne 0 ]; then
+    echo "Unable to add performance parameters."
+    LogMsg "Unable to add performance parameters."
+    UpdateTestState $ICA_TESTABORTED
+fi
+
 # Check for internet protocol version
 CheckIPV6 "$STATIC_IP"
 if [[ $? -eq 0 ]]; then
@@ -279,11 +313,21 @@ else
     ipVersion=
 fi
 
-#
-#Check distro
-#
+# Flushing firewall rules
 iptables -F
+if [ $? -ne 0 ]; then
+    msg="ERROR: Failed to flush iptables rules. Continuing"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+fi
 ip6tables -F
+if [ $? -ne 0 ]; then
+    msg="ERROR: Failed to flush ip6tables rules. Continuing"
+    LogMsg "${msg}"
+    echo "${msg}" >> ~/summary.log
+fi
+
+#Check distro
 GetDistro
 case "$DISTRO" in
 debian*|ubuntu*)
@@ -295,25 +339,21 @@ debian*|ubuntu*)
         UpdateTestState $ICA_TESTFAILED
         exit 1
     fi
-    LogMsg "Installing sar on Ubuntu"
-    apt-get install sysstat -y
+    LogMsg "Installing dependency tools on Ubuntu"
+    apt-get update && apt-get install build-essential git sysstat dstat -y
     if [ $? -ne 0 ]; then
-        msg="ERROR: sysstat failed to install"
+        msg="ERROR: dependencies failed to install"
         LogMsg "${msg}"
         echo "${msg}" >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
-        exit 85
-    fi
-    apt-get install build-essential git -y
-    if [ $? -ne 0 ]; then
-        msg="ERROR: Build essential failed to install"
-        LogMsg "${msg}"
-        echo "${msg}" >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
-        exit 85
     fi
     ;;
 redhat_5|redhat_6|centos_6|centos_5)
+    yum install -y bc sysstat dstat
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check irqbalance status on RHEL 5/6.x."
     service irqbalance status
     if [ $? -eq 3 ]; then
@@ -326,6 +366,7 @@ redhat_5|redhat_6|centos_6|centos_5)
             UpdateTestState $ICA_TESTFAILED
             exit 1
         fi
+        service irqbalance status
     fi
     disable_firewall
     if [[ $? -ne 0 ]]; then
@@ -337,6 +378,12 @@ redhat_5|redhat_6|centos_6|centos_5)
     fi
     ;;
 redhat_7|centos_7)
+    yum install -y bc sysstat dstat
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check irqbalance status on RHEL 7.xx."
     systemctl status irqbalance
     if [ $? -eq 3 ]; then
@@ -349,6 +396,7 @@ redhat_7|centos_7)
             UpdateTestState $ICA_TESTFAILED
             exit 1
         fi
+        systemctl status irqbalance
     fi
     LogMsg "Check firewalld status on RHEL 7.xx."
     systemctl status firewalld
@@ -371,15 +419,15 @@ redhat_7|centos_7)
     fi
     ;;
 suse_12)
+    zypper -n in dstat sysstat gcc
+    if [ $? -ne 0 ]; then
+        msg="ERROR: dependencies failed to install"
+        LogMsg "${msg}"
+        echo "${msg}" >> ~/summary.log
+    fi
     LogMsg "Check iptables status on SLES 12"
     service SuSEfirewall2 status
     if [ $? -ne 3 ]; then
-        iptables -F;
-        if [ $? -ne 0 ]; then
-            msg="ERROR: Failed to flush iptables rules. Continuing"
-            LogMsg "${msg}"
-            echo "${msg}" >> ~/summary.log
-        fi
         service SuSEfirewall2 stop
         if [ $? -ne 0 ]; then
             msg="ERROR: Failed to stop iptables"
@@ -399,7 +447,7 @@ suse_12)
 esac
 
 LogMsg "Enlarging the system limit"
-ulimit -n 30480
+ulimit -n 20480
 if [ $? -ne 0 ]; then
     LogMsg "ERROR: Unable to enlarged system limit"
     UpdateTestState $ICA_TESTABORTED
@@ -420,17 +468,11 @@ if [ $? -ne 0 ]; then
     LogMsg "ERROR: Unable to compile ntttcp-for-linux."
     UpdateTestState $ICA_TESTABORTED
 fi
+
 dos2unix ~/*.sh
 chmod 755 ~/*.sh
-#Config static ip on the client side.
-config_staticip ${STATIC_IP} ${NETMASK}
-if [ $? -ne 0 ]; then
-    echo "ERROR: Function config_staticip failed."
-    LogMsg "ERROR: Function config_staticip failed."
-    UpdateTestState $ICA_TESTABORTED
-fi
 LogMsg "Copy files to server: ${STATIC_IP2}"
-scp -i $HOME/.ssh/$SSH_PRIVATE_KEY -v -o StrictHostKeyChecking=no ~/perf_ntttcp_server.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ~/perf_ntttcp_server.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
 if [ $? -ne 0 ]; then
     msg="ERROR: Unable to copy test scripts to target server machine: ${STATIC_IP2}. scp command failed."
     LogMsg "${msg}"
@@ -438,14 +480,13 @@ if [ $? -ne 0 ]; then
     UpdateTestState $ICA_TESTFAILED
     exit 130
 fi
-scp -i $HOME/.ssh/$SSH_PRIVATE_KEY -v -o StrictHostKeyChecking=no ~/constants.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
-scp -i $HOME/.ssh/$SSH_PRIVATE_KEY -v -o StrictHostKeyChecking=no ~/utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
-scp -i $HOME/.ssh/$SSH_PRIVATE_KEY -v -o StrictHostKeyChecking=no ~/perf_utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ~/constants.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ~/utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
+scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ~/perf_utils.sh ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:
 
 # Start ntttcp in server mode on the Target server side
-#
 LogMsg "Starting ntttcp in server mode on ${STATIC_IP2}"
-ssh -i $HOME/.ssh/$SSH_PRIVATE_KEY -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "echo '~/perf_ntttcp_server.sh > ntttcp_ServerSideScript.log' | at now"
+ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "~/perf_ntttcp_server.sh > ntttcp_ServerSideScript.log"
 if [ $? -ne 0 ]; then
     msg="ERROR: Unable to start ntttcp server scripts on the target server machine"
     LogMsg "${msg}"
@@ -454,47 +495,25 @@ if [ $? -ne 0 ]; then
     exit 130
 fi
 
-# Wait for server to be ready
-#
-wait_for_server=600
-server_state_file=serverstate.txt
-while [ $wait_for_server -gt 0 ]; do
-    # Try to copy and understand server state
-    scp -i $HOME/.ssh/$SSH_PRIVATE_KEY -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:~/state.txt ~/${server_state_file}
-
-    if [ -f ~/${server_state_file} ];
-    then
-        server_state=$(head -n 1 ~/${server_state_file})
-        echo $server_state
-        rm -rf ~/${server_state_file}
-        if [ "$server_state" == "NtttcpRunning" ];
-        then
-            break
-        fi
-    fi
-    sleep 5
-    wait_for_server=$(($wait_for_server - 5))
-done
-
-if [ $wait_for_server -eq 0 ] ;
-then
-    msg="ERROR: ntttcp server script has been triggered but are not in running state within ${wait_for_server} seconds."
-    LogMsg "${msg}"
-    echo "${msg}" >> ~/summary.log
-    UpdateTestState $ICA_TESTFAILED
-    exit 135
-else
-    LogMsg "Ntttcp server are ready."
+#Create log folder
+if [ -d  $HOME/$log_folder ]; then
+    echo "File $log_folder exists: will be deleted."
+    LogMsg "File $log_folder exists." >> ~/summary.log
+    rm -rf $HOME/$log_folder
 fi
 
+mkdir $HOME/$log_folder
+eth_log="$HOME/$log_folder/eth_report.log"
+echo "#test_connections    throughput_gbps    average_packet_size" > $eth_log
+
+sleep 10
 #Starting test
 previous_tx_bytes=$(get_tx_bytes $ETH_NAME)
 previous_tx_pkts=$(get_tx_pkts $ETH_NAME)
-ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${SERVER_IP} "mkdir /root/$log_folder"
-i=0
-while [ "x${TEST_THREADS[$i]}" != "x" ]
+port_change=false
+port=
+for current_test_threads in "${TEST_THREADS[@]}"
 do
-    current_test_threads=${TEST_THREADS[$i]}
     if [ $current_test_threads -lt $MAX_THREADS ]
     then
         num_threads_P=$current_test_threads
@@ -503,20 +522,32 @@ do
         num_threads_P=$MAX_THREADS
         num_threads_n=$(($current_test_threads / $num_threads_P))
     fi
-
+    if ${port_change}
+    then
+        port=20000
+        port_change=false
+    else
+        port=40000
+        port_change=true
+    fi
     echo "======================================"
     echo "Running Test: $num_threads_P X $num_threads_n"
     echo "======================================"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "ulimit -n 20480 && ntttcp -r${SERVER_IP} -P $num_threads_P -e ${ipVersion} > $HOME/$log_folder/ntttcp-receiver-p${num_threads_P}X${num_threads_n}.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "lagscope -r${SERVER_IP} ${ipVersion}"
+    sleep 1
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "for ((i=1;i<=$TEST_DURATION;i++)); do ss -ta | grep ESTA | grep -v ssh | wc -l >> $HOME/$log_folder/tcp-connections-p${current_test_threads}.log; sleep 1; done"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "sar -n DEV 1 ${TEST_DURATION} > $HOME/$log_folder/sar-receiver-p${current_test_threads}.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "dstat -dam 1 ${TEST_DURATION} > $HOME/$log_folder/dstat-receiver-p${current_test_threads}.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -f -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "mpstat -P ALL 1 ${TEST_DURATION} > $HOME/$log_folder/mpstat-receiver-p${current_test_threads}.log"
 
-    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${SERVER_IP} "pkill -f ntttcp"
-    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${SERVER_IP} "ntttcp -r${SERVER_IP} ${ipVersion} -P $num_threads_P -t ${TEST_DURATION} -e > ~/$log_folder/ntttcp-receiver-p${num_threads_P}X${num_threads_n}.log" &
+    sar -n DEV 1 ${TEST_DURATION} > "$HOME/$log_folder/sar-sender-p${current_test_threads}.log" &
+    dstat -dam 1 ${TEST_DURATION} > "$HOME/$log_folder/dstat-sender-p${current_test_threads}.log" &
+    mpstat -P ALL 1 ${TEST_DURATION} > "$HOME/$log_folder/mpstat-sender-p${current_test_threads}.log" &
 
-    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${SERVER_IP} "pkill -f lagscope"
-    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${SERVER_IP} "lagscope -r${SERVER_IP} ${ipVersion}" &
-
-    sleep 2
-    lagscope -s${SERVER_IP} -t ${TEST_DURATION} -V ${ipVersion} > $HOME/$log_folder/lagscope-ntttcp-p${num_threads_P}X${num_threads_n}.log &
-    ntttcp -s${SERVER_IP} ${ipVersion} -P $num_threads_P -n $num_threads_n -t ${TEST_DURATION}  > $HOME/$log_folder/ntttcp-sender-p${num_threads_P}X${num_threads_n}.log
+    lagscope -s${SERVER_IP} -t ${TEST_DURATION} -V ${ipVersion} > "./$log_folder/lagscope-ntttcp-p${num_threads_P}X${num_threads_n}.log" &
+    ntttcp -s${SERVER_IP} -P $num_threads_P -n $num_threads_n -t ${TEST_DURATION} ${ipVersion} -f${port} > "./$log_folder/ntttcp-sender-p${num_threads_P}X${num_threads_n}.log"
+    sts=$?
 
     current_tx_bytes=$(get_tx_bytes $ETH_NAME)
     current_tx_pkts=$(get_tx_pkts $ETH_NAME)
@@ -531,24 +562,37 @@ do
     echo "average packet size: $avg_pkt_size"
     printf "%4s  %8.2f  %8.2f\n" ${current_test_threads} $Throughput $avg_pkt_size >> $eth_log
 
-    echo "current test finished. wait for next one... "
-    i=$(($i + 1))
-    sleep 5
+    echo "current test finished. wait 10 seconds for next one... "
+    sleep 10
+    pkill -x ntttcp
+    pkill -x lagscope
+    pkill -f ESTA
+    pkill -x sar
+    pkill -x dstat
+    pkill -x mpstat
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x ntttcp"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x lagscope"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x sar"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x dstat"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "pkill -x mpstat"
 done
-sts=$?
+
 if [ $sts -eq 0 ]; then
+    ethtool -S eth1 > $HOME/$log_folder/sender-ethtool-eth1.log
+    ethtool -S enP2p0s2 > $HOME/$log_folder/sender-ethtool-enP2p0s2.log
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "ethtool -S eth1 > $HOME/$log_folder/receiver-ethtool-eth1.log"
+    ssh -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2} "ethtool -S enP2p0s2 > $HOME/$log_folder/receiver-ethtool-enP2p0s2.log"
     LogMsg "Ntttcp succeeded with all connections."
     echo "Ntttcp succeeded with all connections." >> ~/summary.log
     cd $HOME
-    scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -v -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@${STATIC_IP2}:/root/$log_folder/* /root/$log_folder
+    scp -i $HOME/.ssh/${SSH_PRIVATE_KEY} -o StrictHostKeyChecking=no ${SERVER_OS_USERNAME}@[${STATIC_IP2}]:/root/$log_folder/* /root/$log_folder
     if [ $? -ne 0 ]; then
-        echo "ERROR: Unable to trnsfer server side logs."
+        echo "ERROR: Unable to transfer server side logs."
         UpdateTestState $ICA_TESTFAILED
     fi
     zip -r $log_folder.zip $log_folder/*
-    sleep 20
     UpdateTestState $ICA_TESTCOMPLETED
-else 
+else
     LogMsg "Something gone wrong. Please re-run.."
     echo "Something gone wrong. Please re-run.." >> ~/summary.log
     UpdateTestState $ICA_TESTFAILED

--- a/WS2012R2/lisa/setupscripts/perf_SRIOV_enable.ps1
+++ b/WS2012R2/lisa/setupscripts/perf_SRIOV_enable.ps1
@@ -1,0 +1,208 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Enable SR-IOV on VM
+
+.Description
+    This is a setupscript that enables SR-IOV on VM
+    Steps:
+    1. Add new NICs to VMs
+    2. Configure/enable SR-IOV on VMs settings via cmdlet Set-VMNetworkAdapter
+    3. Run bondvf.sh on VM2 No more
+    4. Set up SR-IOV on VM2
+    Optional: Set up an internal network on VM2
+
+.Parameter vmName
+    Name of the test VM.
+
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+
+.Parameter testParams
+    Semicolon separated list of test parameters.
+    This setup script does not use any setup scripts.
+
+.Example
+    <test>
+        <testName>VerifyVF_basic</testName>
+        <testScript>SR-IOV_VerifyVF_basic.sh</testScript>
+        <files>remote-scripts\ica\SR-IOV_VerifyVF_basic.sh,remote-scripts/ica/utils.sh</files>
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupscripts\SR-IOV_enable.ps1</file>
+        </setupScript>
+        <noReboot>False</noReboot>
+        <testParams>
+            <param>NETWORK_NAME=SRIOV</param>
+            <param>TC_COVERED=??</param>
+            <param>BOND_IP1=10.11.12.31</param>
+            <param>BOND_IP2=10.11.12.32</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>REMOTE_USER=root</param>
+            <param>Clean_Dependency=yes</param>
+        </testParams>
+        <timeout>600</timeout>
+    </test>
+
+#>
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
+#############################################################
+#
+# Main script body
+#
+#############################################################
+$retVal = $False
+
+# Write out test Params
+$testParams
+
+if ($hvServer -eq $null) {
+    "ERROR: hvServer is null"
+    return $False
+}
+
+if ($testParams -eq $null) {
+    "ERROR: testParams is null"
+    return $False
+}
+
+#change working directory to root dir
+$testParams -match "RootDir=([^;]+)"
+if (-not $?) {
+    "Mandatory param RootDir=Path; not found!"
+    return $false
+}
+$rootDir = $Matches[1]
+
+if (Test-Path $rootDir) {
+    Set-Location -Path $rootDir
+    if (-not $?) {
+        "ERROR: Could not change directory to $rootDir !"
+        return $false
+    }
+    "Changed working directory to $rootDir"
+}
+else {
+    "ERROR: RootDir = $rootDir is not a valid path"
+    return $false
+}
+
+# Source TCUitls.ps1 for getipv4 and other functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+    . .\setupScripts\TCUtils.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Source NET_UTILS.ps1 for network functions
+if (Test-Path ".\setupScripts\NET_UTILS.ps1") {
+    . .\setupScripts\NET_UTILS.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $false
+}
+
+$networkName = $null
+$remoteServer = $null
+$nicIterator = 0
+$vmBondIP = @()
+$bondIterator = 0
+$nicValues = @()
+$leaveTrail = "no"
+$params = $testParams.Split(';')
+foreach ($p in $params)
+{
+    $fields = $p.Split("=")
+
+    switch ($fields[0].Trim())
+    {
+    "VM2NAME" { $vm2Name = $fields[1].Trim() }
+    "SSH_PRIVATE_KEY"  { $sshKey  = $fields[1].Trim() }
+    "ipv4"    { $ipv4    = $fields[1].Trim() }
+    "BOND_IP1" {
+        $vmBondIP1 = $fields[1].Trim()
+        $vmBondIP += ($vmBondIP1)
+        $bondIterator++ }
+    "BOND_IP2" {
+        $vmBondIP2 = $fields[1].Trim()
+        $vmBondIP += ($vmBondIP2)
+        $bondIterator++ }
+    "NETMASK" { $netmask = $fields[1].Trim() }
+    "VM2SERVER" { $remoteServer = $fields[1].Trim()}
+    "NETWORK_NAME" { $networkName = $fields[1].Trim() }
+    default   {}  # unknown param - just ignore it
+    }
+}
+
+if (-not $vm2Name) {
+    "ERROR: test parameter vm2Name was not specified"
+    return $False
+}
+
+# Make sure vm2 is not the same as vm1
+if ("$vm2Name" -like "$vmName") {
+    "ERROR: vm2 must be different from the test VM."
+    return $false
+}
+
+if (-not $networkName) {
+    "ERROR: test parameter NETWORK_NAME was not specified"
+    return $False
+}
+
+# Check if VM2 is on another host
+# If VM2 is on the same host, $remoteServer will be same as $hvServer
+if (-not $remoteServer) {
+    $remoteServer = $hvServer
+}
+
+#
+# Attach SR-IOV to both VMs and start VM2
+#
+# Verify VM2 exists
+$vm2 = Get-VM -Name $vm2Name -ComputerName $remoteServer -ERRORAction SilentlyContinue
+if (-not $vm2) {
+    "ERROR: VM ${vm2Name} does not exist"
+    return $False
+}
+
+# Enable SR-IOV
+Get-VMNetworkAdapter -VMName $vm2Name -ComputerName $remoteServer | Where-Object {($_).SwitchName -eq $networkName} | Set-VMNetworkAdapter -IovWeight 1
+if ($? -eq "True") {
+    $retVal = $True
+}
+else {
+    "ERROR: Failed to enable SR-IOV on $vm2Name!"
+}
+Get-VMNetworkAdapter -VMName $vmName -ComputerName $hvServer | Where-Object {($_).SwitchName -eq $networkName} | Set-VMNetworkAdapter -IovWeight 1
+if ($? -eq "True") {
+    $retVal = $True
+}
+else {
+    "ERROR: Failed to enable SR-IOV on $vmName!"
+}
+
+return $retVal

--- a/WS2012R2/lisa/tools/middleware_bench/AWS.py
+++ b/WS2012R2/lisa/tools/middleware_bench/AWS.py
@@ -302,7 +302,7 @@ class AWSConnector:
                 time.sleep(5)
                 timeout += 5
             # artificial wait for ssh service up status
-            time.sleep(30)
+            time.sleep(60)
             open(host_key_file, 'w').close()
             client = sshclient_from_instance(instance, os.path.join(self.localpath,
                                                                     self.key_name + '.pem'),

--- a/WS2012R2/lisa/tools/middleware_bench/connector.py
+++ b/WS2012R2/lisa/tools/middleware_bench/connector.py
@@ -33,8 +33,7 @@ from cmdshell import SSHClient
 from db_utils import upload_results
 from results_parser import OrionLogsReader, SysbenchLogsReader, MemcachedLogsReader,\
     RedisLogsReader, ApacheLogsReader, MariadbLogsReader, MongodbLogsReader, ZookeeperLogsReader,\
-    TerasortLogsReader, TCPLogsReader, LatencyLogsReader, StorageLogsReader,\
-    VariableTCPBufferLogsReader
+    TerasortLogsReader, TCPLogsReader, LatencyLogsReader, StorageLogsReader, SingleTCPLogsReader
 
 logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
                     datefmt='%y/%m/%d %H:%M:%S', level=logging.INFO)
@@ -1443,9 +1442,8 @@ def test_network_latency(provider, keyid, secret, token, imageid, subscription, 
                        host_type=utils.host_type(provider), instance_size=instancetype)
 
 
-def test_network_variable_tcp_buffer(provider, keyid, secret, token, imageid, subscription, tenant,
-                                     projectid, instancetype, user, localpath, region, zone, sriov,
-                                     kernel):
+def test_network_single_tcp(provider, keyid, secret, token, imageid, subscription, tenant,
+                            projectid, instancetype, user, localpath, region, zone, sriov, kernel):
     """
     Run variable TCP buffer network profile for a single connection.
     :param provider Service provider to be used e.g. azure, aws, gce.
@@ -1488,7 +1486,7 @@ def test_network_variable_tcp_buffer(provider, keyid, secret, token, imageid, su
                                    '/tmp/run_network.sh')
             ssh_client[1].run('chmod +x /tmp/run_network.sh')
             ssh_client[1].run("sed -i 's/\r//' /tmp/run_network.sh")
-            cmd = '/tmp/run_network.sh {} {} {}'.format(vm_ips[2], user, 'variable_tcp_buffer')
+            cmd = '/tmp/run_network.sh {} {} {}'.format(vm_ips[2], user, 'single_tcp')
             log.info('Running command {}'.format(cmd))
             ssh_client[1].run(cmd)
             results_path = os.path.join(localpath, 'network{}_{}.zip'.format(str(time.time()),
@@ -1502,9 +1500,9 @@ def test_network_variable_tcp_buffer(provider, keyid, secret, token, imageid, su
             connector.teardown()
     if results_path:
         upload_results(localpath=localpath,
-                       table_name='Perf_{}_Network_Variable_TCP_Buffer'.format(provider),
-                       results_path=results_path, parser=VariableTCPBufferLogsReader,
-                       test_case_name='{}_Network_Variable_TCP_Buffer_perf_tuned'.format(provider),
+                       table_name='Perf_{}_Network_Single_TCP'.format(provider),
+                       results_path=results_path, parser=SingleTCPLogsReader,
+                       test_case_name='{}_Network_Single_TCP_perf_tuned'.format(provider),
                        provider=provider, region=region, data_path=utils.data_path(sriov),
                        host_type=utils.host_type(provider), instance_size=instancetype)
 

--- a/WS2012R2/lisa/tools/middleware_bench/connector.py
+++ b/WS2012R2/lisa/tools/middleware_bench/connector.py
@@ -33,7 +33,8 @@ from cmdshell import SSHClient
 from db_utils import upload_results
 from results_parser import OrionLogsReader, SysbenchLogsReader, MemcachedLogsReader,\
     RedisLogsReader, ApacheLogsReader, MariadbLogsReader, MongodbLogsReader, ZookeeperLogsReader,\
-    TerasortLogsReader, TCPLogsReader, LatencyLogsReader, StorageLogsReader
+    TerasortLogsReader, TCPLogsReader, LatencyLogsReader, StorageLogsReader,\
+    VariableTCPBufferLogsReader
 
 logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
                     datefmt='%y/%m/%d %H:%M:%S', level=logging.INFO)
@@ -1440,3 +1441,129 @@ def test_network_latency(provider, keyid, secret, token, imageid, subscription, 
                        test_case_name='{}_Network_Latency_perf_tuned'.format(provider),
                        provider=provider, region=region, data_path=utils.data_path(sriov),
                        host_type=utils.host_type(provider), instance_size=instancetype)
+
+
+def test_network_variable_tcp_buffer(provider, keyid, secret, token, imageid, subscription, tenant,
+                                     projectid, instancetype, user, localpath, region, zone, sriov,
+                                     kernel):
+    """
+    Run variable TCP buffer network profile for a single connection.
+    :param provider Service provider to be used e.g. azure, aws, gce.
+    :param keyid: user key for executing remote connection
+    :param secret: user secret for executing remote connection
+    :param token: GCE refresh token obtained with gcloud sdk
+    :param subscription: Azure specific subscription id
+    :param tenant: Azure specific tenant id
+    :param projectid: GCE specific project id
+    :param imageid: AWS OS AMI image id or
+                    Azure image references offer and sku: e.g. 'UbuntuServer#16.04.0-LTS'.
+    :param instancetype: AWS instance resource type e.g 'd2.4xlarge' or
+                        Azure hardware profile vm size e.g. 'Standard_DS14_v2'.
+    :param user: remote ssh user for the instance
+    :param localpath: localpath where the logs should be downloaded, and the
+                        default path for other necessary tools
+    :param region: EC2 region to connect to
+    :param zone: EC2 zone where other resources should be available
+    :param sriov: Enable or disable SR-IOV
+    :param kernel: custom kernel name provided in localpath
+    """
+    connector, vm_ips, device, ssh_client = setup_env(provider=provider, vm_count=2,
+                                                      test_type=None, disk_size=None, raid=False,
+                                                      keyid=keyid, secret=secret, token=token,
+                                                      subscriptionid=subscription, tenantid=tenant,
+                                                      projectid=projectid, imageid=imageid,
+                                                      instancetype=instancetype, user=user,
+                                                      localpath=localpath, region=region,
+                                                      zone=zone, sriov=sriov, kernel=kernel)
+    results_path = None
+    try:
+        if all(client for client in ssh_client.values()):
+            # enable key auth between instances
+            ssh_client[1].put_file(os.path.join(localpath, connector.key_name + '.pem'),
+                                   '/home/{}/.ssh/id_rsa'.format(user))
+            ssh_client[1].run('chmod 0600 /home/{0}/.ssh/id_rsa'.format(user))
+
+            current_path = os.path.dirname(os.path.realpath(__file__))
+            ssh_client[1].put_file(os.path.join(current_path, 'tests', 'run_network.sh'),
+                                   '/tmp/run_network.sh')
+            ssh_client[1].run('chmod +x /tmp/run_network.sh')
+            ssh_client[1].run("sed -i 's/\r//' /tmp/run_network.sh")
+            cmd = '/tmp/run_network.sh {} {} {}'.format(vm_ips[2], user, 'variable_tcp_buffer')
+            log.info('Running command {}'.format(cmd))
+            ssh_client[1].run(cmd)
+            results_path = os.path.join(localpath, 'network{}_{}.zip'.format(str(time.time()),
+                                                                             instancetype))
+            ssh_client[1].get_file('/tmp/network.zip', results_path)
+    except Exception as e:
+        log.error(e)
+        raise
+    finally:
+        if connector:
+            connector.teardown()
+    if results_path:
+        upload_results(localpath=localpath,
+                       table_name='Perf_{}_Network_Variable_TCP_Buffer'.format(provider),
+                       results_path=results_path, parser=VariableTCPBufferLogsReader,
+                       test_case_name='{}_Network_Variable_TCP_Buffer_perf_tuned'.format(provider),
+                       provider=provider, region=region, data_path=utils.data_path(sriov),
+                       host_type=utils.host_type(provider), instance_size=instancetype)
+
+
+def test_sql_server(provider, keyid, secret, token, imageid, subscription, tenant, projectid,
+                    instancetype, user, localpath, region, zone, sriov, kernel):
+    """
+    Run FIO storage profile.
+    :param provider Service provider to be used e.g. azure, aws, gce.
+    :param keyid: user key for executing remote connection
+    :param secret: user secret for executing remote connection
+    :param token: GCE refresh token obtained with gcloud sdk
+    :param subscription: Azure specific subscription id
+    :param tenant: Azure specific tenant id
+    :param projectid: GCE specific project id
+    :param imageid: AWS OS AMI image id or
+                    Azure image references offer and sku: e.g. 'UbuntuServer#16.04.0-LTS'.
+    :param instancetype: AWS instance resource type e.g 'd2.4xlarge' or
+                        Azure hardware profile vm size e.g. 'Standard_DS14_v2'.
+    :param user: remote ssh user for the instance
+    :param localpath: localpath where the logs should be downloaded, and the
+                        default path for other necessary tools
+    :param region: EC2 region to connect to
+    :param zone: EC2 zone where other resources should be available
+    :param sriov: Enable or disable SR-IOV
+    :param kernel: custom kernel name provided in localpath
+    """
+    disk_size = 0
+    if provider == constants.AWS:
+        disk_size = 100
+    elif provider == constants.AZURE:
+        disk_size = 513
+    connector, vm_ips, device, ssh_client = setup_env(provider=provider, vm_count=1,
+                                                      test_type=constants.VM_DISK,
+                                                      disk_size=disk_size, raid=False, keyid=keyid,
+                                                      secret=secret, token=token,
+                                                      subscriptionid=subscription, tenantid=tenant,
+                                                      projectid=projectid, imageid=imageid,
+                                                      instancetype=instancetype, user=user,
+                                                      localpath=localpath, region=region,
+                                                      zone=zone, sriov=sriov, kernel=kernel)
+
+    try:
+        if all(client for client in ssh_client.values()):
+            current_path = os.path.dirname(os.path.realpath(__file__))
+            ssh_client[1].put_file(os.path.join(current_path, 'tests', 'run_storage.sh'),
+                                   '/tmp/run_storage.sh')
+            # ssh_client[1].run('chmod +x /tmp/run_storage.sh')
+            # ssh_client[1].run("sed -i 's/\r//' /tmp/run_storage.sh")
+            # cmd = '/tmp/run_storage.sh {}'.format(device)
+            # log.info('Running command {}'.format(cmd))
+            # ssh_client[1].run(cmd)
+            # ssh_client[1].get_file('/tmp/storage.zip',
+            #                        os.path.join(localpath,
+            #                                     'storage{}_{}.zip'.format(str(time.time()),
+            #                                                               instancetype)))
+    except Exception as e:
+        log.error(e)
+        raise
+    # finally:
+    #     if connector:
+    #         connector.teardown()

--- a/WS2012R2/lisa/tools/middleware_bench/db_utils.py
+++ b/WS2012R2/lisa/tools/middleware_bench/db_utils.py
@@ -33,7 +33,7 @@ COLUMNS = [{'name': 'TestCaseName', 'type': NVARCHAR(50)},
            {'name': 'ClusterSetup', 'type': NVARCHAR(25)},
            {'name': 'HadoopVersion', 'type': NVARCHAR(12)},
            {'name': 'Threads', 'type': DECIMAL(4, 0)},
-           {'name': 'BufferSize', 'type': DECIMAL(5, 0)},
+           {'name': 'BufferSize_Bytes', 'type': DECIMAL(5, 0)},
            {'name': 'TestConnections', 'type': DECIMAL(4, 0)},
            {'name': 'NumberOfConnections', 'type': INT},
            {'name': 'TestPipelines', 'type': DECIMAL(4, 0)},
@@ -147,7 +147,7 @@ def upload_results(localpath=None, table_name=None, results_path=None, parser=No
               *(Column(column['name'], column['type']) for column in table_columns))
 
     # When creating db is also necessary
-    metadata.create_all(checkfirst=True)
+    # metadata.create_all(checkfirst=True)
 
     mapper(TestResults, t)
     session = create_session(bind=e, autocommit=False, autoflush=True)

--- a/WS2012R2/lisa/tools/middleware_bench/db_utils.py
+++ b/WS2012R2/lisa/tools/middleware_bench/db_utils.py
@@ -33,6 +33,7 @@ COLUMNS = [{'name': 'TestCaseName', 'type': NVARCHAR(50)},
            {'name': 'ClusterSetup', 'type': NVARCHAR(25)},
            {'name': 'HadoopVersion', 'type': NVARCHAR(12)},
            {'name': 'Threads', 'type': DECIMAL(4, 0)},
+           {'name': 'BufferSize', 'type': DECIMAL(5, 0)},
            {'name': 'TestConnections', 'type': DECIMAL(4, 0)},
            {'name': 'NumberOfConnections', 'type': INT},
            {'name': 'TestPipelines', 'type': DECIMAL(4, 0)},
@@ -96,6 +97,10 @@ COLUMNS = [{'name': 'TestCaseName', 'type': NVARCHAR(50)},
            {'name': 'MinLatency_us', 'type': DECIMAL(9, 3)},
            {'name': 'Latency95Percentile_us', 'type': DECIMAL(9, 3)},
            {'name': 'Latency99Percentile_us', 'type': DECIMAL(9, 3)},
+           {'name': 'RxThroughput_Gbps', 'type': DECIMAL(5, 3)},
+           {'name': 'TxThroughput_Gbps', 'type': DECIMAL(5, 3)},
+           {'name': 'RetransmittedSegments', 'type': DECIMAL(6, 0)},
+           {'name': 'CongestionWindowSize_KB', 'type': DECIMAL(4, 0)},
            {'name': 'seq_read_iops', 'type': DECIMAL(8, 1)},
            {'name': 'seq_read_lat_usec', 'type': DECIMAL(10, 2)},
            {'name': 'rand_read_iops', 'type': DECIMAL(8, 1)},
@@ -142,7 +147,7 @@ def upload_results(localpath=None, table_name=None, results_path=None, parser=No
               *(Column(column['name'], column['type']) for column in table_columns))
 
     # When creating db is also necessary
-    # metadata.create_all(checkfirst=True)
+    metadata.create_all(checkfirst=True)
 
     mapper(TestResults, t)
     session = create_session(bind=e, autocommit=False, autoflush=True)

--- a/WS2012R2/lisa/tools/middleware_bench/results_parser.py
+++ b/WS2012R2/lisa/tools/middleware_bench/results_parser.py
@@ -1038,17 +1038,17 @@ class LatencyLogsReader(BaseLogsReader):
         return log_dict
 
 
-class VariableTCPBufferLogsReader(BaseLogsReader):
+class SingleTCPLogsReader(BaseLogsReader):
     """
     Subclass for parsing iperf 3 for variable TCP buffer log files e.g.
     lagscope.log
     """
     def __init__(self, log_path=None, test_case_name=None, data_path=None, provider=None,
                  region=None, host_type=None, instance_size=None):
-        super(VariableTCPBufferLogsReader, self).__init__(log_path)
+        super(SingleTCPLogsReader, self).__init__(log_path)
         self.headers = ['RxThroughput_Gbps', 'TxThroughput_Gbps', 'RetransmittedSegments',
                         'CongestionWindowSize_KB']
-        self.sorter = ['BufferSize']
+        self.sorter = ['BufferSize_Bytes']
         self.test_case_name = test_case_name
         self.data_path = data_path
         self.provider = provider
@@ -1071,7 +1071,9 @@ class VariableTCPBufferLogsReader(BaseLogsReader):
         log_dict['HostOS'] = self.host_type
         log_dict['HostType'] = self.provider
         log_dict['GuestSize'] = self.instance_size
-        log_dict['BufferSize'] = f_match.group(1).strip()
+        log_dict['BufferSize_Bytes'] = f_match.group(1).strip()
+        log_dict['IPVersion'] = 'IPv4'
+        log_dict['ProtocolType'] = 'TCP'
         log_dict['RxThroughput_Gbps'] = 0
         log_dict['TxThroughput_Gbps'] = 0
         log_dict['RetransmittedSegments'] = 0

--- a/WS2012R2/lisa/tools/middleware_bench/tests/run_network.sh
+++ b/WS2012R2/lisa/tools/middleware_bench/tests/run_network.sh
@@ -90,7 +90,7 @@ then
     else
         LogMsg "Unsupported distribution: ${distro}."
     fi
-elif [[ ${TEST_TYPE} == "variable_tcp_buffer" ]]
+elif [[ ${TEST_TYPE} == "single_tcp" ]]
 then
     TEST_BUFFERS=(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)
     if [[ ${distro} == *"Ubuntu"* ]]
@@ -213,7 +213,7 @@ function run_iperf_udp()
     fi
 }
 
-function run_variable_tcp_buffer()
+function run_single_tcp()
 {
     current_test_buffer=$1
     LogMsg "======================================"
@@ -243,11 +243,11 @@ then
     do
         run_iperf_udp ${thread}
     done
-elif [[ ${TEST_TYPE} == "variable_tcp_buffer" ]]
+elif [[ ${TEST_TYPE} == "single_tcp" ]]
 then
     for packet in "${TEST_BUFFERS[@]}"
     do
-        run_variable_tcp_buffer ${packet}
+        run_single_tcp ${packet}
     done
 else
     LogMsg "Unsupported test type: ${TEST_TYPE}."

--- a/WS2012R2/lisa/tools/middleware_bench/tests/run_network.sh
+++ b/WS2012R2/lisa/tools/middleware_bench/tests/run_network.sh
@@ -33,8 +33,7 @@ fi
 
 SERVER="$1"
 USER="$2"
-PROTO="$3"
-TEST_THREADS=
+TEST_TYPE="$3"
 
 if [ -e /tmp/summary.log ]; then
     rm -rf /tmp/summary.log
@@ -58,9 +57,9 @@ else
 fi
 sudo iptables -F >> ${LOG_FILE}
 ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo iptables -F" >> ${LOG_FILE}
-mkdir -p /tmp/network${PROTO}
+mkdir -p /tmp/network${TEST_TYPE}
 cd /tmp
-if [[ ${PROTO} == "TCP" ]]
+if [[ ${TEST_TYPE} == "TCP" ]]
 then
     TEST_THREADS=(1 2 4 8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240)
     cd /tmp; git clone https://github.com/Microsoft/ntttcp-for-linux
@@ -71,13 +70,13 @@ then
     cd /tmp/lagscope/src; sudo make && sudo make install
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "cd /tmp; git clone https://github.com/Microsoft/lagscope" >> ${LOG_FILE}
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "cd /tmp/lagscope/src; sudo make && sudo make install" >> ${LOG_FILE}
-elif [[ ${PROTO} == "latency" ]]
+elif [[ ${TEST_TYPE} == "latency" ]]
 then
     cd /tmp; git clone https://github.com/Microsoft/lagscope
     cd /tmp/lagscope/src; sudo make && sudo make install
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "cd /tmp; git clone https://github.com/Microsoft/lagscope" >> ${LOG_FILE}
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "cd /tmp/lagscope/src; sudo make && sudo make install" >> ${LOG_FILE}
-elif [[ ${PROTO} == "UDP" ]]
+elif [[ ${TEST_TYPE} == "UDP" ]]
 then
     TEST_THREADS=(1 2 4 8 16 32 64 128 256 512 1024)
     if [[ ${distro} == *"Ubuntu"* ]]
@@ -91,8 +90,22 @@ then
     else
         LogMsg "Unsupported distribution: ${distro}."
     fi
+elif [[ ${TEST_TYPE} == "variable_tcp_buffer" ]]
+then
+    TEST_BUFFERS=(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)
+    if [[ ${distro} == *"Ubuntu"* ]]
+    then
+        sudo apt-get -y install iperf3 >> ${LOG_FILE}
+        ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo apt-get -y install iperf3" >> ${LOG_FILE}
+    elif [[ ${distro} == *"Amazon"* ]]
+    then
+        cd /tmp; wget https://iperf.fr/download/fedora/iperf3-3.1.3-1.fc24.x86_64.rpm; sudo rpm -ivh iperf3-3.1.3-1.fc24.x86_64.rpm >> ${LOG_FILE}
+        ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "cd /tmp; wget https://iperf.fr/download/fedora/iperf3-3.1.3-1.fc24.x86_64.rpm; sudo rpm -ivh iperf3-3.1.3-1.fc24.x86_64.rpm" >> ${LOG_FILE}
+    else
+        LogMsg "Unsupported distribution: ${distro}."
+    fi
 else
-    LogMsg "Unsupported test type: ${PROTO}."
+    LogMsg "Unsupported test type: ${TEST_TYPE}."
 fi
 
 function get_tx_bytes(){
@@ -119,7 +132,7 @@ function get_tx_pkts(){
     echo ${Tx_pkts}
 }
 
-ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "mkdir /tmp/network${PROTO}"
+ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "mkdir /tmp/network${TEST_TYPE}"
 
 function run_lagscope()
 {
@@ -129,7 +142,7 @@ function run_lagscope()
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo pkill -f lagscope"
     ssh -f -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo lagscope -r${SERVER}"
     sleep 5
-    sudo lagscope -s${SERVER} -n1000000 -i0 -V > "/tmp/network${PROTO}/lagscope.log"
+    sudo lagscope -s${SERVER} -n1000000 -i0 -V > "/tmp/network${TEST_TYPE}/lagscope.log"
     sleep 5
     sudo pkill -f lagscope
 }
@@ -150,21 +163,21 @@ function run_ntttcp ()
     fi
     sudo pkill -f ntttcp
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo pkill -f ntttcp"
-    ssh -f -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo ntttcp -r${SERVER} -P $num_threads_P -t 60 -e > /tmp/network${PROTO}/${current_test_threads}_ntttcp-receiver.log"
+    ssh -f -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo ntttcp -r${SERVER} -P $num_threads_P -t 60 -e > /tmp/network${TEST_TYPE}/${current_test_threads}_ntttcp-receiver.log"
     sudo pkill -f lagscope
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo pkill -f lagscope"
     ssh -f -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo lagscope -r${SERVER}"
     sleep 5
     previous_tx_bytes=$(get_tx_bytes)
     previous_tx_pkts=$(get_tx_pkts)
-    sudo lagscope -s${SERVER} -t 60 -V 4 > "/tmp/network${PROTO}/${current_test_threads}_lagscope.log"
-    sudo ntttcp -s${SERVER} -P ${num_threads_P} -n ${num_threads_n} -t 60  > "/tmp/network${PROTO}/${current_test_threads}_ntttcp-sender.log"
+    sudo lagscope -s${SERVER} -t 60 -V 4 > "/tmp/network${TEST_TYPE}/${current_test_threads}_lagscope.log"
+    sudo ntttcp -s${SERVER} -P ${num_threads_P} -n ${num_threads_n} -t 60  > "/tmp/network${TEST_TYPE}/${current_test_threads}_ntttcp-sender.log"
     current_tx_bytes=$(get_tx_bytes)
     current_tx_pkts=$(get_tx_pkts)
     bytes_new=`(expr ${current_tx_bytes} - ${previous_tx_bytes})`
     pkts_new=`(expr ${current_tx_pkts} - ${previous_tx_pkts})`
     avg_pkt_size=$(echo "scale=2;${bytes_new}/${pkts_new}/1024" | bc)
-    echo "Average Package Size: ${avg_pkt_size}" >> /tmp/network${PROTO}/${current_test_threads}_ntttcp-sender.log
+    echo "Average Package Size: ${avg_pkt_size}" >> /tmp/network${TEST_TYPE}/${current_test_threads}_ntttcp-sender.log
     sleep 10
     sudo pkill -f ntttcp
     sudo pkill -f lagscope
@@ -172,7 +185,7 @@ function run_ntttcp ()
     previous_tx_pkts=${current_tx_pkts}
 }
 
-function run_iperf()
+function run_iperf_udp()
 {
     current_test_threads=$1
     LogMsg "======================================"
@@ -181,7 +194,7 @@ function run_iperf()
     port=8001
     sudo pkill -f iperf3
     ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo pkill -f iperf3" >> ${LOG_FILE}
-
+    sleep 10
     server_iperf_instances=$((current_test_threads/4+port))
     for ((i=port; i<=server_iperf_instances; i++))
     do
@@ -191,40 +204,58 @@ function run_iperf()
 
     while [ ${current_test_threads} -gt 64 ]; do
         number_of_connections=$(($number_of_connections-64))
-        sudo iperf3 -u -c ${SERVER} -p ${port} -4 -b 0 -l 1k -P 64 -t 60 --get-server-output -i 60 > /tmp/network${PROTO}/${current_test_threads}-iperf3.log
+        sudo iperf3 -u -c ${SERVER} -p ${port} -4 -b 0 -l 1k -P 64 -t 60 --get-server-output -i 60 > /tmp/network${TEST_TYPE}/${current_test_threads}-iperf3.log
         port=$(($port + 1))
     done
     if [ ${number_of_connections} -gt 0 ]
     then
-        sudo iperf3 -u -c ${SERVER} -p ${port} -4 -b 0 -l 1k -P ${number_of_connections} -t 60 --get-server-output -i 60 > /tmp/network${PROTO}/${current_test_threads}-iperf3.log
+        sudo iperf3 -u -c ${SERVER} -p ${port} -4 -b 0 -l 1k -P ${number_of_connections} -t 60 --get-server-output -i 60 > /tmp/network${TEST_TYPE}/${current_test_threads}-iperf3.log
     fi
-    sleep 10
-    sudo pkill -f iperf3
-    ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo pkill -f iperf3" >> ${LOG_FILE}
 }
 
-if [[ ${PROTO} == "TCP" ]]
+function run_variable_tcp_buffer()
+{
+    current_test_buffer=$1
+    LogMsg "======================================"
+    LogMsg "Running iPerf3 variable packet size = ${current_test_buffer}"
+    LogMsg "======================================"
+    port=8001
+    sudo pkill -f iperf3
+    ssh -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo pkill -f iperf3" >> ${LOG_FILE}
+    sleep 10
+    ssh -f -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo iperf3 -s 4 -p ${port} -i 60 -D" >> ${LOG_FILE}
+    sleep 3
+    sudo iperf3 -c ${SERVER} -p ${port} -4 -b 0 -l ${current_test_buffer} -P 1 -t 60 --get-server-output -i 60 > /tmp/network${TEST_TYPE}/${current_test_buffer}-iperf3.log
+}
+
+if [[ ${TEST_TYPE} == "TCP" ]]
 then
     for thread in "${TEST_THREADS[@]}"
     do
         run_ntttcp ${thread}
     done
-elif [[ ${PROTO} == "latency" ]]
+elif [[ ${TEST_TYPE} == "latency" ]]
 then
     run_lagscope
-elif [[ ${PROTO} == "UDP" ]]
+elif [[ ${TEST_TYPE} == "UDP" ]]
 then
     for thread in "${TEST_THREADS[@]}"
     do
-        run_iperf ${thread}
+        run_iperf_udp ${thread}
+    done
+elif [[ ${TEST_TYPE} == "variable_tcp_buffer" ]]
+then
+    for packet in "${TEST_BUFFERS[@]}"
+    do
+        run_variable_tcp_buffer ${packet}
     done
 else
-    LogMsg "Unsupported test type: ${PROTO}."
+    LogMsg "Unsupported test type: ${TEST_TYPE}."
 fi
 
 LogMsg "Kernel Version : `uname -r`"
 LogMsg "Guest OS : ${distro}"
 
 cd /tmp
-zip -r network.zip . -i network${PROTO}/* >> ${LOG_FILE}
+zip -r network.zip . -i network${TEST_TYPE}/* >> ${LOG_FILE}
 zip -r network.zip . -i summary.log >> ${LOG_FILE}


### PR DESCRIPTION
Update perf ntttcp and iperf to use a single script w/o sriov. Makes use of an xml specified parameter to do the configurations:
- SRIOV=no (simple config)
- SRIOV=yes (config sriov using transparent-vf)
- SRIOV=bond (config sriov using bondvf.sh)

Also moved all script dependencies to perf_utils in order to avoid circular imports and adjusted function parameters.
