### PR TITLE
Update DM related script to remove vm definition in case xml parameter

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
@@ -30,7 +30,7 @@
 
    The testParams have the format of:
 
-      vmName=Name of a VM, enable=[yes|no], minMem= (decimal) [MB|GB|%], maxMem=(decimal) [MB|GB|%],
+       enableDM=[yes|no], minMem= (decimal) [MB|GB|%], maxMem=(decimal) [MB|GB|%],
       startupMem=(decimal) [MB|GB|%], memWeight=(0 < decimal < 100)
 
    Only the vmName param is taken into consideration. This needs to appear at least twice for
@@ -109,9 +109,6 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
-
 # number of tries
 [int]$tries = 0
 
@@ -161,7 +158,7 @@ foreach ($p in $params)
 
       switch ($fields[0].Trim())
       {
-        "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+        "VM2NAME" { $vm2Name = $fields[1].Trim() }
         "ipv4"    { $ipv4    = $fields[1].Trim() }
         "sshKey"  { $sshKey  = $fields[1].Trim() }
         "tries"  { $tries  = $fields[1].Trim() }
@@ -184,28 +181,7 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 2)
-{
-    "Error: two VMs are necessary for the High Priority test." | Tee-Object -Append -file $summaryLog
-    return $false
-}
-
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-    }
-    else
-    {
-      "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-      return $false
-    }
-}
+$vm1Name = $vmName
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
@@ -237,7 +213,7 @@ if (-not $retVal)
 #
 $timeout = 120
 StartDependencyVM $vm2Name $hvServer $tries
-WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 $vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
 $timeoutStress = 0

--- a/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HighPriority.ps1
@@ -316,7 +316,6 @@ while ($timeout -gt 0)
         {
             "Error: Consume Memory script returned false on VM1 $vm1Name" | Tee-Object -Append -file $summaryLog
             Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-            Stop-VM -VMName $vm3name -ComputerName $hvServer -force
             return $false
         }
         $diff = $totalTimeout - $timeout
@@ -331,7 +330,6 @@ while ($timeout -gt 0)
         {
             "Error: Consume Memory script returned false on VM2 $vm2Name" | Tee-Object -Append -file $summaryLog
             Stop-VM -VMName $vm2name -ComputerName $hvServer -force
-            Stop-VM -VMName $vm3name -ComputerName $hvServer -force
             return $false
         }
         $diff = $totalTimeout - $timeout

--- a/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAddRemove.ps1
@@ -106,9 +106,6 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
-
 # number of tries
 [int]$tries = 0
 
@@ -158,7 +155,7 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-        "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+        "VM2NAME"       { $vm2Name = $fields[1].Trim() }
         "ipv4"    { $ipv4    = $fields[1].Trim() }
         "sshKey"  { $sshKey  = $fields[1].Trim() }
         "tries"  { $tries  = $fields[1].Trim() }
@@ -177,33 +174,11 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 2)
-{
-    "Error: two VMs are necessary for the Maximum Memory Honored test."
-    return $false
-}
-
 $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-    }
-    else
-    {
-        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-        return $false
-    }
-}
-
+$vm1Name = $vmName
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
 {
@@ -222,9 +197,10 @@ if (-not $vm2)
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng"
+
 if (-not $retVal)
 {
-    "stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
+    "Error: stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog
     return $false
 }
 

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
@@ -101,7 +101,7 @@ $sshKey = $null
 $ipv4 = $null
 
 # Name of first VM
-$vm1Name = $null
+$vm1Name = $vmName
 
 # Number of tries
 [int]$tries = 0
@@ -152,7 +152,6 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-        "vmName"  { $vm1Name =$fields[1].Trim() }
         "ipv4"    { $ipv4    = $fields[1].Trim() }
         "sshKey"  { $sshKey  = $fields[1].Trim() }
         "tries"  { $tries  = $fields[1].Trim() }
@@ -173,11 +172,6 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmName -notlike $vm1Name)
-{
-    "Error: the VMName testParam needs to be the same as the VMName from the global setting"
-    return $false
-}
 
 $summaryLog = "${vmName}_summary.log"
 del $summaryLog -ErrorAction SilentlyContinue
