### PR TITLE
GrowFSAfterResize: skip xfs test when xfs tools not present

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/STOR_VHDXResize_GrowFSAfterResize.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_VHDXResize_GrowFSAfterResize.sh
@@ -113,6 +113,7 @@ for fs in "${fileSystems[@]}"; do
         echo "Error: File-system tools for $fs not present. Skipping filesystem $fs.">> ~/summary.log
         LogMsg "Error: File-system tools for $fs not present. Skipping filesystem $fs."
         count=`expr $count + 1`
+        continue
     else
         #Use -f option for xfs filesystem, but ignore parameter for other filesystems
         option=""


### PR DESCRIPTION
We have been testing resize cases on RHEL6, on which xfs tools are not present.
There is actually some script trying to skip xfs in this circumstance, but it does not work correctly.