### PR TITLE
Added logging to test case file

### DIFF
--- a/WS2012R2/lisa/setupscripts/STOR_VSS_3Chain_VHD_backup.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_3Chain_VHD_backup.ps1
@@ -120,28 +120,17 @@ function FixSnapshots($vmName, $hvServer)
 # Main script body
 #
 #######################################################################
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
 
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    Write-Output "Error: VM name is null"
     return $retVal
 }
 
 if ($hvServer -eq $null)
 {
-    $logger.error("hvServer is null")
+    Write-Output "Error: hvServer is null"
     return $retVal
 }
 
@@ -160,35 +149,49 @@ foreach ($p in $params)
      default  {}
     }
 }
+
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    Write-Output "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
-    return $False
-}
-
-if ($null -eq $rootdir)
-{
-    $logger.error("Test parameter rootdir was not specified")
+    Write-Output "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    Write-Output "ERROR: Test parameter driveletter was not specified."
     return $False
 }
+
+# Change the working directory to where we need to be
+if (-not (Test-Path $rootDir))
+{
+    Write-Output "Error: The directory `"${rootDir}`" does not exist"
+    return $False
+}
+
 $vmName1 = "${vmName}_ChildVM"
 
 cd $rootDir
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
 $logger.info("This script covers test case: ${TC_COVERED}")
-
-
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_DiskStress.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_DiskStress.ps1
@@ -73,24 +73,13 @@ $remoteScript = "STOR_VSS_Disk_Stress.sh"
 # 
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    Write-Output "ERROR: VM name is null"
     return $retVal
 }
+
 # Check input params
 $params = $testParams.Split(";")
 
@@ -109,32 +98,34 @@ foreach ($p in $params)
         default  {}          
         }
 }
+
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    Write-Output "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    Write-Output "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    Write-Output "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    Write-Output "ERROR: Test parameter driveletter was not specified."
     return $False
 }
+
 if ($null -eq $iOzoneVers)
 {
-    $logger.error("Test parameter iOzoneVers was not specified")
+    Write-Output "ERROR: Test parameter iOzoneVers was not specified"
     return $False
 }
 
@@ -146,8 +137,20 @@ if ($null -eq $TestLogDir)
 # Change the working directory to where we need to be
 cd $rootDir
 
-$logger.info("This script covers test case: ${TC_COVERED}")
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
 
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
+$logger.info("This script covers test case: ${TC_COVERED}")
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Fail.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Fail.ps1
@@ -75,22 +75,10 @@ $retVal = $false
 # 
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    Write-Output "ERROR: VM name is null"
     return $retVal
 }
 
@@ -112,33 +100,34 @@ foreach ($p in $params)
         default  {}
         }
 }
+
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    Write-Output "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    Write-Output "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    Write-Output "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    Write-Output "ERROR: Test parameter driveletter was not specified."
     return $False
 }
 
 if ($null -eq $FILESYS)
 {
-    $logger.error("Test parameter FILESYS was not specified.")
+    Write-Output "ERROR: Test parameter FILESYS was not specified."
     return $False
 }
 
@@ -150,8 +139,20 @@ if ($null -eq $TestLogDir)
 # Change the working directory to where we need to be
 cd $rootDir
 
-$logger.info("This script covers test case: ${TC_COVERED}")
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
 
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
+$logger.info("This script covers test case: ${TC_COVERED}")
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_ISCSI.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_ISCSI.ps1
@@ -71,22 +71,10 @@ $remoteScript = "STOR_VSS_ISCSI_PartitionDisks.sh"
 # 
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    "ERROR: VM name is null"
     return $retVal
 }
 
@@ -112,45 +100,56 @@ foreach ($p in $params)
 
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    "ERROR: Test parameter driveletter was not specified."
     return $False
 }
 
 if ($null -eq $FILESYS)
 {
-    $logger.error("Test parameter FILESYS was not specified")
+    "ERROR: Test parameter FILESYS was not specified"
     return $False
 }
 
 if ($null -eq $TargetIP)
 {
-    $logger.error("Test parameter TargetIP was not specified")
+    "ERROR: Test parameter TargetIP was not specified"
     return $False
 }
 
 # Change the working directory to where we need to be
 cd $rootDir
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
 $logger.info("This script covers test case: ${TC_COVERED}")
-
-
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_ISO_NoNetwork.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_ISO_NoNetwork.ps1
@@ -128,22 +128,10 @@ function RunRemoteScriptNoState($remoteScript)
 #
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    Write-Output "ERROR: VM name is null"
     return $retVal
 }
 
@@ -164,27 +152,28 @@ foreach ($p in $params)
         default  {}
         }
 }
+
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    Write-Output "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    Write-Output "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    Write-Output "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    Write-Output "ERROR: Test parameter driveletter was not specified."
     return $False
 }
 
@@ -195,8 +184,20 @@ if ($null -eq $TestLogDir)
 
 # Change the working directory to where we need to be
 cd $rootDir
-$logger.info("This script covers test case: ${TC_COVERED}")
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
 
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
+$logger.info("This script covers test case: ${TC_COVERED}")
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Mount_Multi_Paths.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Mount_Multi_Paths.ps1
@@ -74,22 +74,10 @@ $retVal = $false
 #
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    Write-Output "ERROR: VM name is null"
     return $retVal
 }
 
@@ -114,31 +102,31 @@ foreach ($p in $params)
 
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    Write-Output "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    Write-Output "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    Write-Output "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    Write-Output "ERROR: Test parameter driveletter was not specified."
     return $False
 }
 
 if ($null -eq $FILESYS)
 {
-    $logger.error("Test parameter FILESYS was not specified.")
+    Write-Output "ERROR: Test parameter FILESYS was not specified."
     return $False
 }
 
@@ -150,8 +138,20 @@ if ($null -eq $TestLogDir)
 # Change the working directory to where we need to be
 cd $rootDir
 
-$logger.info("This script covers test case: ${TC_COVERED}")
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
 
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
+$logger.info("This script covers test case: ${TC_COVERED}")
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Mount_Squashfs.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Mount_Squashfs.ps1
@@ -66,22 +66,10 @@ $retVal = $false
 #
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    Write-Output "ERROR: VM name is null"
     return $retVal
 }
 
@@ -105,25 +93,25 @@ foreach ($p in $params)
 
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    Write-Output "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    Write-Output "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    Write-Output "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    Write-Output "ERROR: Test parameter driveletter was not specified."
     return $False
 }
 
@@ -134,7 +122,30 @@ if ($null -eq $TestLogDir)
 
 # Change the working directory to where we need to be
 cd $rootDir
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
 $logger.info("This script covers test case: ${TC_COVERED}")
+
+# Source STOR_VSS_Utils.ps1 for common VSS functions
+if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {
+	. .\setupScripts\STOR_VSS_Utils.ps1
+	$logger.info("Sourced STOR_VSS_Utils.ps1")
+}
+else {
+	$logger.errror("Could not find setupScripts\STOR_VSS_Utils.ps1")
+	return $false
+}
 
 $sts = runSetup $vmName $hvServer $driveletter
 if (-not $sts[-1])

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Partition.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_Partition.ps1
@@ -75,22 +75,10 @@ $remoteScript = "PartitionDisks.sh"
 # 
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    "ERROR: VM name is null"
     return $retVal
 }
 
@@ -114,36 +102,50 @@ foreach ($p in $params)
 
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    "ERROR: Test parameter driveletter was not specified."
     return $False
 }
 
 if ($null -eq $FILESYS)
 {
-    $logger.error("Test parameter FILESYS was not specified")
+    "ERROR: Test parameter FILESYS was not specified"
     return $False
 }
 
 # Change the working directory to where we need to be
 cd $rootDir
+
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
 $logger.info("This script covers test case: ${TC_COVERED}")
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_State.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_BackupRestore_State.ps1
@@ -107,22 +107,10 @@ function ChangeVMState($vmState,$vmName)
 #
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
+    "ERROR: VM name is null"
     return $retVal
 }
 
@@ -147,36 +135,48 @@ foreach ($p in $params)
 
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    "ERROR: Backup driveletter is not specified."
     return $False
 }
 
 if ($null -eq $vmState)
 {
-    $logger.error("vmState param is not specified.")
+    "ERROR: vmState param is not specified."
     return $False
 }
 
 # Change the working directory to where we need to be
 cd $rootDir
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
 
 $logger.info("This script covers test case: ${TC_COVERED}")
 

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Change_Hypervvssd.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Change_Hypervvssd.ps1
@@ -66,23 +66,11 @@ $remoteScript = "STOR_VSS_Set_VSS_Daemon.sh"
 #
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
-    return $retVal
+    "ERROR: VM name is null"
+    return $False
 }
 
 # Check input params
@@ -106,33 +94,44 @@ foreach ($p in $params)
 
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    "ERROR: Backup driveletter is not specified."
     return $False
 }
 
 # Change the working directory to where we need to be
 cd $rootDir
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
+
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
 $logger.info("This script covers test case: ${TC_COVERED}")
-
-
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Backup_Disable_Enable_VSS.ps1
@@ -64,24 +64,13 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 #
 #######################################################################
 
-# Source TCUtils.ps1 for common functions
-if (Test-Path ".\setupScripts\TCUtils.ps1") {
-	. .\setupScripts\TCUtils.ps1
-	"Info: Sourced TCUtils.ps1"
-}
-else {
-	"Error: Could not find setupScripts\TCUtils.ps1"
-	return $false
-}
-
-$global:logger = [Logger]::new("${vmName}_summary.log")
-
 # Check input arguments
 if ($vmName -eq $null)
 {
-    $logger.error("VM name is null")
-    return $retVal
+    "ERROR: VM name is null"
+    return $False
 }
+
 # Check input params
 $params = $testParams.Split(";")
 
@@ -99,35 +88,48 @@ foreach ($p in $params)
      default  {}
     }
 }
+
 if ($null -eq $sshKey)
 {
-    $logger.error("Test parameter sshKey was not specified")
+    "ERROR: Test parameter sshKey was not specified"
     return $False
 }
 
 if ($null -eq $ipv4)
 {
-    $logger.error("Test parameter ipv4 was not specified")
+    "ERROR: Test parameter ipv4 was not specified"
     return $False
 }
 
 if ($null -eq $rootdir)
 {
-    $logger.error("Test parameter rootdir was not specified")
+    "ERROR: Test parameter rootdir was not specified"
     return $False
 }
 
 if ($null -eq $driveletter)
 {
-    $logger.error("Backup driveletter is not specified.")
+    "ERROR: Backup driveletter is not specified."
     return $False
 }
 
 # Change the working directory to where we need to be
 cd $rootDir
 
-$logger.info("This script covers test case: ${TC_COVERED}")
+# Source TCUtils.ps1 for common functions
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+	. .\setupScripts\TCUtils.ps1
+	"Info: Sourced TCUtils.ps1"
+}
+else {
+	"Error: Could not find setupScripts\TCUtils.ps1"
+	return $false
+}
 
+$loggerManager = [LoggerManager]::GetLoggerManager($vmName, $testParams)
+$global:logger = $loggerManager.TestCase
+
+$logger.info("This script covers test case: ${TC_COVERED}")
 
 # Source STOR_VSS_Utils.ps1 for common VSS functions
 if (Test-Path ".\setupScripts\STOR_VSS_Utils.ps1") {

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -152,35 +152,84 @@ function GetIPv4([String] $vmName, [String] $server)
 #
 #######################################################################
 class Logger {
-  [String] $LogFile
+    [String] $LogFile
+    [Boolean] $AddTimestamp
 
-  Logger([String] $logFile='default.log') {
-    del $logFile -ErrorAction SilentlyContinue
-    $this.LogFile = $logFile
-  }
+    Logger([String] $logFile, [Boolean] $addTimestamp) {
+        $this.SummaryLogFile = $logFile
+        $this.AddTimestamp = $addTimestamp 
+    }
 
-  [void] info([String] $message) {
-    $this.logMessage("Info: ${message}")
-  }
+    [void] info([String] $message) {
+        $color = "white"
+        $this.logMessage("Info: ${message}", $color)
+    }
 
-  [void] error([String] $message) {
-    $this.logMessage("Error: ${message}")
-  }
+    [void] error([String] $message) {
+        $color = "Red"
+        $this.logMessage("Error: ${message}", $color)
+    }
 
-  [void] debug([String] $message) {
-    $this.logMessage("Debug: ${message}")
-  }
+    [void] debug([String] $message) {
+        $color = "Gray"
+        $this.logMessage("Debug: ${message}", $color)
+    }
 
-  [void] warning([String] $message) {
-     $this.logMessage("Warning: ${message}")
-  }
+    [void] warning([String] $message) {
+        $color = "Yellow" 
+        $this.logMessage("Warning: ${message}", $color)
+    }
 
-  [void] logMessage([String] $message) {
-    $timestamp = $(Get-Date -Format G)
-    $finalMessage = "${timestamp} - ${message}"
-    Write-Host $finalMessage
-    $finalMessage | Add-Content $this.LogFile
-  }
+    [void] logMessage([String] $message, [String] $color) {
+        if ($this.AddTimestamp) {
+            $timestamp = $(Get-Date -Format G)
+            $message = "${timestamp} - ${message}"
+        }
+        Write-Host $message -ForegroundColor $color
+        $message | Add-Content $this.LogFile
+    }
+}
+
+
+#######################################################################
+#
+# Logger
+#
+#######################################################################
+class LoggerManager {
+    [Logger] $Summary
+    [Logger] $TestCase
+
+    LoggerManager([Logger] $summaryLogger, [Logger] $testCaseLogger) {
+        $this.Summary = $summaryLogger
+        $this.TestCase = $testCaseLogger 
+    }
+
+    [LoggerManager] GetLoggerManager([String] $vmName, [String] $testParams) {
+        $params = $testParams.Split(";")
+        $testLogDir = $null
+        $testName = $null
+        foreach ($p in $params) {
+            $fields = $p.Split("=")
+            if ($fields[0].Trim() -eq "TestLogDir") {
+                $testLogDir = $fields[1].Trim()
+            } elseif ($fields[0].Trim() -eq "TestName") {
+                $testName = $fields[1].Trim()
+            }
+        }
+
+        if ((-not $testLogDir) -or (-not $testName)) {
+            throw [System.ArgumentException] "TestLogDir or TestName not found."
+        }
+
+        $summaryLog = "${vmName}_summary.log"
+        Remove-Item $summaryLog -ErrorAction SilentlyContinue
+        $testLog = "${testLogDir}\${vmName}_${testName}_ps.log"
+
+        $summaryLogger = [Logger]::new($summaryLog, $False)
+        $testLogger = [Logger]::new($testLog, $True)
+        return [LoggerManager]::new($summaryLogger, $testLogger)
+    }
 }
 
 #######################################################################

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -156,7 +156,7 @@ class Logger {
     [Boolean] $AddTimestamp
 
     Logger([String] $logFile, [Boolean] $addTimestamp) {
-        $this.SummaryLogFile = $logFile
+        $this.LogFile = $logFile
         $this.AddTimestamp = $addTimestamp 
     }
 
@@ -193,7 +193,7 @@ class Logger {
 
 #######################################################################
 #
-# Logger
+# LoggerManager
 #
 #######################################################################
 class LoggerManager {
@@ -205,7 +205,7 @@ class LoggerManager {
         $this.TestCase = $testCaseLogger 
     }
 
-    [LoggerManager] GetLoggerManager([String] $vmName, [String] $testParams) {
+    [LoggerManager] static GetLoggerManager([String] $vmName, [String] $testParams) {
         $params = $testParams.Split(";")
         $testLogDir = $null
         $testName = $null
@@ -231,7 +231,6 @@ class LoggerManager {
         return [LoggerManager]::new($summaryLogger, $testLogger)
     }
 }
-
 #######################################################################
 #
 # GetIPv4ViaHyperV()


### PR DESCRIPTION
A new step was added in the Logger class in order to log messages in the test summary file. In the new behavior, time-stamped messages are directed towards the standard output and the test summary file whereas the logs directed towards the general summary file are not time-stamped.

The Logger class was moved into a separate file in order to avoid missing variables errors from TCUtils.ps1 and a GetLogger static method has been added in order to abstract the process of parsing testParams and creating the log file names. 
Test scripts that contained logger code (VSS Tests) have been updated on the new behavior.