@@ -194,6 +188,7 @@ if (-not $vm1)
 "Checking if stress-ng is installed"
 
 $retVal = check_app "stress-ng"
+
 if (-not $retVal)
 {
     "stress-ng is not installed! Please install it before running the memory stress tests." | Tee-Object -Append -file $summaryLog

--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_stressapptest.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_stressapptest.ps1
@@ -197,7 +197,7 @@ $sshKey = $null
 $ipv4 = $null
 
 # Name of first VM
-$vm1Name = $null
+$vm1Name = $vmName
 
 # number of tries
 [int]$tries = 0
@@ -248,7 +248,6 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vm1Name =$fields[1].Trim() }
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
@@ -265,12 +264,6 @@ if (-not $sshKey)
 if ($tries -le 0)
 {
     $tries = $defaultTries
-}
-
-if ($vmName -notlike $vm1Name)
-{
-    "Error: the VMName testParam needs to be the same as the VMName from the global setting"
-    return $false
 }
 
 $summaryLog = "${vmName}_summary.log"

--- a/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_MaxMemHonor.ps1
@@ -109,9 +109,6 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
-
 # number of tries
 [int]$tries = 0
 
@@ -161,7 +158,7 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+      "VM2NAME"       { $vm2Name = $fields[1].Trim() }
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
@@ -184,29 +181,7 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 2)
-{
-    "Error: two VMs are necessary for the Maximum Memory Honored test." | Tee-Object -Append -file $summaryLog
-    return $false
-}
-
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-    }
-    else
-    {
-        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-        return $false
-    }
-}
+$vm1Name = $vmName
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
@@ -240,7 +215,7 @@ if (-not $retVal)
 #
 $timeout = 120
 StartDependencyVM $vm2Name $hvServer $tries
-WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 $vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
 $timeoutStress = 0

--- a/WS2012R2/lisa/setupscripts/DM_MinMemHonor.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_MinMemHonor.ps1
@@ -105,9 +105,6 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
-
 # number of tries
 [int]$tries = 0
 
@@ -157,7 +154,7 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+      "VM2NAME"       { $vm2Name = $fields[1].Trim() }
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
@@ -180,28 +177,7 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 2)
-{
-    "Error: two VMs are necessary for the Minimum Memory Honored test." | Tee-Object -Append -file $summaryLog
-    return $false
-}
-
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-    }
-    else
-    {
-        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-        return $false
-    }
-}
+$vm1Name = $vmName
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
@@ -222,7 +198,7 @@ if (-not $vm2)
 #
 $timeout = 120
 StartDependencyVM $vm2Name $hvServer $tries
-WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 
 # Get VM's minimum memory setting
 [int64]$vm1MinMem = ($vm1.MemoryMinimum/1MB)

--- a/WS2012R2/lisa/setupscripts/DM_PressureChangesDemand.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_PressureChangesDemand.ps1
@@ -152,7 +152,6 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-        "vmName"  { $vm1Name =$fields[1].Trim() }
         "ipv4"    { $ipv4    = $fields[1].Trim() }
         "sshKey"  { $sshKey  = $fields[1].Trim() }
         "tries"  { $tries  = $fields[1].Trim() }
@@ -175,12 +174,7 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmName -notlike $vm1Name)
-{
-    "Error: the VMName testParam needs to be the same as the VMName from the global setting" | Tee-Object -Append -file $summaryLog
-    return $false
-}
-
+$vm1Name = $vmName
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
 {

--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -111,8 +111,8 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
+# Name of third VM if have
+$vm3Name = $null
 
 # number of tries
 [int]$tries = 0
@@ -163,7 +163,8 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-        "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+        "VM2NAME"       { $vm2Name = $fields[1].Trim() }
+        "VM3NAME"       { $vm3Name = $fields[1].Trim() }
         "ipv4"    { $ipv4    = $fields[1].Trim() }
         "sshKey"  { $sshKey  = $fields[1].Trim() }
         "tries"  { $tries  = $fields[1].Trim() }
@@ -186,36 +187,8 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 3)
-{
-    "Error: three VMs are necessary for the StartupLowCompete test." | Tee-Object -Append -file $summaryLog
-    return $false
-}
 
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-$vm3Name = $vmNames[2]
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-
-    }
-    elseif ($vm3Name -like $vmName)
-    {
-        # switch vm1Name with vm3Name
-        $vm1Name = $vmNames[2]
-        $vm3Name = $vmNames[0]
-    }
-    else
-    {
-        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-        return $false
-    }
-}
+$vm1Name = $vmName
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
@@ -299,7 +272,7 @@ if (-not $retVal)
 #
 $timeout = 120
 StartDependencyVM $vm2Name $hvServer $tries
-WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 $vm2ipv4 = GetIPv4 $vm2Name $hvServer
 
 $timeoutStress = 1

--- a/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_RemoveUnderPressure.ps1
@@ -61,8 +61,8 @@
     Test data for this test case
 
     .Example
-    setupscripts\DM_RemoveUnderPressure.ps1 -vmName nameOfVM -hvServer localhost -testParams 'sshKey=KEY;ipv4=IPAddress;rootDir=path\to\dir;vmName=NameOfVM1
-        vmName=NameOfVM2;vmName=NameOfVM3'
+    setupscripts\DM_RemoveUnderPressure.ps1 -vmName nameOfVM -hvServer localhost -testParams 'sshKey=KEY;ipv4=IPAddress;rootDir=path\to\dir;
+        vm2Name=NameOfVM2;vm3Name=NameOfVM3'
 #>
 
 param([string] $vmName, [string] $hvServer, [string] $testParams)

--- a/WS2012R2/lisa/setupscripts/DM_SaveRestore.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_SaveRestore.ps1
@@ -30,8 +30,8 @@
 
    The testParams have the format of:
 
-      vmName=Name of a VM, enable=[yes|no], minMem= (decimal) [MB|GB|%], maxMem=(decimal) [MB|GB|%], 
-      startupMem=(decimal) [MB|GB|%], memWeight=(0 < decimal < 100) 
+      vmName=Name of a VM, enable=[yes|no], minMem= (decimal) [MB|GB|%], maxMem=(decimal) [MB|GB|%],
+      startupMem=(decimal) [MB|GB|%], memWeight=(0 < decimal < 100)
 
    Only the vmName param is taken into consideration. This needs to appear at least twice for
    the test to start.
@@ -49,7 +49,7 @@
        vmName=sles11x64sp3_2;enable=yes;minMem=512MB;maxMem=25%;startupMem=25%;memWeight=0"
 
    All scripts must return a boolean to indicate if the script completed successfully or not.
-   
+
    .Parameter vmName
     Name of the VM to remove NIC from .
 
@@ -107,9 +107,6 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
-
 # number of tries
 [int]$tries = 0
 
@@ -159,15 +156,15 @@ $params = $testParams.Split(";")
 foreach ($p in $params)
 {
     $fields = $p.Split("=")
-    
+
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+      "VM2NAME"       { $vm2Name = $fields[1].Trim() }
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
       "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
-    } 
+    }
 }
 
 $summaryLog = "${vmName}_summary.log"
@@ -179,28 +176,7 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 2)
-{
-    "Error: two VMs are necessary for the StartupLowCompete test." | Tee-Object -Append -file $summaryLog
-    return $false
-}
-
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-    }
-    else 
-    {
-        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-        return $false
-    }
-}
+$vm1Name = $vmName
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
@@ -218,7 +194,7 @@ if (-not $vm2)
 
 # sleep 1 minute for VM to start reporting demand
 $sleepPeriod = 60
