### PR TITLE
Fix bug: Not looking for right hyperv daemon files on RHEL6

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
@@ -106,7 +106,7 @@ CheckHypervDaemons()
 
         for (( i=0; i<$len_hv; i++))
         do
-            CheckDaemonsFilesRHEL6 ${hv_service[$i]}
+            CheckDaemonsFilesRHEL6 ${hv[$i]}
             CheckDaemonsStatus ${hv[$i]} ${hv_alias[$i]}
         done
         ;;


### PR DESCRIPTION
"Check_HypervDaemons_Files_Status" case failed on RHEL6.9
The script was looking for "xxx.service" for hyperv daemons on rhel6, but rhel6 does not use systemctl. Unsurprisingly, case failed. I don't know why this happens since this is not a new case. Probably nobody used it on rhel6.
This patch worked for me