### PR TITLE
Minor update CheckNuma_Maximum in coreTests.xml for startupMem

### DIFF
--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -284,7 +284,6 @@
             <testParams>
                 <param>TC_COVERED=CORE-22</param>
                 <param>enableDM=no</param>
-                <param>staticMem=2048MB</param>
                 <param>memWeight=0</param>
                 <param>VCPU=4</param>
                 <param>NumaNodes=1</param>
@@ -296,7 +295,7 @@
         <test>
             <testName>CheckNuma_Maximum</testName>
             <setupScript>
-            	<file>setupScripts\DM_DISABLE.ps1</file>
+            	<file>setupScripts\DM_CONFIGURE_MEMORY.ps1</file>
             	<file>setupScripts\ChangeCPU.ps1</file>
             </setupScript>
             <testScript>setupScripts\NUMA.ps1</testScript>
@@ -309,8 +308,8 @@
                 <param>NumaNodes=4</param>
                 <param>Sockets=2</param>
                 <param>MemSize=1024MB</param>
-		<param>staticMem=2048MB</param>
-		<param>memWeight=0</param>
+                <param>startupMem=2048MB</param>
+                <param>memWeight=0</param>
             </testParams>
             <timeout>600</timeout>
         </test>


### PR DESCRIPTION

update CheckNuma_Maximum in coreTests.xml for startupMem:
1) remove staticMem=2048MB,  ChangeCPU, DM_Disable or DM_Cofig_Memory,NUMA.ps1, no file to parse this staticMem
2) add startupMem=2048 for CheckNuma_Maximum, change DM_Cofig_Memory to set up startupMem.

note: NumaNodes name is a little confusing, I want to update it, but too many files use ChangeCPU.ps1 :)

Just find this issue since before our test machines by default using 2048 as memory, after set new vm as 4G as default, get the error.

Thank you so much.
