### PR TITLE
Shielded VMs testing: Added Deployed VMs test cases

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_UpgradeKernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_UpgradeKernel.sh
@@ -44,6 +44,8 @@ if is_fedora ; then
 
 elif is_ubuntu ; then
 	DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+	new_kernel=$(dpkg --list | grep linux-image | awk {'print $2'} | head -1 | sed "s/linux-image-//")
+	apt-get install -y linux-cloud-tools-common linux-tools-$new_kernel linux-cloud-tools-$new_kernel
 
 elif is_suse ; then
 	zypper --non-interactive dist-upgrade

--- a/WS2012R2/lisa/remote-scripts/ica/shielded_deployed_functions.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/shielded_deployed_functions.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+# Description:
+#   Functions for Deployed Shielded VMs test cases
+########################################################################
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+UpgradeBootComponent()
+{
+	GetDistro
+    case "$DISTRO" in
+        suse*)
+            zypper --non-interactive in grub2
+            if [ $? -ne 0 ]; then
+                msg="ERROR: Failed to install grub2"
+                LogMsg "$msg"
+                UpdateSummary "$msg"
+                SetTestStateFailed
+                exit 1
+        	else
+            	SetTestStateCompleted
+            fi
+            ;;
+        ubuntu*)
+            apt-get install grub -y
+            if [ $? -ne 0 ]; then
+                msg="ERROR: Failed to install grub2"
+                LogMsg "$msg"
+                UpdateSummary "$msg"
+                SetTestStateFailed
+                exit 1
+            else
+            	SetTestStateCompleted
+            fi
+            ;;
+        redhat*|centos*)
+            yum install grub2 -y
+            if [ $? -ne 0 ]; then
+                msg="ERROR: Failed to install grub2"
+                LogMsg "$msg"
+                UpdateSummary "$msg"
+                SetTestStateFailed
+                exit 1
+        	else
+            	SetTestStateCompleted
+            fi
+            ;;
+        *)
+            msg="ERROR: OS Version not supported"
+            LogMsg "$msg"
+            UpdateSummary "$msg"
+            SetTestStateFailed
+            exit 1
+        ;;
+    esac
+}
+
+AddSerial ()
+{
+	GetDistro
+    case "$DISTRO" in
+        suse*)
+            boot_filepath="/boot/grub2/grub.cfg"
+            ;;
+        ubuntu*)
+            boot_filepath="/boot/grub/grub.cfg"
+            ;;
+        redhat*|centos*)
+            boot_filepath="/boot/efi/EFI/redhat/grub.cfg"
+            ;;
+        *)
+            msg="ERROR: OS Version not supported"
+            LogMsg "$msg"
+            UpdateSummary "$msg"
+            SetTestStateFailed
+            exit 1
+        ;;
+    esac
+
+    sed -i "/vmlinuz-`uname -r`/ s/$/ console=tty0 console=ttyS1/" $boot_filepath
+    if [ $? -ne 0 ]; then
+        msg="ERROR: Failed to modify grub"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 1
+	else
+    	SetTestStateCompleted
+    fi
+}

