### PR TITLE
Add UIO test case - UIO_Basics

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Hyperv_Daemons_Files_Status.sh
@@ -152,10 +152,11 @@ CheckVMFeatureSupportStatus()
   do
       if [ ${kernel_array[$n]} -gt ${specifiedKernel_array[$n]} ];then
           return 0
+      elif [ ${kernel_array[$n]} -lt ${specifiedKernel_array[$n]} ];then
+          return 1
       fi
   done
-
-  return 1
+  return 0
 }
 
 #######################################################################
@@ -174,7 +175,7 @@ CheckDaemonsFilesRHEL7()
 
   # for rhel7.3+(kernel-3.10.0-514), no need to check 90-default.preset
   local kernel=$(uname -r)
-  CheckVMFeatureSupportStatus "3.10.0-513"
+  CheckVMFeatureSupportStatus "3.10.0-514"
 
   if [ $? -ne 0 ]; then
     LogMsg "INFO: Check 90-default.preset for $kernel"

--- a/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+	echo "Error: unable to source utils.sh!"
+	echo "TestAborted" > state.txt
+	exit 2
+}
+
+#######################################################################
+# Check kernel version is newer than the specified version
+# if return 0, the current kernel version is newer than specified version
+# else, the current kernel version is older than specified version
+#######################################################################
+CheckVMFeatureSupportStatus()
+{
+    specifiedKernel=$1
+    if [ $specifiedKernel == "" ];then
+        return 1
+    fi
+    # for example 3.10.0-514.el7.x86_64
+    # get kernel version array is (3 10 0 514)
+    local kernel_array=(`uname -r | awk -F '[.-]' '{print $1,$2,$3,$4}'`)
+    local specifiedKernel_array=(`echo $specifiedKernel | awk -F '[.-]' '{print $1,$2,$3,$4}'`)
+    local index=${!kernel_array[@]}
+    local n=0
+    for n in $index
+    do
+        if [ ${kernel_array[$n]} -gt ${specifiedKernel_array[$n]} ];then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+#######################################################################
+# Pre-settings & Functions
+#######################################################################
+
+UtilsInit
+
+# Check kernel version
+CheckVMFeatureSupportStatus "3.10.0-610"
+if [ $? -ne 0 ]; then
+    LogMsg "INFO: this kernel version does not support uio feature, skip test"
+    UpdateSummary "INFO: this kernel version does not support uio feature, skip test"
+    UpdateTestState $ICA_TESTSKIPPED
+    exit 1
+fi
+
+# Check if the module is successfully loaded
+# Param:
+#  $1: module name
+#  $2: 1 if the module is expected to be loadd,
+#      0 if it is expected NOT loaded
+CheckModule(){
+    ret=$(lsmod |awk "\$1==\"$1\"" |wc -l)
+
+    if [ $2 -eq 1 ]; then
+        if [ $ret -eq 1 ]; then
+            LogMsg "Success: $1 loaded"
+        else
+            LogMsg "Fail: module $1 is not loaded"
+            UpdateSummary "Fail: module $1 is not loaded"
+            SetTestStateFailed
+            exit 1
+        fi
+    fi
+
+    if [ $2 -eq 0 ]; then
+        if [ $ret -eq 0 ]; then
+            LogMsg "Success: $1 unloaded"
+        else
+            LogMsg "Fail: module $1 is not unloaded"
+            UpdateSummary "Fail: module $1 is not unloaded"
+            SetTestStateFailed
+            exit 1
+        fi
+    fi
+}
+
+# Check return value. If return value is 0, log success; if not 0, log error and
+# mark the test as failed.
+# Param:
+# $1: Operation description (Log info)
+CheckSuccess(){
+    if [ $? -eq 0 ]; then
+        LogMsg "Success: $1"
+    else
+        LogMsg "Error: $1"
+        UpdateSummary "Error: $1"
+        SetTestStateFailed
+        exit 1
+    fi
+}
+
+#######################################################################
+# Main test body
+#######################################################################
+
+# Part I: Test loading/unloading uio & uio_hv_generic
+for i in $(seq 100)
+do
+    # Test loading uio
+    modprobe uio
+    CheckModule uio 1
+
+    # Test unloading uio
+    #  make sure uio generic is unloaded before unloading uio
+    modprobe -r uio_hv_generic
+    modprobe -r uio
+    CheckModule uio 0
+
+    # Test loading uio_hv_generic
+    modprobe uio_hv_generic
+    #  uio shold also be loaded when loading uio generic
+    CheckModule uio 1
+    CheckModule uio_hv_generic 1
+
+    # Test unloading uio generic
+    modprobe -r uio_hv_generic
+    CheckModule uio_hv_generic 0
+
+    # Test unloading uio
+    modprobe -r uio
+    CheckModule uio 0
+done
+
+# Part I pass
+UpdateSummary "Success: loading/unloading uio and uio_hv_generic modules"
+
+# Part II: Test reassign a device (network adapter) to uio_hv_generic driver
+
+# Setup: load uio generic
+modprobe uio_hv_generic
+CheckSuccess "Load uio_hv_generic"
+
+# Setup: Find the not connected network adapter, will use it to test uio
+InactiveNIC=`ip address |awk '$9=="DOWN" { print substr($2, 1, length($2)-1) }'`
+CheckSuccess "Get inactive nic info"
+
+# Setup: acquire adapter class id
+ClassID=`cat /sys/class/net/$InactiveNIC/device/class_id |awk '{ print( substr($1, 2, length($1)-2)) }'`
+CheckSuccess "Get network adapter class id"
+
+# Setup: acquire adapter device id
+DeviceID=`cat /sys/class/net/$InactiveNIC/device/device_id |awk '{ print( substr($1, 2, length($1)-2)) }'`
+CheckSuccess "Get network adapter device id"
+
+# Setup: add new id to uio generic
+echo $ClassID > /sys/bus/vmbus/drivers/uio_hv_generic/new_id
+CheckSuccess "Add new id for uio_hv_generic"
+
+# Setup: unbind device from netvsc
+echo -n $DeviceID > /sys/bus/vmbus/drivers/hv_netvsc/unbind
+CheckSuccess "Unbind device from hv_netvsc"
+
+# Test binding device to uio generic
+echo -n $DeviceID > /sys/bus/vmbus/drivers/uio_hv_generic/bind
+CheckSuccess "Assigned device to uio_hv_generic"
+
+# Check /dev/uio0 exists
+if [ -e "/dev/uio0" ]; then
+    LogMsg "Success: /dev/uio0 found"
+else
+    LogMsg "Fail: /dev/uio0 not found"
+    UpdateSummary "Fail: /dev/uio0 not found"
+    SetTestStateFailed
+    exit 1
+fi
+
+# Test unbinding device from uio generic
+echo -n $DeviceID > /sys/bus/vmbus/drivers/uio_hv_generic/unbind
+CheckSuccess "Unbind device from uio_hv_generic"
+
+# Part II pass
+UpdateSummary "Success: uio_hv_generic: device assign/deassigned"
+
+# Bind device back to netvsc.
+# This is not part of the test, just to recover environment so that this
+# script can be reruned. Nevertheless, If this part fails, it could be a
+# potential issue.
+echo -n $DeviceID > /sys/bus/vmbus/drivers/hv_netvsc/bind
+CheckSuccess "Assign network adapter back to hv_netvsc"
+
+SetTestStateCompleted
+exit 0

--- a/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
@@ -32,33 +32,6 @@ dos2unix utils.sh
 }
 
 #######################################################################
