### PR TITLE
Stop remaining child processes

### DIFF
--- a/WS2012R2/lisa/lisa.ps1
+++ b/WS2012R2/lisa/lisa.ps1
@@ -997,6 +997,16 @@ function ValidateXMLFile ([String] $xmlFilename)
     ValidateUserXmlFile $xmlFilename
 }
 
+function StopChildProcesses
+{
+    # Get the PID of the Powershell window and stop all child processes after testing is done
+    $parentProcessPid = $PID
+    $children = Get-WmiObject WIN32_Process | where `
+        {$_.ParentProcessId -eq $parentProcessPid -and $_.Name -ne "conhost.exe"}
+        foreach ($child in $children) {
+            Stop-Process -Force $child.Handle -Confirm:$false -ErrorAction SilentlyContinue
+        }
+}
 
 ########################################################################
 #
@@ -1023,6 +1033,8 @@ switch ($cmdVerb)
         {
             $lisaExitCode = 2
         }
+        #Stop all processes started by automation during the test
+        StopChildProcesses
     }
 "validate" {
         $sts = ValidateXmlFile $cmdNoun


### PR DESCRIPTION
There are cases when some processes remain hanging after the testing
is done. In those cases lisa will stop the remaining processes.