-while ($sleepPeriod -gt 0) 
+while ($sleepPeriod -gt 0)
 {
     # get VM1's Memory
     [int64]$vm1BeforeAssigned = ($vm1.MemoryAssigned/[int64]1048576)
@@ -253,9 +229,9 @@ if ($vm1BeforeDemand -le 0)
 #
 $timeout = 120
 StartDependencyVM $vm2Name $hvServer $tries
-WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 
-# sleep another 2 minute trying to get VM2's memory demand 
+# sleep another 2 minute trying to get VM2's memory demand
 $sleepPeriod = 120 #seconds
 # get VM2's Memory
 while ($sleepPeriod -gt 0)

--- a/WS2012R2/lisa/setupscripts/DM_StartupLowCompete.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_StartupLowCompete.ps1
@@ -108,9 +108,6 @@ $vm1Name = $null
 # Name of second VM
 $vm2Name = $null
 
-# string array vmNames
-[String[]]$vmNames = @()
-
 # number of tries
 [int]$tries = 0
 
@@ -163,11 +160,12 @@ foreach ($p in $params)
 
     switch ($fields[0].Trim())
     {
-      "vmName"  { $vmNames = $vmNames + $fields[1].Trim() }
+      "VM2NAME"       { $vm2Name = $fields[1].Trim() }
       "ipv4"    { $ipv4    = $fields[1].Trim() }
       "sshKey"  { $sshKey  = $fields[1].Trim() }
       "tries"  { $tries  = $fields[1].Trim() }
       "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+
     }
 }
 
@@ -180,28 +178,8 @@ if ($tries -le 0)
     $tries = $defaultTries
 }
 
-if ($vmNames.count -lt 2)
-{
-    "Error: two VMs are necessary for the StartupLowCompete test." | Tee-Object -Append -file $summaryLog
-    return $false
-}
 
-$vm1Name = $vmNames[0]
-$vm2Name = $vmNames[1]
-if ($vm1Name -notlike $vmName)
-{
-    if ($vm2Name -like $vmName)
-    {
-        # switch vm1Name with vm2Name
-        $vm1Name = $vmNames[1]
-        $vm2Name = $vmNames[0]
-    }
-    else
-    {
-        "Error: The first vmName testparam must be the same as the vmname from the vm section in the xml." | Tee-Object -Append -file $summaryLog
-        return $false
-    }
-}
+$vm1Name = $vmName
 
 $vm1 = Get-VM -Name $vm1Name -ComputerName $hvServer -ErrorAction SilentlyContinue
 if (-not $vm1)
@@ -254,7 +232,7 @@ if ($vm1BeforeDemand -le 0)
 #
 $timeout = 120
 StartDependencyVM $vm2Name $hvServer $tries