-# Check kernel version is newer than the specified version
-# if return 0, the current kernel version is newer than specified version
-# else, the current kernel version is older than specified version
-#######################################################################
-CheckVMFeatureSupportStatus()
-{
-    specifiedKernel=$1
-    if [ $specifiedKernel == "" ];then
-        return 1
-    fi
-    # for example 3.10.0-514.el7.x86_64
-    # get kernel version array is (3 10 0 514)
-    local kernel_array=(`uname -r | awk -F '[.-]' '{print $1,$2,$3,$4}'`)
-    local specifiedKernel_array=(`echo $specifiedKernel | awk -F '[.-]' '{print $1,$2,$3,$4}'`)
-    local index=${!kernel_array[@]}
-    local n=0
-    for n in $index
-    do
-        if [ ${kernel_array[$n]} -gt ${specifiedKernel_array[$n]} ];then
-            return 0
-        fi
-    done
-
-    return 1
-}
-
-#######################################################################
 # Pre-settings & Functions
 #######################################################################
 

--- a/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
@@ -65,7 +65,7 @@ CheckVMFeatureSupportStatus()
 UtilsInit
 
 # Check kernel version
-CheckVMFeatureSupportStatus "3.10.0-610"
+CheckVMFeatureSupportStatus "3.10.0-692"
 if [ $? -ne 0 ]; then
     LogMsg "INFO: this kernel version does not support uio feature, skip test"
     UpdateSummary "INFO: this kernel version does not support uio feature, skip test"

--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -298,6 +298,37 @@ GetDistro()
 	return 0
 }
 
