### PR TITLE
 Shielded VMs testing: Added TDC test cases

### DIFF
--- a/WS2012R2/lisa/setupscripts/Shielded_TDC.Tests.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_TDC.Tests.ps1
@@ -1,0 +1,132 @@
+﻿########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+#
+# Linux Shielded VMs TDC pester tests
+#
+
+Param(
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'Name of the VHDx where lsvmprep has been run')]
+    [ValidateNotNullorEmpty()]
+    [String]$lsvmprepVhdName,
+
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'Path of the VHDx that will be used for dependency VM')]
+    [ValidateNotNullorEmpty()]
+    [String]$dependencyVhdPath,
+	
+	[Parameter(Mandatory = $true,Position = 0,HelpMessage = 'SSH key for connecting to the Dependency VM')]
+    [ValidateNotNullorEmpty()]
+    [String]$sshKey,
+	
+	[Parameter(Mandatory = $true,Position = 0,HelpMessage = 'Path of the encrypted VHDx with no lsvmtools')]
+    [ValidateNotNullorEmpty()]
+    [String]$vhdNoLsvmtools
+)
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+
+Describe "Run the TDC wizard with a Linux VHDX file" {
+    Context "Submit the VHDX file (after running lsvmprep) to the TDC Wizard." {
+
+        It "Running TDC-01" {
+            # Get full VHDx path
+            $vhdPath = Get_Full_VHD_Path $lsvmprepVhdName
+            $vhdPath | Should not Be $null
+
+            # Search for the certificate or create one
+            $signCert = Get_Certificate
+            $signCert | Should not Be $null
+
+            # Make the template
+            Run_TDC $vhdPath $signcert | Should be $true
+        }
+    }
+}
+
+Describe "Verify the output LSVM VHDX file from the TDC Wizard" {
+    Context "1.  Verify the Volume Signature Catalog (VSC) file was created.
+            2.  Attach the templatized VHDX file as a disk on a Linux VM.
+            3.  Create the following directory: /lsvmefi
+            4.  Mount the EFI partition of the templatized VHDX file on the /lsvmefi mount point.
+            5.  Verify the boot loader is the Minimal OS, not the Shim, or MBLoad.
+            6.  Examine the contents of the VSC file and look for the hashes for various partitions." {
+        
+        It "Running TDC-02" {			
+            # Get full VHDx path
+            $vhdPath = Get_Full_VHD_Path $lsvmprepVhdName
+            $vhdPath | Should not Be $null
+
+			# Search for the certificate or create one
+            $signCert = Get_Certificate
+            $signCert | Should not Be $null
+			
+			# Make the template
+            Run_TDC $vhdPath $signcert | Should be $true
+			
+			# Run the test
+            Verify_TDC $vhdPath $dependencyVhdPath $sshKey | Should be $true
+			
+			# Clean the dependency VM
+			CleanupDependency
+        }
+    } 
+}
+
+Describe "Verify a VHDX file that has not had lsvmprep run fails TDC" {
+    Context "1.  Create Gen 2 Linux VM.
+            2.  Do not install lsvmtools.
+            3.  Submit the VHDX file from the VM in step 1 to the TDC Wizard." {
+        
+        It "Running TDC-03" {
+			# Copy VHDx from share
+            $vhdPath = Copy_vhdx_from_share $vhdNoLsvmtools
+			$vhdPath | Should not Be $null
+			
+			# Search for the certificate or create one
+            $signCert = Get_Certificate
+            $signCert | Should not Be $null
+			
+			# Make the template
+            Run_TDC $vhdPath $signcert | Should be $false
+        }
+    }
+}
+
+Describe "Test TDC using Linux VHDX file and an invalid certificate" {
+    Context "1.  Submit a properly prepared Linux VHDX file to the TDC Wizard
+            2.  Specify an invalid certificate.
+            3.  Submit the VHDX file from the VM in step 1 to the TDC Wizard." {
+        
+        It "Running TDC-04" {
+		    # Get full VHDx path
+            $vhdPath = Get_Full_VHD_Path $lsvmprepVhdName
+            $vhdPath | Should not Be $null
+
+			# Search for the invalid certificate or create one
+            $signCert = Get_invalid_certificate
+			$signCert | Should not Be $null
+			
+			# Make the template
+            Run_TDC $vhdPath $signcert | Should be $false
+        }
+    }
+}

