### PR TITLE
Fixed CopyLargeFile TC for IPv6

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NET_COPY_LARGE.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_COPY_LARGE.sh
@@ -561,7 +561,7 @@ LogMsg "Received $output_file from $STATIC_IP2"
 UpdateSummary "Received $output_file from $STATIC_IP2"
 
 if [ "${TestIPV6}" = "yes" ]; then
-	scp -6 -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$REMOTE_USER"@\["$STATIC_IP2_V6"\]:"$remote_home"/"$output_file" "$HOME"/"$output_file"
+	scp -6 -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$REMOTE_USER"@\["$STATIC_IP2_V6%${SYNTH_NET_INTERFACES[@]}"\]:"$remote_home"/"$output_file" "$HOME"/"$output_file"
 
 	if [ 0 -ne $? ]; then
 		#try to erase file from remote vm


### PR DESCRIPTION
In case of IPv6 testing of CopyLargeFile a Private network is used
and SCP has to be forced to use the addapter connected to that
network. Otherwise the external network might be used, resulting in
test failure.