+# Check kernel version is above/equal to feature supported version
+# eg. CheckVMFeatureSupportStatus "3.10.0-513"
+# Return value:
+#   0: current version equals or above supported version
+#   1: current version is below supported version, or no param
+CheckVMFeatureSupportStatus()
+{
+    specifiedKernel=$1
+    if [ $specifiedKernel == "" ];then
+        return 1
+    fi
+    # for example 3.10.0-514.el7.x86_64
+    # get kernel version array is (3 10 0 514)
+    local kernel_array=(`uname -r | awk -F '[.-]' '{print $1,$2,$3,$4}'`)
+    local specifiedKernel_array=(`echo $specifiedKernel | awk -F '[.-]' '{print $1,$2,$3,$4}'`)
+    local index=${!kernel_array[@]}
+    local n=0
+    for n in $index
+    do
+        # above support version, returns 0
+        if [ ${kernel_array[$n]} -gt ${specifiedKernel_array[$n]} ];then
+            return 0
+        elif [ ${kernel_array[$n]} -lt ${specifiedKernel_array[$n]} ];then
+        # below support version, returns 1
+            return 1
+        fi
+    done
+    # strictly equal to support version, returns 0
+    return 0
+}
+
 # Function to get all synthetic network interfaces
 # Sets the $SYNTH_NET_INTERFACES array elements to an interface name suitable for ifconfig etc.
 # Takes no arguments

--- a/WS2012R2/lisa/xml/UIO_Tests.xml
+++ b/WS2012R2/lisa/xml/UIO_Tests.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+    Licensed under the Apache License, Version 2.0 (the ""License"");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+    ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+    PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+
+    See the Apache Version 2.0 License for specific language governing
+    permissions and limitations under the License.
+-->
+
+<config>
+
+    <global>
+        <logfileRootDir>TestResults</logfileRootDir>
+        <defaultSnapshot>ICABase</defaultSnapshot>
+        <email>
+            <recipients>
+                <to>myself@mycompany.com</to>
+            </recipients>
+            <sender>myself@mycompany.com</sender>
+            <subject>LIS UIO test results on WS2012R2</subject>
+            <smtpServer>mysmtphost.mycompany.com</smtpServer>
+        </email>
+    </global>
+
+    <testSuites>
+        <suite>
+            <suiteName>UIO</suiteName>
+            <suiteTests>
+                <suiteTest>UIO_Basic</suiteTest>
+            </suiteTests>
+        </suite>
+    </testSuites>
+
+	<testCases>
+        <test>
+              <testName>UIO_Basic</testName>
+              <setupScript>setupScripts\NET_ADD_NIC_MAC.ps1</setupScript>
+              <testScript>UIO_Basic.sh</testScript>
+              <files>remote-scripts/ica/utils.sh,remote-scripts/ica/UIO_Basic.sh</files>
+              <testParams>
+                  <param>NIC=NetworkAdapter,None,InvalidNIC</param>
+                  <param>TC_COVERED=UIO-01</param>
+              </testParams>
+              <timeout>400</timeout>
+        </test>
+	</testCases>
+
+    <VMs>
+        <vm>
+            <hvServer>localhost</hvServer>
+            <vmName>VM_NAME</vmName>
+            <os>Linux</os>
+            <ipv4></ipv4>
+            <sshKey>PKI_id_rsa.ppk</sshKey>
+            <suite>UIO</suite>
+        </vm>
+    </VMs>
+
+</config>


### PR DESCRIPTION
This test covers basic operations of uio and uio_hv_generic:
  1. loading/unloading uio & uio_generic for 100 times
  2. assign a device (network adapter) to uio_hv_generic

Manal test steps:
1. setup another network adapter for the vm
2. Load uio, check it is loaded
  \# modprobe uio
  \# lsmod |grep uio
3. Unload uio, check it is unloaded
  \# modprobe -r uio
  \# lsmod |grep uio
4. Load uio_hv_generic, check uio & uio_hv_generic are loaded
  \# modprobe uio_hv_generic
  \# lsmod |grep uio
5. Add new id (ClassID) to uio_hv_generic
  \# ip addr
  ( Use new network adapter for the ehtx in following commands )
  \# ClassID=`cat /sys/class/net/ethx/device/class_id |awk '{ print( substr($1, 2, length($1)-2)) }'`
  \# echo $ClassID > /sys/bus/vmbus/drivers/uio_hv_generic/new_id
6. Deassign the device from kernel hv_netvsc driver
  \# DeviceID=`cat /sys/class/net/ethx/device/device_id |awk '{ print( substr($1, 2, length($1)-2)) }'`
  \# echo -n $DeviceID > /sys/bus/vmbus/drivers/hv_netvsc/unbind
  (Make sure to use 'echo -n')
7. Assign the device to uio_hv_generic
  \# echo -n $DeviceID > /sys/bus/vmbus/drivers/uio_hv_generic/bind
  Check /dev/uio0 exists.