--- a/WS2012R2/lisa/setupscripts/Shielded_TDC.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_TDC.ps1
@@ -1,0 +1,208 @@
+﻿########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+#
+# Linux Shielded VMs TDC automation functions
+#
+
+function Get_Full_VHD_Path([string] $vhd_name)
+{
+    $hostInfo = Get-VMHost
+    if (-not $hostInfo) {
+        return $false
+    }
+
+    $defaultVhdPath = $hostInfo.VirtualHardDiskPath
+    if (-not $defaultVhdPath.EndsWith("\")) {
+        $defaultVhdPath += "\"
+    }
+
+    $full_vhd_path = $defaultVhdPath + $vhd_name
+	$tested_vhd_path = $full_vhd_path -replace 'TDC','TDC-Test'
+	
+	# Make a copy of the encypted VHDx for testing only
+    Copy-Item -Path $full_vhd_path -Destination $tested_vhd_path -Force
+    if (-not $?) {
+        return $false
+    }
+	
+    return $tested_vhd_path
+}
+
+function Get_Certificate
+{
+    # Search certificate
+    $thumbprint = ""
+    $certificates = Get-ChildItem -Recurse Cert:\LocalMachine\My
+    foreach ($certificate in $certificates) {
+        if ($certificate.Subject -eq 'CN=Template Disk Signer Certificate'){
+            $thumbprint = $certificate.Thumbprint
+            break
+        }
+    }
+
+    # If a certificate was not found, create one. Else, import the existing one
+    if ($thumbprint -eq "") {
+        $signcert = New-SelfSignedCertificate -Subject 'CN=Template Disk Signer Certificate'
+    }
+    else {
+        $signcert = Get-Item Cert:\LocalMachine\My\$thumbprint       
+    }
+
+    return $signcert
+}
+
+function CleanupDependency
+{
+    # Clean up
+    $sts = Stop-VM -Name 'TDC_Dependency' -TurnOff
+
+    # Delete New VM created
+    $sts = Remove-VM -Name 'TDC_Dependency' -Confirm:$false -Force
+}
+
+function Run_TDC ([string] $vhd_path, $signcert)
+{	
+    # Make the Template
+	try {
+		Protect-TemplateDisk -Path $vhd_path -TemplateName "Shielded_TDC-Testing" -Version '1.0.0.0' -Certificate $signcert -ProtectedTemplateTargetDiskType 'PreprocessedLinux'
+	}
+	catch {
+		return $false
+	}
+    
+	return $true
+}
+
+function Verify_TDC ([string] $vhd_path, [string]$dep_vhd, [string]$sshKey)
+{
+	# Test dependency VHDx path
+    $sts = Test-Path $dep_vhd
+    if (-not $?) {
+        return $false
+    }
+	
+	# Copy dependency VHDx
+	$dependency_vhd_path = $vhd_path -replace 'TDC','TDC-Dependency'
+	Copy-Item -Path $dep_vhd -Destination $dependency_vhd_path -Force
+    if (-not $?) {
+        return $false
+    }
+	
+	# Make a new VM
+	$newVm = New-VM -Name 'TDC_Dependency' -VHDPath $dependency_vhd_path -MemoryStartupBytes 2048MB -SwitchName 'External' -Generation 1
+	if (-not $?) {
+        return $false
+    }
+	
+	# Attach the test VHDx to the VM
+	$sts = Add-VMHardDiskDrive -VMName 'TDC_Dependency' -ControllerType SCSI -ControllerNumber 0 -ControllerLocation 1 -Path $vhd_path
+	if (-not $?) {
+        return $false
+    }
+	
+	# Start VM and get IP
+	$sts = Start-VM -Name 'TDC_Dependency'
+	$waitTimeOut = 200
+	while ($waitTimeOut -gt 0) {
+		$vmIp = $(Get-VMNetworkAdapter -VMName 'TDC_Dependency' ).IpAddresses
+		if ($vmIp -ne "") {
+			$waitTimeOut = 0
+		}
+		Start-Sleep -s 5
+	}
+	
+	Start-Sleep -s 20
+	$vmIpAddr = $(Get-VMNetworkAdapter -VMName 'TDC_Dependency' ).IpAddresses[0]
+	
+	# Mount the template
+	$sts =  echo y | .\bin\plink.exe -i ssh\$sshKey root@${vmIpAddr} "mkdir lsvmefi && mount /dev/sdb1 lsvmefi"
+	
+	# Check for vsc file and bootos.wim
+	$bootOS = .\bin\plink.exe -i ssh\$sshKey root@${vmIpAddr} "find -name 'bootos.wim'"
+	if ($bootOS -eq $null) {
+		return $false
+	}
+	
+	$vscFile = .\bin\plink.exe -i ssh\$sshKey root@${vmIpAddr} "find -name '*vsc'"
+	if ($vscFile -eq $null) {
+		return $false
+	}
+	
+	# Check for encryption on sdb2 and sdb3
+	$sts = .\bin\plink.exe -i ssh\$sshKey root@${vmIpAddr} "mount /dev/sdb2 /mnt"
+	if ($?) {
+        return $false
+    }
+	
+	$sts = .\bin\plink.exe -i ssh\$sshKey root@${vmIpAddr} "mount /dev/sdb3 /mnt"
+	if ($?) {
+        return $false
+    }
+	
+	return $true
+}
+
+function Copy_vhdx_from_share ([string] $vhd_no_lsvmtools)
+{
+	# Test VHDx path
+    $sts = Test-Path $vhd_no_lsvmtools
+    if (-not $?) {
+        return $false
+    }
+	
+    $defaultVhdPath = $(Get-VMHost).VirtualHardDiskPath
+    if (-not $defaultVhdPath.EndsWith("\")) {
+        $defaultVhdPath += "\"
+    }
+
+	# Make a copy of the encypted VHDx for testing only
+	$destination_vhd_path = $defaultVhdPath + "TDC_no_lsvmtools.vhdx"
+    Copy-Item -Path $vhd_no_lsvmtools -Destination $destination_vhd_path -Force
+    if (-not $?) {
+        return $false
+    }
+    return $destination_vhd_path
+}
+
+function Get_invalid_certificate
+{
+    # Search invalid certificate
+    $thumbprint = ""
+    $certificates = Get-ChildItem -Recurse Cert:\CurrentUser\My
+    foreach ($certificate in $certificates) {
+        if ($certificate.Subject -eq 'CN=Shielded Bad Certificate'){
+            $thumbprint = $certificate.Thumbprint
+            break
+        }
+    }
+
+    # If a certificate was not found, create one. Else, import the existing one
+    if ($thumbprint -eq "") {
+        $signcert = New-SelfSignedCertificate -Type Custom -Subject "CN=Shielded Bad Certificate" `
+		-TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.4") -KeyUsage DataEncipherment `
+		-KeyAlgorithm RSA -KeyLength 1024 -SmimeCapabilities -CertStoreLocation "Cert:\CurrentUser\My"
+    }
+    else {
+        $signcert = Get-Item Cert:CurrentUser\My\$thumbprint       
+    }
+	
+	return $signcert
+}

--- a/WS2012R2/lisa/setupscripts/Shielded_template_prepare.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_template_prepare.ps1
@@ -1,0 +1,105 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+<#
+.Synopsis
+    Setup script that will prepare VM for making a template
+
+.Description
+    This is a cleanup script that will run after the encrypted VM 
+    is shut down.
+    The script will delete the checkpoint and also will check the boot 
+    order and change it to the vhdx file if it's the case
+
+    A typical XML definition for this test case would look similar
+    to the following:
+    <test>
+        <testName>Verify_lsvmprep</testName>
+        <testScript>shielded_verify_lsvmprep.sh</testScript>
+        <files>remote-scripts/ica/shielded_verify_lsvmprep.sh,remote-scripts/ica/utils.sh</files> 
+        <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
+            <file>setupScripts\Shielded_Add_DecryptVHD.ps1</file>
+        </setupScript> 
+        <testParams>
+            <param>TC_COVERED=LSVM-PRE-03</param>
+        </testParams>
+        <cleanupScript>
+            <file>setupScripts\Shielded_Remove_DecryptVHD.ps1</file>
+            <file>setupScripts\Shielded_template_prepare.ps1</file>
+        </cleanupScript>
+        <timeout>600</timeout>
+        <onError>Abort</onError>
+        <noReboot>False</noReboot>
+    </test>
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+
+############################################################################
+#
+# Main script
+#
+############################################################################
+
+# Check input arguments
+if ($vmName -eq $null -or $vmName.Length -eq 0) {
+    "Error: VM name is null"
+    return $false
+}
+
+if ($hvServer -eq $null -or $hvServer.Length -eq 0) {
+    "Error: hvServer is null"
+    return $false
+}
+
+if ($testParams -eq $null -or $testParams.Length -lt 3) {
+    "Error: No testParams provided"
+    "Shielded_Add_decryptVHD.ps1 requires test params"
+    return $false
+}
+
+# Remove snapshot
+Remove-VMSnapshot -vmName $vmName -ComputerName $hvServer -Name 'ICABase'
+if (-not $?) {
+    "Error: Failed to delete the snapshot ICABase"
+    return $false
+}
+Start-Sleep -s 20
+
+# Get boot vhdx
+$bootDrive = Get-VMHardDiskDrive -vmName $vmName -ComputerName $hvServer -ControllerLocation 0 -ControllerNumber 0 -ControllerType 'SCSI'
+
+# Check boot order
+$bootOrder = $(Get-VMFirmware -vmName $vmName -ComputerName $hvServer).BootOrder
+if ($bootOrder[0].BootType -eq 'File') {
+    "Changing first boot option to vhdx"
+    
+    # Set first boot device to above vhdx
+    Set-VMFirmware -vmName $vmName -ComputerName $hvServer -FirstBootDevice $bootDrive
+}
+
+# Make a copy of the vhdx
+$pre_tdc_vhdx_location = $bootDrive.Path
+$tdc_vhdx_location = $pre_tdc_vhdx_location -replace 'PRE-',''
+Copy-Item -Path $pre_tdc_vhdx_location -Destination $tdc_vhdx_location -Force
+
+return $true

--- a/WS2012R2/lisa/xml/Shielded_PreTDC.xml
+++ b/WS2012R2/lisa/xml/Shielded_PreTDC.xml
@@ -48,8 +48,11 @@
                 <suiteTest>Verify_dependencies</suiteTest>
                 <suiteTest>Verify_lsvmprep</suiteTest>
                 <suiteTest>Verify_not_encrypted</suiteTest>
-                <suiteTest>Verify_passphrase</suiteTest> 
-                <suiteTest>Verify_insufficient_space</suiteTest> 
+                <suiteTest>Verify_passphrase</suiteTest>
+                <suiteTest>Verify_insufficient_space</suiteTest>
+
+                <!-- Post testing preparation -->
+                <suiteTest>Prepare_VM_for_TDC</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -173,6 +176,26 @@
                 <param>fill_disk=yes</param>
             </testParams>
             <cleanupScript>setupScripts\Shielded_Remove_DecryptVHD.ps1</cleanupScript>
+            <timeout>600</timeout>
+            <onError>Abort</onError>
+            <noReboot>False</noReboot>
+        </test>
+
+        <test>
+            <testName>Prepare_VM_for_TDC</testName>
+            <testScript>shielded_verify_lsvmprep.sh</testScript>
+            <files>remote-scripts/ica/shielded_verify_lsvmprep.sh,remote-scripts/ica/utils.sh</files> 
+            <setupScript>
+                <file>setupscripts\RevertSnapshot.ps1</file>
+                <file>setupScripts\Shielded_Add_DecryptVHD.ps1</file>
+            </setupScript> 
+            <testParams>
+                <param>TC_COVERED=LSVM-Prepare_TDC</param>
+            </testParams>
+            <cleanupScript>
+                <file>setupScripts\Shielded_Remove_DecryptVHD.ps1</file>
+                <file>setupScripts\Shielded_template_prepare.ps1</file>
+            </cleanupScript>
             <timeout>600</timeout>
             <onError>Abort</onError>
             <noReboot>False</noReboot>


### PR DESCRIPTION
>>These are test scripts that must be used with pester -
Tests included:
--LSVM-TDC-01: Run the TDC wizard with a Linux VHDX file.
--LSVM-TDC-02: Verify the output LSVM VHDX file from the TDC Wizard.
--LSVM-TDC-03: Verify a VHDX file that has not had lsvmprep run fails
TDC
--LSVM-TDC-04: Test TDC using Linux VHDX file and an invalid certificate

>>Also added post testing preparation for TDC 
TDC needs the VM to be corectly configured - no checkpoints and first boot option
set to hard drive. A copy of the vhdx is also made for later use.