### PR TITLE
Shielded VMs testing: Added dependency file

### DIFF
--- a/WS2012R2/lisa/Infrastructure/Windows_unattend_file.xml
+++ b/WS2012R2/lisa/Infrastructure/Windows_unattend_file.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+
+<!-- Autounattend_x64-UEFI_sample.xml 
+
+This file automates the Windows installation. 
+
+     Before using this file:
+      * Replace ProductKey with a product key for the edition of Windows you are installing
+        (example: Windows 8 Pro)
+        Note:
+           The product key used in Microsoft-Windows-Setup\UserData\ProductKey\Key 
+           can be used many times in different installations and is not used to activate Windows. 
+           It is only used to choose which edition of Windows to install. 
+           
+           The individual product key is either specified by the user, or by setting 
+           Microsoft-Windows-Shell-Setup\ProductKey.
+     * Set the default language to your own:
+       Replace "en-US" with your language code in Microsoft-Windows-International-Core-WinPE\SetupUILanguage. 
+       For a list of languages, see http://go.microsoft.com/fwlink/?LinkId=206620.
+     * OEMs: Replace OEMInformation with your support information
+
+     To use this file: 
+        Save this file on the root of a USB flash drive with the filename: Autounattend.xml
+        Put the Windows DVD and the USB key into a new x64-UEFI PC.
+-->
+
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <Manufacturer>[ REPLACE WITH COMPANY NAME ]</Manufacturer>
+                <SupportURL>[ REPLACE WITH SUPPORT WEBSITE ]</SupportURL>
+            </OEMInformation>
+        </component>
+    </settings>
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <CreatePartitions>
+                        <!-- Windows RE Tools partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Size>300</Size>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+
+                        <!-- System partition (ESP) -->
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Size>100</Size>
+                            <Type>EFI</Type>
+                        </CreatePartition>
+
+                        <!-- Microsoft reserved partition (MSR) -->
+                        <CreatePartition wcm:action="add">
+                            <Order>3</Order>
+                            <Size>128</Size>
+                            <Type>MSR</Type>
+                        </CreatePartition>
+
+                        <!-- Windows partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>4</Order>
+                            <Extend>true</Extend> 
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                    </CreatePartitions>
+
+                    <ModifyPartitions>
+                        <!-- Windows RE Tools partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Label>WINRE</Label>
+                            <Format>NTFS</Format>
+                            <TypeID>de94bba4-06d1-4d40-a16a-bfd50179d6ac</TypeID>
+                        </ModifyPartition>
+
+                        <!-- System partition (ESP) -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                            <Label>System</Label>
+                            <Format>FAT32</Format>
+                        </ModifyPartition>
+
+                        <!-- Microsoft reserved partition (MSR) -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>3</Order>
+                            <PartitionID>3</PartitionID>
+                        </ModifyPartition>
+
+                        <!-- Windows partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>4</Order>
+                            <PartitionID>4</PartitionID>
+                            <Label>Windows</Label>
+                            <Format>NTFS</Format>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                </Disk>
+                <WillShowUI>OnError</WillShowUI>
+            </DiskConfiguration>
+            <ImageInstall>
+                <OSImage>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>4</PartitionID>
+                    </InstallTo>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <ProductKey>
+                    <WillShowUI>OnError</WillShowUI>
+                    <Key>[ REPLACE WITH PRODUCT KEY ]</Key>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+            </UserData>
+        </component>
+    </settings>
+</unattend>

--- a/WS2012R2/lisa/setupscripts/Shielded_TDC.Tests.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_TDC.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Verify the output LSVM VHDX file from the TDC Wizard" {
             Verify_TDC $vhdPath $dependencyVhdPath $sshKey | Should be $true
 			
 			# Clean the dependency VM
-			CleanupDependency
+			CleanupDependency 'TDC_Dependency'
         }
     } 
 }

--- a/WS2012R2/lisa/setupscripts/Shielded_TDC.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_TDC.ps1
@@ -69,13 +69,13 @@ function Get_Certificate
     return $signcert
 }
 
-function CleanupDependency
+function CleanupDependency ([string]$vmName)
 {
     # Clean up
-    $sts = Stop-VM -Name 'TDC_Dependency' -TurnOff
+    $sts = Stop-VM -Name $vmName -TurnOff
 
     # Delete New VM created
-    $sts = Remove-VM -Name 'TDC_Dependency' -Confirm:$false -Force
+    $sts = Remove-VM -Name $vmName -Confirm:$false -Force
 }
 
 function Run_TDC ([string] $vhd_path, $signcert)


### PR DESCRIPTION
Windows unattend install file was added. This is needed for creating the
PDK file. It also can be found here:
https://technet.microsoft.com/en-us/library/cc732280(v=ws.10).aspx
Small code change - Replaced hardcoded VM name with a variable.