### PR TITLE
Update storage resize limiation for host from 50G to 20G

### DIFF
--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_Basic.ps1
@@ -190,7 +190,7 @@ Write-Output "Covers: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 # Convert the new size
 #
 $newVhdxSize = ConvertStringToUInt64 $newSize
-$sizeFlag = ConvertStringToUInt64 "50GB"
+$sizeFlag = ConvertStringToUInt64 "20GB"
 #
 # Make sure the VM has a SCSI 0 controller, and that
 # Lun 0 on the controller has a .vhdx file attached.

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_DiskOver2TB.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_DiskOver2TB.ps1
@@ -176,7 +176,7 @@ Write-Output "Covers: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 # Convert the new size
 #
 $newVhdxSize = ConvertStringToUInt64 $newSize
-$sizeFlag = ConvertStringToUInt64 "50GB"
+$sizeFlag = ConvertStringToUInt64 "20GB"
 #
 # Make sure the VM has a SCSI 0 controller, and that
 # Lun 0 on the controller has a .vhdx file attached.

--- a/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VHDXResize_GrowShrink.ps1
@@ -196,7 +196,7 @@ Write-Output "Covers: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
 
 $newVhdxGrowSize = ConvertStringToUInt64 $newGrowSize
 $newVhdxShrinkSize = ConvertStringToUInt64 $newShrinkSize
-$sizeFlag = ConvertStringToUInt64 "50GB"
+$sizeFlag = ConvertStringToUInt64 "20GB"
 
 #
 # Make sure the VM has a SCSI 0 controller, and that

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
@@ -159,7 +159,7 @@ function checkResults([string] $vmName, [string] $hvServer)
 {
    # Review the results
 	$RestoreTime = (New-Timespan -Start (Get-WBJob -Previous 1).StartTime -End (Get-WBJob -Previous 1).EndTime).Minutes
-	$logger.error("Restore duration: $RestoreTime minutes")
+	$logger.info("Restore duration: $RestoreTime minutes")
 
 	# Make sure VM exists after VSS backup/restore operation
 	$vm = Get-VM -Name $vmName -ComputerName $hvServer

--- a/WS2012R2/lisa/xml/STOR_VHDXResize.xml
+++ b/WS2012R2/lisa/xml/STOR_VHDXResize.xml
@@ -303,7 +303,7 @@
                 <param>SectorSize=512</param>
                 <param>DefaultSize=127GB</param>
                 <param>NewSize=2304GB</param>
-                <param>fileSystems=(ext4 ext3 xfs)</param>
+                <param>fileSystems=(ext4 xfs)</param>
                 <param>ControllerType=SCSI</param>
                 <param>TC_COVERED=STOR-VHDx-05a</param>
             </testparams>
@@ -323,7 +323,7 @@
                 <param>SectorSize=512</param>
                 <param>DefaultSize=127GB</param>
                 <param>NewSize=2304GB</param>
-                <param>fileSystems=(ext4 ext3 xfs)</param>
+                <param>fileSystems=(ext4 xfs)</param>
                 <param>ControllerType=IDE</param>
                 <param>TC_COVERED=STOR-VHDx-05b</param>
             </testparams>
@@ -344,7 +344,7 @@
                 <param>DefaultSize=3GB</param>
                 <param>growSize=2304GB</param>
                 <param>shrinkSize=3GB</param>
-                <param>fileSystems=(ext4 ext3 xfs)</param>
+                <param>fileSystems=(ext4 xfs)</param>
                 <param>ControllerType=SCSI</param>
                <param>TC_COVERED=STOR-VHDx-06a</param>
             </testparams>
@@ -365,7 +365,7 @@
                <param>DefaultSize=3GB</param>
                <param>growSize=2304GB</param>
                <param>shrinkSize=3GB</param>
-               <param>fileSystems=(ext4 ext3 xfs)</param>
+               <param>fileSystems=(ext4 xfs)</param>
                <param>ControllerType=SCSI</param>
                <param>Offline=True</param>
                <param>TC_COVERED=STOR-VHDx-06b</param>
@@ -387,7 +387,7 @@
                 <param>DefaultSize=3GB</param>
                 <param>growSize=2304GB</param>
                 <param>shrinkSize=3GB</param>
-                <param>fileSystems=(ext4 ext3 xfs)</param>
+                <param>fileSystems=(ext4 xfs)</param>
                 <param>ControllerType=IDE</param>
                 <param>TC_COVERED=STOR-VHDx-06c</param>
             </testparams>


### PR DESCRIPTION
Minor updates:
1) update host storage size flag from 50GB to 20GB, since our test host has less storage, if the limitation set  as 50GB, storage resize related test cases will fail. Have check resize related test cases, generally it will change from 3G size to 4G. For 2304GB, if it is format as ext4, disk size is about 1.1G, if set as ext3, disk size will be 150G, here ignore ext3 file system.

In the file STOR_VHDXResize_PartitionDiskOver2TB.sh line 129, if it could mkfs successfully, will break the look, so it only test ext4 here. 

2)  Remove the ext3 from the xml when resize more than 2T.

3) Minor update logger.info from logger.error for "Restore duration" information for backup test case.