### PR TITLE
Minor changes to lisa behavior

### DIFF
--- a/WS2012R2/lisa/lisa.ps1
+++ b/WS2012R2/lisa/lisa.ps1
@@ -986,7 +986,7 @@ switch ($cmdVerb)
         # we need to check the last one which is the final
         if (!$sts[-1])
         {
-            $lisaExitCode = 0
+            $lisaExitCode = 2
         }
     }
 "validate" {


### PR DESCRIPTION
1. Added functionality for the "onError" tag in DoDiagnoseHungSystem
state. This feature worked only when a running test entered
failed/aborted state. Sometimes the VM enters aborted state because it's
not booting and this fix is covering this scenario.
2. Reverted lisa exit code because Jenkins jobs no longer catch lisa
fails