### PR TITLE
Updated KVP XML file to reboot after Rescind test

### DIFF
--- a/WS2012R2/lisa/xml/KvpTests.xml
+++ b/WS2012R2/lisa/xml/KvpTests.xml
@@ -185,7 +185,7 @@
             <testScript>SetupScripts\KVP_TestRescind.ps1</testScript>
             <timeout>600</timeout>
             <onError>Continue</onError>
-            <noReboot>True</noReboot>
+            <noReboot>False</noReboot>
             <testparams>
                 <param>TC_COVERED=KVP-11</param>
                 <!-- Number of times to disable and reenable the KVP service -->


### PR DESCRIPTION
If the VM does not reboot after testing the rescind issue and the
issue is present, the following test scenarios will be also affected.