### PR TITLE
lis_install.sh - code fix

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
@@ -56,7 +56,8 @@ function download_archive {
 	fi
 
 	# Download file
-	wget "$LIS_URL$AZURE_TOKEN"
+    TAR_NAME="${LIS_URL##*/}"
+	wget "$LIS_URL$AZURE_TOKEN" -O "$TAR_NAME"
 	if [ $? -ne 0 ]; then
 		msg="ERROR: Archive download failed"
 		LogMsg "$msg"

--- a/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
@@ -56,7 +56,7 @@ function download_archive {
 	fi
 
 	# Download file
-    TAR_NAME="${LIS_URL##*/}"
+	TAR_NAME="${LIS_URL##*/}"
 	wget "$LIS_URL$AZURE_TOKEN" -O "$TAR_NAME"
 	if [ $? -ne 0 ]; then
 		msg="ERROR: Archive download failed"
@@ -74,12 +74,12 @@ function download_archive {
 function install_lis {
 	# Extract archive
 	tar -xzvf lis-rpm*.tar.gz
-		if [ $? -ne 0 ]; then
+	if [ $? -ne 0 ]; then
 		msg="ERROR: Extracting the archive failed"
 		LogMsg "$msg"
 		UpdateSummary "$msg"
 		SetTestStateFailed
-		exit 1
+	exit 1
 	fi
 
 	# Install LIS

--- a/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
@@ -79,7 +79,7 @@ function install_lis {
 		LogMsg "$msg"
 		UpdateSummary "$msg"
 		SetTestStateFailed
-	exit 1
+		exit 1
 	fi
 
 	# Install LIS


### PR DESCRIPTION
Some times wget might append the token at the end of the file name.
This is resolved by using -O flag with the actual file name as a value.