### PR TITLE
Minor update STOR_unPlug_Plug error.clear position

### DIFF
--- a/WS2012R2/lisa/setupscripts/STOR_unPlug_Plug.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_unPlug_Plug.ps1
@@ -70,6 +70,7 @@ param([string] $vmName, [string] $hvServer, [string] $testParams)
 function AttachVHDxDiskDrive( [string] $vmName, [string] $hvServer,
                         [string] $vhdxPath, [string] $controllerType,[string] $controllerID,[string] $lun )
 {
+    $error.Clear()
     Add-VMHardDiskDrive -VMName $vmName `
                         -ComputerName $hvServer `
                         -Path $vhdxPath `
@@ -82,13 +83,13 @@ function AttachVHDxDiskDrive( [string] $vmName, [string] $hvServer,
         $error[0].Exception
         return $False
     }
-    $error.Clear()
     return $True
 }
 
 function RemoveVHDxDiskDrive( [string] $vmName, [string] $hvServer,
                         [string] $controllerType,[string] $controllerID,[string] $lun)
 {
+    $error.Clear()
     Remove-VMHardDiskDrive -VMName $vmName `
                            -ComputerName $hvServer `
                            -ControllerType $controllerType `
@@ -100,7 +101,6 @@ function RemoveVHDxDiskDrive( [string] $vmName, [string] $hvServer,
         $error[0].Exception
         return $False
     }
-    $error.Clear()
     return $True
 }
 


### PR DESCRIPTION
When testing on the rhel 7.5 gen2 vm, get the $error information: how the WARNING: fdisk GPT support is currently new, and therefore in an experimental phase. 
so firstly do $error.Clear() then do  Add-VMHardDiskDrive and  Remove-VMHardDiskDrive to avoid other warning inducing test case failure.

Thank you so much. 