--- a/WS2012R2/lisa/setupscripts/Shielded_DEP.Tests.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_DEP.Tests.ps1
@@ -1,0 +1,466 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+#
+# Linux Deployed Shielded VMs pester tests
+#
+
+Param(    
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'Share location')]
+    [ValidateNotNullorEmpty()]
+    [String]$sharePath,
+    
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'User name which has access to share')]
+    [ValidateNotNullorEmpty()]
+    [String]$shareUser,
+    
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'Account password which has access to share')]
+    [ValidateNotNullorEmpty()]
+    [String]$sharePassword,
+    
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'SSH key to access the VM')]
+    [ValidateNotNullorEmpty()]
+    [String]$sshKey,
+    
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'VHD that will be used to create a dependency VM')]
+    [ValidateNotNullorEmpty()]
+    [String]$dependencyVhdPath
+)
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+
+# Import Shielded_TDC.ps1; It cointains a couple of functions we can re-use
+if (Test-Path ".\setupScripts\Shielded_TDC.ps1") {
+    . .\setupScripts\Shielded_TDC.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\Shielded_TDC.ps1"
+    return $false
+}
+
+# Import Shielded_PRO.ps1
+if (Test-Path ".\setupScripts\Shielded_PRO.ps1") {
+    . .\setupScripts\Shielded_PRO.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\Shielded_PRO.ps1"
+    return $false
+}
+
+# Import TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+    . .\setupScripts\TCUtils.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+Describe "Preparation tasks for Deployed Shielded VMs testing"{
+    Context "1. Copy template and PDK from share
+            2. Provison a test VM
+            3. Turn off the VM and take a snapshot" {
+        It "Running LSVM-DEP-Preparation" {
+            # Copy VHDx from share
+            Copy_template_from_share $sharePath | Should be $true
+
+            # Make a local copy for DEP test  suite
+            Copy-Item -Path $test_vhd_path -Destination $dep_vhd_path -Force -EA SilentlyContinue
+            $? | Should be $true
+
+            # Copy PDK file from share
+            Copy-Item -Path $(Get-ChildItem $sharePath -Filter *.pdk).FullName -Destination $dep_pdk_path -Force -EA SilentlyContinue
+            $? | Should be $true
+
+            # Provision the VM
+            Provision "LSVM_Dep_Test" | Should be $false
+
+            # Check if the deployed VM has booted
+            $vm_ipv4 = GetDEP_ipv4 "LSVM_Dep_Test"
+            $vm_ipv4 | Should not Be $null
+
+            TakeSnapshot "LSVM_Dep_Test" | Should be $true
+        }
+    }
+}
+
+Describe "Update the kernel on a LSVM and verify the VM continues to boot successfully" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots.
+            3.  Run a distro specific command to update the kernel.
+            4.  Verify the kernel packages were update successfully.
+            5.  Reboot the VM" {
+
+        It "Running LSVM-DEP-01" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Check if the deployed VM has booted
+            $ipv4 = GetDEP_ipv4 "LSVM_Dep_Test"
+            $ipv4 | Should not Be $null
+
+            # Send utils.sh to VM
+            SendFile $ipv4 $sshKey 'utils.sh' | Should be $true
+
+            # Run the test script and wait for the results
+            RunScript $ipv4 $sshKey 'SR-IOV_UpgradeKernel.sh' | Should be $true
+
+            # Compare kernels
+            CompareKernels $ipv4 $sshKey "LSVM_Dep_Test" | Should be $true
+        }
+    }
+}
+
+Describe "Update a boot component on a LSVM and verify the VM boots successfully" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots.
+            3.  Run a distro specific command to update one of the boot components.
+            4.  Reboot the VM." {
+        
+        It "Running LSVM-DEP-02" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Check if the deployed VM has booted
+            $ipv4 = GetDEP_ipv4 "LSVM_Dep_Test"
+            $ipv4 | Should not Be $null
+
+            # Send utils.sh to VM
+            SendFile $ipv4 $sshKey 'utils.sh' | Should be $true
+
+            # Send shielded_deployed_functions.sh to VM
+            SendFile $ipv4 $sshKey 'shielded_deployed_functions.sh' | Should be $true
+
+            # Run the test script
+            UpgradeGrub $ipv4 $sshKey "LSVM_Dep_Test" | Should be $true
+        }
+    } 
+}
+
+Describe "Clone a Linux Shielded VM VHDX and confirm it fails to boot" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots.
+            3.  Shutdown a function Linux Shielded VM.
+            4.  Make a copy of the Linux Shielded VMs VHDX file.
+            5.  On the same host, create a new Gen 2 VM with Secure boot enabled, and a vTPM.
+            6.  Use the copied VHDX file as the boot disk of the VM created in step 3.
+            7.  Boot the new VM." {
+        
+        It "Running LSVM-DEP-03" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Make a copy of the vhd used to provision the vm
+            CopyVHD "LSVM_Dep_Test" | Should be $true
+
+            # Make a VHD clone and attach it to the provisioned VM
+            ClonedVHD $sshKey "LSVM_Dep_Test" | Should be $false
+
+            # Clean VM
+            CleanupDependency 'LSVM_Dep_Test_Clone'
+        }
+    }
+}
+
+Describe "Verify well known DMCrypt/LUKS passwords no longer work" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+        2.  Verify the VM boots.
+        3.  Shutdown the VM.
+        4.  Make a copy of the VHDX file from the VM in step 1.
+        5.  Using a second Linux VM (non-shielded VM), connect the copied VHDX file as a data disk.
+        6.  In the second Linux VM, try to mount the boot/root partition using well-known passphrase." {
+        
+        It "Running LSVM-DEP-04" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Make a copy of the vhd used to provision the vm
+            CopyVHD "LSVM_Dep_Test" | Should be $true
+
+            # Create a Dependency VM
+            $vm_ipv4 = DependencyVM $dependencyVhdPath 
+            $vm_ipv4 | Should not be $null
+
+            VerfifyPassphrase $sshKey $vm_ipv4 | Should be $true
+
+            # Clean VM
+            CleanupDependency 'LSVM_Dependency'
+        }
+    }
+}
+
+Describe "Upgrade MBLoad to a newer version" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Install an updated version of the LSVMTools package.
+            4.  Run the utility to upgrade MBLoad.
+            5.  Reboot the VM." {
+        
+        It "Running LSVM-DEP-05" -Pending {
+
+        }
+    }
+}
+
+Describe "Downgrade MBLoad to an older version." {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Install an older version of the LSVMTools package.
+            4.  Run the utility to ‘upgrade’ the MBLoad.
+            5.  Reboot the VM." {
+        
+        It "Running LSVM-DEP-06" -Pending {
+
+        }
+    }
+}
+
+Describe "Live Migrate a LSVM" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Migrate the Linux Shielded VM to another Hyper-V host in the same HGS fabric.
+            4.  Reboot the VM two or more times after it has been migrated." {
+        
+        It "Running LSVM-DEP-07" -Pending {
+
+        }
+    }
+}
+
+Describe "Export/Import a LSVM" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Export the VM to a shared directory.
+            4.  On a separate Hyper-V host, import the exported VM." {
+        
+        It "Running LSVM-DEP-08" -Pending {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            ExportVM "LSVM_Dep_Test" | Should be $true
+
+        }
+    }
+}
+
+Describe "Online Backup/Restore a data disk on a Linux Shielded VM" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Add an additional disk drive to the VM.  This will be referred to as the data disk.
+            4.  Add some files to the data disk.
+            5.  Perform an online backup of the data disk.
+            6.  Create an additional file on the data disk.
+            7.  Modify the contents of an existing file on the data disk.
+            8.  Restore the data disk from the backup created in step 5." {
+        
+        It "Running LSVM-DEP-09" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Create a data disk
+            CreateDataDisk "LSVM_Dep_Test" $sshKey | Should be $true
+
+            # Backup the VM
+            BackupVM "LSVM_Dep_Test" "F:" | Should be $true
+
+            # Write additional data
+            WriteDataOnVM "LSVM_Dep_Test" $sshKey  "echo 'Second' > dataDisk/secondFile" | Should be $true
+            WriteDataOnVM "LSVM_Dep_Test" $sshKey  "echo 'Test' > dataDisk/firstFile" | Should be $true
+
+            # Restore VM
+            RestoreVM | Should be $true
+
+            # Check VM
+            CheckRestoreStatus $sshKey 'yes' 'dataDisk/secondFile' 'Second' | Should be $true
+            CheckRestoreStatus $sshKey 'yes' 'dataDisk/firstFile' 'Test' | Should be $true
+
+            # Clean Backup
+            BackupClean | Should be $true
+        }
+    }
+}
+
+Describe "Online Backup, then Restore the system disk of a Linux Shielded VM" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Perform an online backup of the system disk.
+            4.  Create an additional file on the system disk
+            5.  Modify the contents of an existing file.
+            6.  Shutdown the VM.
+            7.  Restore the system disk from the backup created in step 3.
+            8.  Boot the VM." {
+        
+        It "Running LSVM-DEP-10" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Write data
+            WriteDataOnVM "LSVM_Dep_Test" $sshKey "echo 'First' > firstFile" | Should be $true
+            
+            # Backup the VM
+            BackupVM "LSVM_Dep_Test" "F:" | Should be $true
+
+            # Write additional data
+            WriteDataOnVM "LSVM_Dep_Test" $sshKey  "echo 'Test' > secondFile" | Should be $true
+            WriteDataOnVM "LSVM_Dep_Test" $sshKey  "echo 'Test' > firstFile" | Should be $true
+
+            # Restore VM
+            RestoreVM | Should be $true
+
+            # Check VM
+            CheckRestoreStatus $sshKey 'no' 'secondFile' 'Test' | Should be $true
+            CheckRestoreStatus $sshKey 'no' 'firstFile' 'Test' | Should be $true
+
+            # Clean Backup
+            BackupClean | Should be $true
+        }
+    }
+}
+
+Describe "Use Backup to restore the system disk to an older version of MBLoad" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Perform a backup of the system disk.
+            4.  Install an upgraded LSVMTools package and update MBLoad.
+            5.  Verify the VM continues to boot.
+            6.  Create a new file on the system disk
+            7.  Restore the system disk from the backup created in step 3.
+            8.  Reboot the VM." {
+        
+        It "Running LSVM-DEP-11" -Pending{
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+            
+            # Backup the VM
+            BackupVM "LSVM_Dep_Test" "F:" | Should be $true
+
+            # Write additional data & upgrade LSVMTools
+            WriteDataOnVM "LSVM_Dep_Test" $sshKey  "echo 'Test' > firstFile" | Should be $true
+
+            # Restore VM
+            RestoreVM | Should be $true
+
+            # Check VM
+            CheckRestoreStatus $sshKey 'no' 'firstFile' 'Test' | Should be $true
+
+            # Clean Backup
+            BackupClean | Should be $true
+        }
+    }
+}
+
+Describe "Add COM port to LSVM" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Shutdown the VM.
+            4.  Use the PowerShell cmdlet Set-VMComPort to add/configure a COM port to the VM." {
+        
+        It "Running LSVM-DEP-12" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Check if the deployed VM has booted
+            $ipv4 = GetDEP_ipv4 "LSVM_Dep_Test"
+            $ipv4 | Should not Be $null
+
+            # Send utils.sh to VM
+            SendFile $ipv4 $sshKey 'utils.sh' | Should be $true
+
+            # Send shielded_deployed_functions.sh to VM
+            SendFile $ipv4 $sshKey 'shielded_deployed_functions.sh' | Should be $true
+
+            # Make necessary grub config
+            ModifyGrub $ipv4 $sshKey "LSVM_Dep_Test" | Should be $true
+
+            AddComPort "LSVM_Dep_Test" | Should be $true
+        }
+    }
+}
+
+Describe "Attack a VHDX file of a functioning LSVM" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Shutdown the VM.
+            4.  Make a copy the VHDX file from the Linux Shielded VM created in step 1.
+            5.  Add the copied VHDX file as a data disk to a separate existing Linux VM.
+            6.  Mount the EFI partition from the copied VHDX file in the second Linux VM.
+            7.  Replace MBLoad in the EFI partition with Grub.
+            8.  Copy the grub.cfg to the same directory.
+            9.  Unmount the VHDX file from the second VM.
+            10. Replace the LSVMs boot disk with the modified VHDX file.
+            11. Boot the VM." {
+        
+        It "Running LSVM-DEP-13" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Make a copy of the vhd used to provision the vm
+            CopyVHD "LSVM_Dep_Test" | Should be $true
+
+            # Create a Dependency VM
+            $vm_ipv4 = DependencyVM $dependencyVhdPath 
+            $vm_ipv4 | Should not be $null
+
+            # Make the changes to the cloned VHDx
+            ModifyBoot $vm_ipv4 $sshKey "LSVM_Dep_Test" | Should be $true
+        }
+    }
+}
+
+Describe "Replicate a LSVM to a different host which uses the same HGS" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Replicate the VM to a different Hyper-V host which is using the same HGS that the original Hyper-V host is using.
+            4.  Boot the VM." {
+        
+        It "Running LSVM-DEP-14" -Pending{
+
+        }
+    }
+}
+
+Describe "VHD recovery with LSVM recovery key" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Shutdown the VM.
+            4.  Make a copy of the VMs VHDX file.
+            5.  Copy the VHDX file to a separate Hyper-V host.
+            6.  Using a Linux VM on the separate Hyper-V host, and attach the VHDX file as a data disk to the VM.
+            7.  Boot the Linux VM.
+            8.  Use the LSVM recovery key to recover the boot partition and root partition passphrases.
+            9.  Mount the boot partition.
+            10. Mount the root partition." {
+        
+        It "Running LSVM-DEP-15" -Pending{
+
+        }
+    }
+}
+
+Describe "Disable Secure Boot and verify Linux Shielded VM fails to boot" {
+    Context "1. Create a Linux Shielded VM from a known good template.
+            2.  Verify the VM boots successfully.
+            3.  Shutdown theVM.
+            4.  Disable Secure Boot for the VM.
+            5.  Boot the VM." {
+        
+        It "Running LSVM-DEP-16" {
+            ApplySnapshot "LSVM_Dep_Test" | Should be $true
+
+            # Disable SecureBoot
+            DisableSecureBoot "LSVM_Dep_Test" | Should be $true
+
+            # Disable SecureBoot
+            CleanupDependency "LSVM_Dep_Test"
+        }
+    }
+}

