### PR TITLE
Fix bug: GetVMFeatureSupportStatus() potential incorrect return value

### DIFF
--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -2114,6 +2114,9 @@ function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$su
 		if ($ckernel[$i] -lt $sKernel[$i] ) {
 			return $false
 		}
+		if ($ckernel[$i] -gt $sKernel[$i] ) {
+			return $true
+		}
 	}
 	return $true
 }


### PR DESCRIPTION
GetVMFeatureSupportStatus() would return wrong value in specific
condition. eg. feature is supported in version "3.3.3-3", current
kernel version is "3.4.2-3", function would return $false, which is
obviously incorrect.