### PR TITLE
Increased Kdump TC timeout values

### DIFF
--- a/WS2012R2/lisa/setupscripts/Kdump.ps1
+++ b/WS2012R2/lisa/setupscripts/Kdump.ps1
@@ -231,8 +231,8 @@ bin\pscp -q -i ssh\${sshKey} root@${ipv4}:summary.log $logdir/${TC_COVERED}_exec
 #
 Write-Output "Trigger the kernel panic..."
 if ($nmi -eq 1){
-    # Waiting to kdump_execute.sh to finish his activity.
-    Start-Sleep -S 70
+    # Waiting to kdump_execute.sh to finish execution.
+    Start-Sleep -S 100
     Debug-VM -Name $vmName -InjectNonMaskableInterrupt -ComputerName $hvServer -Force
 }
 else {
@@ -266,7 +266,7 @@ Write-Output "Info: VM Heartbeat is OK"
 # Waiting the VM to have a connection
 #
 Write-Output "Info: Checking the VM connection after kernel panic"
-$sts = WaitForVMToStartSSH $ipv4 100
+$sts = WaitForVMToStartSSH $ipv4 400
 if (-not $sts[-1]){
     Write-Output "Error: $vmName didn't restart after triggering the crash" | Tee-Object -Append -file $summaryLog
     return $false

--- a/WS2012R2/lisa/xml/Kdump_Tests.xml
+++ b/WS2012R2/lisa/xml/Kdump_Tests.xml
@@ -66,7 +66,7 @@
                 <param>VCPU=1</param>
                 <param>VMMemory=4GB</param>
             </testParams>
-            <timeout>600</timeout>
+            <timeout>1000</timeout>
         </test>
 
         <test>
@@ -84,7 +84,7 @@
                 <param>VCPU=2</param>
                 <param>VMMemory=2GB</param>
             </testParams>
-            <timeout>600</timeout>
+            <timeout>1000</timeout>
         </test>
 
         <test>
@@ -103,7 +103,7 @@
                 <param>VMMemory=3GB</param>
                 <param>NMI=1</param>
             </testParams>
-            <timeout>600</timeout>
+            <timeout>1000</timeout>
         </test>
 
         <test>
@@ -122,7 +122,7 @@
                 <param>VCPU=2</param>
                 <param>VMMemory=2GB</param>
             </testParams>
-            <timeout>600</timeout>
+            <timeout>1000</timeout>
         </test>
 
         <test>
@@ -141,7 +141,7 @@
                 <param>VCPU=4</param>
                 <param>VMMemory=2GB</param>
             </testParams>
-            <timeout>600</timeout>
+            <timeout>1000</timeout>
         </test>
 
         <test>
@@ -160,7 +160,7 @@
                 <param>VCPU=16</param>
                 <param>VMMemory=4GB</param>
             </testParams>
-            <timeout>600</timeout>
+            <timeout>1000</timeout>
         </test>
 
         <test>
@@ -179,7 +179,7 @@
                 <param>VCPU=1</param>
                 <param>VMMemory=4GB</param>
             </testParams>
-            <timeout>700</timeout>
+            <timeout>1000</timeout>
         </test>
     </testCases>
 


### PR DESCRIPTION
In case of external Kdump usage, the time needed to create the vmcore
file is bigger, and the automation needs to wait accordingly.