--- a/WS2012R2/lisa/setupscripts/Shielded_DEP.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_DEP.ps1
@@ -1,0 +1,681 @@
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+#
+# Linux Deployed Shielded VMs automation functions
+#
+
+# Import TCUtils.ps1
+if (Test-Path ".\setupScripts\TCUtils.ps1") {
+    . .\setupScripts\TCUtils.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\TCUtils.ps1"
+    return $false
+}
+
+# Import NET_Utils.ps1
+if (Test-Path ".\setupScripts\NET_UTILS.ps1") {
+    . .\setupScripts\NET_UTILS.ps1
+}
+else {
+    "ERROR: Could not find setupScripts\NET_UTILS.ps1"
+    return $false
+}
+
+function Provision ([string] $VMName)
+{
+    $hasErrors = $false
+    $sts_folder = Remove-Item -Recurse -Force -Path $VMPath -EA SilentlyContinue
+    $sts_folder = New-Item -ItemType directory -Path $VMPath
+
+    New-ShieldedVMSpecializationDataFile -ShieldedVMSpecializationDataFilePath $fskfile -SpecializationDataPairs @{ '@ComputerName@' = "$VMName"; '@TimeZone@' = 'Pacific Standard Time' }
+    Copy-Item -Path $dep_vhd_path -Destination $VmVhdPath -Force
+
+    # Create VM
+    $vm = New-VM -Name $VMName -Generation 2 -VHDPath $VmVhdPath -MemoryStartupBytes 2GB -Path $VMPath -SwitchName 'External' -erroraction Stop
+    Start-Sleep -s 5 
+    Set-VMFirmware -VM $vm -SecureBootTemplate OpenSourceShieldedVM
+
+    $kp = Get-KeyProtectorFromShieldingDataFile -ShieldingDataFilePath $dep_pdk_path
+    $sts_vmkp = Set-VMkeyProtector -VM $vm -KeyProtector $kp
+
+    # Get PDK security policy
+    $importpdk = Invoke-CimMethod -ClassName  Msps_ProvisioningFileProcessor -Namespace root\msps -MethodName PopulateFromFile -Arguments @{FilePath=$dep_pdk_path }
+    $cimvm = Get-CimInstance  -Namespace root\virtualization\v2 -Class Msvm_ComputerSystem -Filter "ElementName = '$VMName'"
+     
+    $vsd = Get-CimAssociatedInstance -InputObject $cimvm -ResultClassName "Msvm_VirtualSystemSettingData"
+    $vmms = gcim -Namespace root\virtualization\v2 -ClassName Msvm_VirtualSystemManagementService
+    $ssd = Get-CimAssociatedInstance -InputObject $vsd -ResultClassName "Msvm_SecuritySettingData"
+    $ss = Get-CimAssociatedInstance -InputObject $cimvm -ResultClassName "Msvm_SecuritySErvice"
+    $cimSerializer = [Microsoft.Management.Infrastructure.Serialization.CimSerializer]::Create()
+    $ssdString = [System.Text.Encoding]::Unicode.GetString($cimSerializer.Serialize($ssd, [Microsoft.Management.Infrastructure.Serialization.InstanceSerializationOptions]::None))
+    $result = Invoke-CimMethod -InputObject $ss -MethodName SetSecurityPolicy -Arguments @{"SecuritySettingData"=$ssdString;"SecurityPolicy"=$importPdk.ProvisioningFile.PolicyData}
+     
+    # Initialize Shileded VM
+    $sts_vmtpm = Enable-VMTPM -vm $vm
+    $sts_init = Initialize-ShieldedVM -VM $vm -ShieldingDataFilePath $dep_pdk_path -ShieldedVMSpecializationDataFilePath $fskfile -EA SilentlyContinue
+    if (-not $?){
+        $hasErrors = $true
+    }
+
+    # Wait for provisioning completion
+    $provisionComplete = $false
+    while (-not $provisionComplete) {
+        # The Get-ShieldedVMProvisioningStatus cmdlet can throw errors if it completes provisioning quickly and the job CIM is gone
+        $status = Get-ShieldedVMProvisioningStatus -VM $vm -ErrorAction SilentlyContinue
+        if ($status -eq $null) {
+            $event = Get-winevent -logname *shield* |? {$_.Id -eq 407}
+            if ($event -eq $null) {
+                $hasErrors = $true
+            }
+            $provisionComplete = $true
+        }
+        elseif ($status.PercentComplete -eq 100) {
+            Write-Host $status
+            $provisionComplete = $true
+            if ($status.JobState -eq 10) {
+                Write-Error "The provisioning session is complete, but failed to provision the VM."
+                $hasErrors = $true
+            }
+
+            # Find event
+            Start-Sleep -Seconds 5
+            $event = Get-winevent -logname *shield* |? {$_.Id -eq 407}
+            if ($event -eq $null) {
+                Write-Error "Shielded VM Event 407 (denotes a successful shielded VM provision) is not present"
+                $hasErrors = $true
+            }
+        }
+        elseif ($status.ErrorCode -ne 0) {
+            Write-Error ("Error found with code " + $status.ErrorCode)
+            $errorCode = $status.ErrorCode
+            Write-Error $status.ErrorDescription
+            $hasErrors = $true
+            $provisionComplete = $true
+        }
+        else {
+            Write-Host ("Percent complete: " + $status.PercentComplete)
+            Write-Host ($status.Jobstatus)
+            Write-Host "Sleeping for 30 seconds"
+            Start-Sleep -Seconds 30
+        }
+    }
+
+    return $hasErrors
+}
+
+function GetDEP_ipv4 ([string] $VMName)
+{
+    $waitTimeOut = 200
+    while ($waitTimeOut -gt 0) {
+        $vmIp = $(Get-VMNetworkAdapter -VMName $VMName).IpAddresses
+        if ($vmIp -ne "") {
+            $waitTimeOut = 0
+        }
+        Start-Sleep -s 5
+    }
+    Start-Sleep -s 20
+    $vmIpAddr = $(Get-VMNetworkAdapter -VMName $VMName).IpAddresses[0]
+    return $vmIpAddr
+}
+
+function TakeSnapshot ([string] $VMName)
+{
+    if ((Get-VM -Name $VMName).State -ne "Off") {
+        Stop-VM -Name $VMName -Force -Confirm:$false
+    }
+
+    Start-Sleep -s 5
+    Checkpoint-VM -Name  $VMName -SnapshotName 'Deployed'
+    if (-not $?) {
+        return $false
+    }
+
+    return $true
+}
+
+function ApplySnapshot ([string] $VMName)
+{
+    if ((Get-VM -Name $VMName).State -ne "Off") {
+        Stop-VM -Name $VMName -Force -Confirm:$false
+        Start-Sleep -s 5
+    }
+
+    $snap = Get-VMSnapshot -VMName $VMName -Name 'Deployed'
+
+    Restore-VMSnapshot $snap -Confirm:$false
+    if ($? -ne "True") {
+        return $false
+    }
+    else {
+        Start-VM $VMName
+        WaitForVMToStartKVP $VMName 'localhost' 150
+        return $true
+    } 
+}
+
+function SendFile ([string] $ipv4, [string] $sshKey, [string] $fileName)
+{
+    $retVal = SendFileToVM $ipv4 $sshKey ".\remote-scripts\ica\$fileName" "/root/$fileName"
+    $retVal = SendCommandToVM $ipv4 $sshKey "cd /root && dos2unix $fileName && chmod u+x $fileName"
+    return $retVal
+}
+
+function RunScript ([string] $ipv4, [string] $sshKey, [string] $fileName)
+{
+    $sts = RunRemoteScript $fileName
+    return $sts[-1]
+}
+
+function RestartVM ([string] $vmName)
+{
+    Restart-VM -VMName $vmName -Force
+    $timeout = 200
+    if (-not (WaitForVMToStartKVP $vmName 'localhost' $timeout )){
+        return $false
+    }
+
+    Start-Sleep -s 15
+    # Get the ipv4, maybe it may change after the reboot
+    $ipv4 = GetIPv4 $vmName 'localhost'
+    Write-Host "${vmName} IP Address after reboot: ${ipv4}"
+
+    return $ipv4
+}
+
+function CompareKernels ([string] $ipv4, [string] $sshKey, [string] $vmName)
+{
+    # Get the actual kernel version
+    $old_kernel_verion = check_kernel
+    Write-Host $old_kernel_verion
+
+    # Restart VM
+    $ipv4 =  RestartVM $vmName
+    Write-Host $ipv4
+
+    # Get the new kernel version
+    $new_kernel_verion = check_kernel
+    Write-Host $new_kernel_verion
+
+    # Check if kernel version is different
+    if ($old_kernel_verion -ne $new_kernel_verion) {
+        return $true
+    }
+    else {
+        return $false
+    }
+}
+
+function UpgradeGrub ([string] $ipv4, [string] $sshKey, [string] $vmName)
+{
+    # Update grub
+    $retVal = SendCommandToVM $ipv4 $sshKey ". shielded_deployed_functions.sh && UpgradeBootComponent && cat state.txt"
+    if (-not $retVal) {
+        return $false
+    }
+    # Check status
+    $state = .\bin\plink.exe -i ssh\$sshKey root@$ipv4 "cat state.txt"
+    if ($state -ne "TestCompleted") {
+        return $false
+    }
+
+    # Restart VM
+    $ipv4 = ""
+    $ipv4 =  RestartVM $vmName
+    if ($ipv4 -eq "") {
+        return $false
+    }
+
+    return $true
+}
+
+function CopyVHD ([string] $VMName)
+{
+    if ((Get-VM -Name $VMName).State -ne "Off") {
+        Stop-VM -Name $VMName -Force -Confirm:$false
+        Start-Sleep -s 5
+    }
+
+    # Get parent VHD
+    $parent = GetParentVHD $VMName 'localhost'
+
+    # Make a copy
+    $parent_clone = $parent -replace '.vhdx','_Clone.vhdx'
+
+    Copy-Item -Path $parent -Destination $parent_clone -Force
+    if (-not $?) {
+        return $false
+    }
+    Write-Host $parent_clone
+    Set-Variable -Name 'parentClone' -Value $parent_clone -Scope Global
+    return $true
+}
+
+function ClonedVHD ([string] $sshKey, [string] $VMName)
+{
+    # Make a new Gen2 VM
+    $VMName_clone = $vmName + "_Clone"
+    New-ShieldedVMSpecializationDataFile -ShieldedVMSpecializationDataFilePath $fskfile -SpecializationDataPairs @{ '@ComputerName@' = "$VMName_clone"; '@TimeZone@' = 'Pacific Standard Time' }
+    $vm = New-VM -Name $VMName_clone -Generation 2 -VHDPath $parentClone -MemoryStartupBytes 1GB -Path $VMPath
+    Set-VMFirmware -VM $vm -SecureBootTemplate OpenSourceShieldedVM
+
+    $kp = Get-KeyProtectorFromShieldingDataFile -ShieldingDataFilePath $dep_pdk_path
+    $sts_vmkp = Set-VMkeyProtector -VM $vm -KeyProtector $kp
+
+    # Get PDK security policy
+    $importpdk = Invoke-CimMethod -ClassName  Msps_ProvisioningFileProcessor -Namespace root\msps -MethodName PopulateFromFile -Arguments @{FilePath=$dep_pdk_path }
+    $cimvm = Get-CimInstance  -Namespace root\virtualization\v2 -Class Msvm_ComputerSystem -Filter "ElementName = '$VMName_clone'"
+     
+    $vsd = Get-CimAssociatedInstance -InputObject $cimvm -ResultClassName "Msvm_VirtualSystemSettingData"
+    $vmms = gcim -Namespace root\virtualization\v2 -ClassName Msvm_VirtualSystemManagementService
+    $ssd = Get-CimAssociatedInstance -InputObject $vsd -ResultClassName "Msvm_SecuritySettingData"
+    $ss = Get-CimAssociatedInstance -InputObject $cimvm -ResultClassName "Msvm_SecuritySErvice"
+    $cimSerializer = [Microsoft.Management.Infrastructure.Serialization.CimSerializer]::Create()
+    $ssdString = [System.Text.Encoding]::Unicode.GetString($cimSerializer.Serialize($ssd, [Microsoft.Management.Infrastructure.Serialization.InstanceSerializationOptions]::None))
+    $result = Invoke-CimMethod -InputObject $ss -MethodName SetSecurityPolicy -Arguments @{"SecuritySettingData"=$ssdString;"SecurityPolicy"=$importPdk.ProvisioningFile.PolicyData}
+    Enable-VMTPM -VM $vm
+
+    # Check if the VM boots. It's expected to fail
+    Start-VM $VMName_clone
+    if (-not $?) {
+        return $false
+    }
+    $timeout = 120
+    if (-not (WaitForVMToStartKVP $vmName 'localhost' $timeout )){
+        return $false
+    }
+    else {
+        return $true    
+    }  
+}
+
+function DependencyVM ([string] $dep_vhd)
+{
+    # Test dependency VHDx path
+    $sts = Test-Path $dep_vhd
+    if (-not $?) {
+        return $false
+    }
+    $dependency_destination = $dep_vhd_path -replace 'DEP_test','Dependency'
+    Copy-Item -Path $dep_vhd -Destination $dependency_destination -Force
+    if (-not $?) {
+        return $false
+    }
+    
+    # Make a new VM
+    $newVm = New-VM -Name 'LSVM_Dependency' -VHDPath $dependency_destination -MemoryStartupBytes 2048MB -SwitchName 'External' -Generation 1
+    if (-not $?) {
+        return $false
+    }
+    
+    # Attach the test VHDx to the VM
+    $sts = Add-VMHardDiskDrive -VMName 'LSVM_Dependency' -ControllerType SCSI -ControllerNumber 0 -ControllerLocation 1 -Path $parentClone
+    if (-not $?) {
+        return $false
+    }
+    
+    # Start VM and get IP
+    $sts = Start-VM -Name 'LSVM_Dependency'
+    $timeout = 150
+    if (-not (WaitForVMToStartKVP 'LSVM_Dependency' 'localhost' $timeout )){
+        return $false
+    }
+    Start-Sleep -s 15
+    $ipv4 = GetIPv4 'LSVM_Dependency' 'localhost'
+    
+    return $ipv4   
+}
+
+function VerfifyPassphrase ([string] $sshKey, [string] $ipv4)
+{
+    $sts_root = SendCommandToVM $ipv4 $sshkey "yes passphrase | cryptsetup luksOpen /dev/sdb3 encrypted_root"
+    $sts_boot = SendCommandToVM $ipv4 $sshkey "yes passphrase | cryptsetup luksOpen /dev/sdb2 encrypted_boot"
+
+    if (($sts_root -eq $True) -or ($sts_root -eq $True)) {
+        return $false
+    }
+    else {
+        return $true
+    }
+}
+
+function ExportVM ([string] $VMName)
+{
+    StopVM $VMName
+
+    $exportPath = (Get-VMHost).VirtualMachinePath + "\ExportTest\"
+    Set-Variable -Name 'export_path' -Value $exportPath -Scope Global
+    $vmPath = $exportPath + $vmName +"\"
+    Set-Variable -Name 'export_path_vm' -Value $vmPath -Scope Global
+
+    # Delete existing export, if any.
+    Remove-Item -Path $vmPath -Recurse -Force -ErrorAction SilentlyContinue
+
+    # Export the VM
+    Export-VM -Name $vmName -ComputerName 'localhost' -Path $exportPath -Confirm:$False -Verbose
+    if ($? -ne "True") {
+        Write-Output "Error while exporting the VM" | Out-File -Append $summaryLog
+        return $false
+    }
+
+    return $true
+}
+
+function CreateDataDisk ([string] $VMName, [string] $sshKey)
+{
+    StopVM $VMName
+
+    # Create the data disk
+    $vhdName = $dep_vhd_path -replace 'DEP_test','DataDisk'
+    Set-Variable -Name 'dataDiskLocation' -Value $vhdName -Scope Global
+
+    # Delete existing data disk, if any.
+    Remove-Item -Path $vhdName -Recurse -Force -ErrorAction SilentlyContinue
+    New-Vhd -Path $vhdName -SizeBytes 1GB -Dynamic -BlockSizeBytes 1MB
+    if (-not $?) {
+        return $false
+    }
+
+    # Attach the data disk to the VM
+    $sts = Add-VMHardDiskDrive -VMName $VMName -ControllerType SCSI -ControllerNumber 0 -ControllerLocation 1 -Path $vhdName
+    if (-not $?) {
+        return $false
+    }
+
+    # Start VM and get IP
+    $ipv4 = StartVM $VMName
+    if (-not (isValidIPv4 $ipv4)) {
+        return $false
+    }
+
+    # Create partition
+    SendCommandToVM $ipv4 $sshkey "(echo n; echo p; echo 2; echo ; echo ;echo w) | fdisk /dev/sdb 2> /dev/null"
+    if (-not $?) {
+        return $false
+    }
+
+    # Format partition && mount it
+    SendCommandToVM $ipv4 $sshkey "mkfs -t xfs /dev/sdb2 && mkdir dataDisk && mount /dev/sdb2 dataDisk"
+    if (-not $?) {
+        return $false
+    }
+
+    # Make a new file
+    SendCommandToVM $ipv4 $sshkey "echo 'FirstFile' > dataDisk/firstFile"
+    if (-not $?) {
+        return $false
+    }
+
+    return $true
+}
+
+function BackupVM ([string] $VMName, [string] $letter)
+{
+    # Remove Existing Backup Policy
+    try { Remove-WBPolicy -all -force }
+    Catch { Write-Host 'Removing WBPolicy' }
+
+    # Set up a new Backup Policy
+    $policy = New-WBPolicy
+
+    # Set the backup location
+    $backupLocation = New-WBBackupTarget -VolumePath $letter
+    Set-Variable -Name 'backupLocation' -Value $backupLocation -Scope Global
+
+    # Define VSS WBBackup type
+    Set-WBVssBackupOptions -Policy $policy -VssCopyBackup
+
+    # Add the Virtual machines to the list
+    $VM = Get-WBVirtualMachine | where vmname -like $VMName
+    Add-WBVirtualMachine -Policy $policy -VirtualMachine $VM
+    Add-WBBackupTarget -Policy $policy -Target $backupLocation
+
+    # Start the backup
+    Write-Host "Backing to $letter"
+    Start-WBBackup -Policy $policy
+
+    # Review the results
+    $BackupTime = (New-Timespan -Start (Get-WBJob -Previous 1).StartTime -End (Get-WBJob -Previous 1).EndTime).Minutes
+
+    $sts=Get-WBJob -Previous 1
+    if ($sts.JobState -ne "Completed" -or $sts.HResult -ne 0) {
+        return $false
+    }
+    Start-Sleep -s 30
+    return $true
+}
+
+function RestoreVM
+{
+    # Get BackupSet
+    $BackupSet = Get-WBBackupSet -BackupTarget $backupLocation
+
+    # Start restore
+    Start-WBHyperVRecovery -BackupSet $BackupSet -VMInBackup $BackupSet.Application[0].Component[0] -Force -WarningAction SilentlyContinue
+    $sts=Get-WBJob -Previous 1
+    if ($sts.JobState -ne "Completed" -or $sts.HResult -ne 0){
+        return $false
+    }
+
+    Write-Host "Restore Completed!"
+    return $true
+}
+
+function CheckRestoreStatus ([string] $sshKey, [string] $mountDisk, [string] $file_location, [string] $file_content)
+{
+    if (Get-VM -Name $VM_name |  Where { $_.State -notlike "Running" }) {
+         # Start VM and get IP
+        $ipv4 = StartVM $VM_name
+        if (-not (isValidIPv4 $ipv4)) {
+            return $false
+        }
+
+        # Mount the data disk (if it is required)
+        if ($mountDisk -eq 'yes') {
+            SendCommandToVM $ipv4 $sshKey "mount /dev/sdb2 dataDisk"
+            if (-not $?) {
+                return $false
+            }    
+        }   
+    }
+
+    # Check the second file. It should not be present anymore
+    $sts = SendCommandToVM $ipv4 $sshKey "cat $file_location | grep $file_content"
+    if (-not $sts) {
+        return $true
+    }
+    else {
+        return $false
+    }
+}
+
+function ModifyGrub ([string] $ipv4, [string] $sshKey, [string] $vmName)
+{
+    # Update grub
+    $retVal = SendCommandToVM $ipv4 $sshKey ". shielded_deployed_functions.sh && AddSerial"
+    if (-not $retVal) {
+        return $false
+    }
+    # Check status
+    $state = .\bin\plink.exe -i ssh\$sshKey root@$ipv4 "cat state.txt"
+    if ($state -ne "TestCompleted") {
+        return $false
+    }
+
+    StopVM $vmName
+    return $true
+}
+
+function BackupClean
+{
+    try { 
+        Remove-WBBackupSet -BackupTarget $backupLocation -Force -WarningAction SilentlyContinue 
+    }
+    Catch { 
+        Write-Host "No existing backup's to remove"
+    }
+}
+
+function AddComPort ([string] $VMName)
+{
+    # Get VM Security. We need to know if it's type is Shielded or EncryptionSupported
+    if ($(Get-VMSecurity $VMName).Shielded -eq $False) {
+        $isShielded = 'no'
+    }
+    else {
+        $isShielded = 'yes'
+    }
+    # Add COM Port
+    Set-VMComPort -vmName $VMName -ComputerName 'localhost' -Number 2 -Path "\\.\pipe\log"
+
+    # Start icaserial
+    $currentPath = $pwd.Path
+    $jobName = "COM_Reader"
+    Remove-Item COM.log -Force -EA SilentlyContinue
+    $job = $(Start-Job -Name $jobName -ScriptBlock { Set-Location $args[0]; .\bin\icaserial.exe READ \\localhost\pipe\log | Out-File COM.log } -ArgumentList $currentPath)
+
+    # Start VM
+    $ipv4 = StartVM $VMName
+    if (-not (isValidIPv4 $ipv4)) {
+        return $false
+    }
+
+    # Stop icaserial
+    Stop-Job -Id $job.id
+
+    # If it's shielded, logs should be empty. If it's not shielded, logs should have boot logs
+    if ($isShielded -eq 'no') {
+        if ($(Get-Item .\COM.log -EA SilentlyContinue).Length -gt 5kb) {
+            return $true
+        }
+        else {
+            return $false
+        }
+    }
+    else {
+        if ($(Get-Item .\COM.log -EA SilentlyContinue).Length -gt 1kb) {
+            return $false
+        }
+        else {
+            return $true
+        }    
+    }
+}
+
+function ModifyBoot ([string] $ipv4, [string] $sshKey, [string] $VMName)
+{
+    # Mount the template and make the changes
+    $retVal = SendCommandToVM $ipv4 $sshKey "mkdir lsvmefi && mount /dev/sdb1 lsvmefi"
+    if (-not $retVal) {
+        return $false
+    }
+    $retVal = SendCommandToVM $ipv4 $sshKey "cd lsvmefi/EFI/boot && rm -rf lsvm* sealedkeys"
+    if (-not $retVal) {
+        return $false
+    }
+    $retVal = SendCommandToVM $ipv4 $sshKey "umount /dev/sdb1"
+    if (-not $retVal) {
+        return $false
+    }
+
+    # Clean VM
+    CleanupDependency 'LSVM_Dependency'
+    
+    # Attach the VHD to the existing VMName
+    Remove-VMHardDiskDrive -VMName $VMName -ControllerType SCSI -ControllerNumber 0 -ControllerLocation 0
+    if (-not $?) {
+        return $false
+    }
+    Add-VMHardDiskDrive -VMName $VMName -ControllerType SCSI -ControllerNumber 0 -ControllerLocation 0 -Path $parentClone
+    if (-not $?) {
+        return $false
+    }
+
+    $ipv4 = StartVM $VMName
+    if (-not (isValidIPv4 $ipv4)) {
+        return $true
+    }
+    else {
+        return $false 
+    }   
+}
+
+function DisableSecureBoot ([string] $VMName)
+{
+    StopVM $VMName
+    Set-VMFirmware -VMName $VMName -EnableSecureBoot Off
+    if (-not $?) {
+        return $false
+    }
+
+    $ipv4 = StartVM $VMName
+    if (-not (isValidIPv4 $ipv4)) {
+        return $true
+    }
+    else {
+        return $false  
+    }
+}
+
+function StopVM ([string] $VMName)
+{
+    if ((Get-VM -Name $VMName).State -ne "Off") {
+        Stop-VM -Name $VMName -Force -Confirm:$false
+        Start-Sleep -s 5
+    }
+}
+
+function StartVM ([string] $VMName)
+{
+    # Start VM and get IP
+    $sts = Start-VM -Name $VMName
+    $timeout = 150
+    if (-not (WaitForVMToStartKVP $VMName 'localhost' $timeout )){
+        return $false
+    }
+    Start-Sleep -s 15
+    $ipv4 = GetIPv4 $VMName 'localhost'
+    return $ipv4
+}
+
+function WriteDataOnVM ([string] $VMName, [string] $sshKey, [string] $cmdToSend)
+{
+    $ipv4 = GetIPv4 $VMName 'localhost'
+    SendCommandToVM $ipv4 $sshkey $cmdToSend
+    if (-not $?) {
+        return $false
+    }
+    else {
+        return $true
+    }  
+}
+
+# Construct global variables
+$VM_name = "LSVM_Dep_Test"
+$defaultVhdPath = $(Get-VMHost).VirtualHardDiskPath
+if (-not $defaultVhdPath.EndsWith("\")) {
+    $defaultVhdPath += "\"
+}
+$dep_vhd_path = $defaultVhdPath + "LSVM-DEP_test.vhdx"
+$dep_pdk_path = $defaultVhdPath + "PDK_Test.pdk"
+$VMPath = $defaultVhdPath + "Provision_Test\"
+$VmVhdPath = $VMPath + '\' + $VM_name + '.vhdx'
+$fskFile = $VMPath + '\' + $VM_name + '.fsk'

--- a/WS2012R2/lisa/setupscripts/Shielded_PRO.ps1
+++ b/WS2012R2/lisa/setupscripts/Shielded_PRO.ps1
@@ -270,7 +270,7 @@ function Copy_Files_to_GH ([string] $GH_IP, [string] $share_path, $gh_creds, $sh
 		Remove-PSDrive -Name "PRO_Test"
 		return $sts
 	}	
-
+	Restart-Service WinRm -Force
 	return $copy_files_cmd
 }
 
@@ -437,6 +437,7 @@ function Clean_provisioned_VM ([string] $GH_IP, $gh_creds)
 		return $sts
 	}
 	
+	Restart-Service WinRm -Force
 	return $clean_cmd
 }
 


### PR DESCRIPTION
Shielded VMs testing: Added Deployed VMs test cases
- These are test scripts that must be used with pester-
Tests included:
-- LSVM-DEP-01: Update the kernel on a LSVM and verify the VM continues to boot successfully
-- LSVM-DEP-02: Update a boot component on a LSVM and verify the VM boots successfully.
-- LSVM-DEP-03: Clone a Linux Shielded VM VHDX and confirm it fails to boot.
-- LSVM-DEP-04: Verify well known DMCrypt/LUKS passwords no longer work
-- LSVM-DEP-09: Online Backup/Restore a data disk on a Linux Shielded VM
-- LSVM-DEP-10: Online Backup, then Restore the system disk of a Linux Shielded VM
-- LSVM-DEP-12: Add COM port to LSVM
-- LSVM-DEP-13: Attack a VHDX file of a functioning LSVM
-- LSVM-DEP-16: Disable Secure Boot and verify Linux Shielded VM fails to boot