### PR TITLE
remote-scripts/ica/Kdump_Config.sh: Fix issue - can not find grub.cfg…

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Config.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Config.sh
@@ -151,6 +151,8 @@ ConfigRhel()
         boot_filepath=/boot/grub2/grub.cfg
     elif [ $os_GENERATION -eq 2 ] && [ $os_RELEASE -eq 7 ]; then
         boot_filepath=/boot/efi/EFI/redhat/grub.cfg
+    else
+	boot_filepath=`find /boot -name grub.cfg`
     fi
 
     # Enable kdump service


### PR DESCRIPTION
Can not find grub.cfg on fedora, this patch is to find grub.cfg on fedora