### PR TITLE
Minor update NET_MAX_NIC by adding sleep time after ifup

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NET_MAX_NIC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_MAX_NIC.sh
@@ -59,7 +59,8 @@ function ConfigureInterfaces
 		fi
 
 		ifdown $IFACE && ifup $IFACE
-
+		#sleep a while after ifup
+		sleep 10
 		# Chech for gateway
 		LogMsg "Info : Checking if default gateway is set for ${IFACE}"
 		UpdateSummary "Info : Checking if default gateway is set for ${IFACE}"

--- a/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
+++ b/WS2012R2/lisa/xml/STOR_VSS_Backup_Tests.xml
@@ -284,7 +284,7 @@
             <testParams>
                 <param>TC_COVERED=VSS-21</param>
             </testParams>
-            <timeout>2400</timeout>
+            <timeout>3000</timeout>
             <OnError>Continue</OnError>
         </test>
 
@@ -296,7 +296,7 @@
             <testParams>
                 <param>TC_COVERED=VSS-22</param>
             </testParams>
-            <timeout>2400</timeout>
+            <timeout>3000</timeout>
             <OnError>Continue</OnError>
         </test>
 


### PR DESCRIPTION
MaxNIC,MaxLegacyNIC,MaxSyntheticNIC all use file NET_MAX_NIC.sh, after ifup ethX, it also needs a while to get gateway. so add sleep for a while before CheckGateway to make cases more stable.