### PR TITLE
Fix: TCUtils.ps1: GetVMFeatureSupportStatus wrong return value

### DIFF
--- a/WS2012R2/lisa/setupscripts/KVP_TestRescind.ps1
+++ b/WS2012R2/lisa/setupscripts/KVP_TestRescind.ps1
@@ -158,8 +158,8 @@ if ($checkVM -eq "True") {
         return $Failed
     }
 
-# Check if VM is RedHat 7.2 or older and if it uses external LIS
-    $supportkernel = "3.10.0.327" #kernel version for RHEL 7.2
+    # Check if VM is RedHat 7.3 or later (and if not, check external LIS exists)
+    $supportkernel = "3.10.0.514" #kernel version for RHEL 7.3
     $isRHEL = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "yum --version"
     if ($? -eq "True") {
         $kernelSupport = GetVMFeatureSupportStatus $ipv4 $sshKey $supportkernel

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -2115,11 +2115,13 @@ function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$su
     for ($i=0; $i -le 3; $i++) {
         if ($cKernel[$i] -lt $sKernel[$i] ) {
             $cmpResult = $false
+            break;
         }
         if ($cKernel[$i] -gt $sKernel[$i] ) {
             $cmpResult = $true
             break
         }
+        if ($i -eq 3) { $cmpResult = $True }
     }
     return $cmpResult
 }


### PR DESCRIPTION
The patch 1406f1b #915 is bringing back a issue fixed in patch 16d1884 #905 .
eg. Feature is supported in version "3.3.3-3", current kernel version is "3.2.4-3", function would return $True, which is incorrect.