### PR TITLE
Updated TC to turnoff the VM

### DIFF
--- a/WS2012R2/lisa/setupscripts/VMBus_PanicNotifier.ps1
+++ b/WS2012R2/lisa/setupscripts/VMBus_PanicNotifier.ps1
@@ -268,6 +268,12 @@ if ($timeout -le 0)
 }
 
 #
-# Report test results
+# TurnOff VM and report test results
 #
+
+Stop-VM -Name $vmName -ComputerName $hvServer -TurnOff
+if ($? -ne $true) {
+    Write-Output "Error: Unable to TurnOff VM after test completion." | Tee-Object -Append -file $summaryLog
+}
+
 return $testPassed


### PR DESCRIPTION
There are cases when the VM would not reboot after triggering the
crash and remain in an hanging state. To avoid this behavior we
TurnOff the VM after testing is done.