-WaitForVMToStartKVP $vm2Name $hvServer $timeout 
+WaitForVMToStartKVP $vm2Name $hvServer $timeout
 
 # get VM1's Memory
 [int64]$vm1AfterAssigned = ($vm1.MemoryAssigned/[int64]1048576)

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -157,7 +157,7 @@ class Logger {
 
     Logger([String] $logFile, [Boolean] $addTimestamp) {
         $this.LogFile = $logFile
-        $this.AddTimestamp = $addTimestamp 
+        $this.AddTimestamp = $addTimestamp
     }
 
     [void] info([String] $message) {
@@ -176,7 +176,7 @@ class Logger {
     }
 
     [void] warning([String] $message) {
-        $color = "Yellow" 
+        $color = "Yellow"
         $this.logMessage("Warning: ${message}", $color)
     }
 
@@ -202,7 +202,7 @@ class LoggerManager {
 
     LoggerManager([Logger] $summaryLogger, [Logger] $testCaseLogger) {
         $this.Summary = $summaryLogger
-        $this.TestCase = $testCaseLogger 
+        $this.TestCase = $testCaseLogger
     }
 
     [LoggerManager] static GetLoggerManager([String] $vmName, [String] $testParams) {
@@ -1311,7 +1311,7 @@ function check_app([string]$app_name, [string]$custom_ip)
     }
     .\bin\plink -i ssh\${sshKey} root@${target_ip} "command -v ${app_name}"
     if (-not $?) {
-        Write-Output "ERROR: ${app_name} is not installed on the VM" -ErrorAction SilentlyContinue
+        Write-Output "ERROR: ${app_name} is not installed on the VM" -ErrorAction SilentlyContinue | Out-File -Append $summaryLog
         return $False
     }
 }
@@ -2182,7 +2182,7 @@ $DM_scriptBlock = {
             __chunks=128
         else
             __chunks=512
-        fi   
+        fi
         __threads=`$(($memMB/__chunks))
         if [ $timeoutStress -eq 0 ]; then
             timeout=10000000

--- a/WS2012R2/lisa/xml/AllTests_Gen2VM.xml
+++ b/WS2012R2/lisa/xml/AllTests_Gen2VM.xml
@@ -359,6 +359,7 @@
         <onError>Continue</onError>
         <testParams>
             <param>TC_COVERED=CORE-23</param>
+            <param>enableDM=no</param>
             <param>VCPU=8</param>
             <param>NumaNodes=4</param>
             <param>Sockets=2</param>
@@ -1833,7 +1834,6 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-01</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=1GB</param>
@@ -1870,7 +1870,6 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-03</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=1024MB</param>
             <param>maxMem=4GB</param>
@@ -1888,14 +1887,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-04</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=1024MB</param>
             <param>maxMem=6GB</param>
             <param>startupMem=1024MB</param>
             <param>memWeight=100</param>
             <param>staticMem=1024MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=70%</param>
@@ -1913,14 +1910,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-05</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=80%</param>
             <param>startupMem=79%</param>
             <param>memWeight=0</param>
             <param>staticMem=512MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=20%</param>
@@ -1938,21 +1933,19 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-06</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=60%</param>
             <param>startupMem=60%</param>
             <param>memWeight=0</param>
             <param>staticMem=1024MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=40%</param>
             <param>startupMem=40%</param>
             <param>memWeight=0</param>
             <param>staticMem=512MB</param>
-            <param>vmName=VM3Name</param>
+            <param>vm3Name=VM3Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=25%</param>
@@ -1970,7 +1963,6 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-07</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=20%</param>
@@ -1988,14 +1980,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-08</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=50%</param>
             <param>startupMem=50%</param>
             <param>memWeight=100</param>
             <param>staticMem=1024MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=50%</param>
@@ -2013,14 +2003,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-09</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=50%</param>
             <param>maxMem=80%</param>
             <param>startupMem=80%</param>
             <param>memWeight=0</param>
             <param>staticMem=1024MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=50%</param>
@@ -2038,14 +2026,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-10</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=80%</param>
             <param>startupMem=80%</param>
             <param>memWeight=0</param>
             <param>staticMem=1024MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=40%</param>
@@ -2063,14 +2049,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-11</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=80%</param>
             <param>startupMem=80%</param>
             <param>memWeight=0</param>
             <param>staticMem=512MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=20%</param>
@@ -2088,14 +2072,12 @@
         <setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
         <testParams>
             <param>TC_COVERED=DM-12</param>
-            <param>vmName=VMName</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=20%</param>
             <param>startupMem=20%</param>
             <param>memWeight=0</param>
             <param>staticMem=512MB</param>
-            <param>vmName=VM2Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=75%</param>

--- a/WS2012R2/lisa/xml/AllTests_Gen2VM.xml
+++ b/WS2012R2/lisa/xml/AllTests_Gen2VM.xml
@@ -1945,7 +1945,6 @@
             <param>startupMem=40%</param>
             <param>memWeight=0</param>
             <param>staticMem=512MB</param>
-            <param>vm3Name=VM3Name</param>
             <param>enableDM=yes</param>
             <param>minMem=512MB</param>
             <param>maxMem=25%</param>
@@ -2243,6 +2242,7 @@
             <sshKey>linux_id_rsa.ppk</sshKey>
             <testParams>
                 <param>VM2NAME=vmName</param>
+                <param>VM3NAME=vm3Name</param>
                 <param>SSH_PRIVATE_KEY=linux_id_rsa</param>
                 <param>SnapshotName=ICABase</param>
             </testParams>

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -304,6 +304,7 @@
             <onError>Continue</onError>
             <testParams>
                 <param>TC_COVERED=CORE-23</param>
+                <param>enableDM=no</param>
                 <param>VCPU=8</param>
                 <param>NumaNodes=4</param>
                 <param>Sockets=2</param>

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -22,13 +22,13 @@
 				<suiteTest>DM_loaded</suiteTest>
 				<suiteTest>HotAdd_Verify_udev</suiteTest>
 
-				<!--Dynamic Memory – Hot Add--> 
+				<!--Dynamic Memory – Hot Add-->
 				<!-- Basic Hot Add tests -->
 				<suiteTest>HotAdd</suiteTest>
-				<suiteTest>HotAddStressapptest</suiteTest> 
+				<suiteTest>HotAddStressapptest</suiteTest>
 				<suiteTest>DemandPressure</suiteTest>
 
-				<!-- Complex Hot Add tests -->	
+				<!-- Complex Hot Add tests -->
 				<suiteTest>HotRemove</suiteTest>
 				<suiteTest>StartupHighCompete</suiteTest>
 				<suiteTest>HighPriority</suiteTest>
@@ -54,7 +54,6 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-01</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=2GB</param>
@@ -91,7 +90,6 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-03</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=4GB</param>
@@ -111,7 +109,6 @@
 			<testParams>
 				<param>TC_COVERED=DM-04</param>
 				<param>Stress_Level=0</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=4GB</param>
@@ -130,14 +127,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-05</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=40%</param>
 				<param>startupMem=1024MB</param>
 				<param>memWeight=100</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=85%</param>
@@ -156,14 +151,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-06</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=80%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
@@ -181,21 +174,19 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-07</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=60%</param>
 				<param>startupMem=60%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=40%</param>
 				<param>startupMem=40%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM3Name</param>
+				<param>vm3Name=VM3Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=25%</param>
@@ -214,7 +205,6 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-08</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
@@ -233,14 +223,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-09</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
 				<param>startupMem=45%</param>
 				<param>memWeight=100</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
@@ -259,14 +247,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-10</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=40%</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=70%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=50%</param>
@@ -284,14 +270,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-11</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=80%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=40%</param>
@@ -309,14 +293,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-12</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
 				<param>startupMem=80%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
@@ -334,14 +316,12 @@
 			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
 			<testParams>
 				<param>TC_COVERED=DM-13</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=20%</param>
 				<param>startupMem=20%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vmName=VM2Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=80%</param>
@@ -360,7 +340,6 @@
 			<testParams>
 				<param>TC_COVERED=DM-14</param>
 				<param>Stress_Level=1</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=4GB</param>
@@ -380,7 +359,6 @@
 			<testParams>
 				<param>TC_COVERED=DM-15</param>
 				<param>Stress_Level=2</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=4GB</param>
@@ -400,7 +378,6 @@
 			<testParams>
 				<param>TC_COVERED=DM-16</param>
 				<param>Stress_Level=3</param>
-				<param>vmName=VMName</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=8GB</param>
@@ -416,13 +393,18 @@
 	</testCases>
 
 	<VMs>
-		<vm>
-			<hvServer>localhost</hvServer>
-			<vmName>VMName</vmName>
-			<os>Linux</os>
-			<ipv4></ipv4>
-			<sshKey>linux_id_rsa.ppk</sshKey>
-			<suite>DM</suite>
-		</vm>
-	</VMs>
+        <vm>
+            <hvServer>localhost</hvServer>
+            <vmName>VMName</vmName>
+            <os>Linux</os>
+            <ipv4></ipv4>
+            <sshKey>linux_id_rsa.ppk</sshKey>
+            <testParams>
+                <param>VM2NAME=vm2Name</param>
+                <param>SnapshotName=ICABase</param>
+            </testParams>
+            <suite>DM</suite>
+        </vm>
+    </VMs>
+
 </config>

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -186,7 +186,6 @@
 				<param>startupMem=40%</param>
 				<param>memWeight=0</param>
 				<param>staticMem=1024MB</param>
-				<param>vm3Name=VM3Name</param>
 				<param>enableDM=yes</param>
 				<param>minMem=1024MB</param>
 				<param>maxMem=25%</param>
@@ -400,7 +399,8 @@
             <ipv4></ipv4>
             <sshKey>linux_id_rsa.ppk</sshKey>
             <testParams>
-                <param>VM2NAME=vm2Name</param>
+                <param>VM2Name=vm2Name</param>
+                <param>VM3Name=vm3Name</param>
                 <param>SnapshotName=ICABase</param>
             </testParams>
             <suite>DM</suite>


### PR DESCRIPTION
Orignial DM.xml includes VMName, which is used to define the test vmName and dependency vmName. Since two vms name can be defined in the VMs section, we could use and avoid defining them in the testParams section.

Also we run all the cases in one xml file, vmName and VM2Name are defined dynamically, it cannot change the DM.xml single case's parameter by automation, so submit this pull requests.

Thank you.