### PR TITLE
Auto detect vm generation in lsvmbus-basic

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/lsvmbus_basic.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/lsvmbus_basic.sh
@@ -93,7 +93,8 @@ if [ -z $lsvmbus_path ]; then
     exit 1
 fi
 
-if [ "$generation" -eq "1" ]; then
+GetGuestGeneration
+if [ "$os_GENERATION" -eq "1" ]; then
     tokens+=("Synthetic IDE Controller")
 fi
 

--- a/WS2012R2/lisa/xml/lsvmbus.xml
+++ b/WS2012R2/lisa/xml/lsvmbus.xml
@@ -61,7 +61,6 @@
             <param>startupMem=2048MB</param>
             <param>memWeight=0</param>
             <param>staticMem=2048MB</param>
-            <param>generation=1</param>
         </testParams>
         <timeout>800</timeout>
         </test>


### PR DESCRIPTION
The generation info for lsvmbus-basic case is manually defined in xml.
This patch make the shell script detect vm generation automatically.