### PR TITLE
VM state file separation

### DIFF
--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -2326,9 +2326,9 @@ function DoTestStarting([System.Xml.XmlElement] $vm, [XML] $xmlData)
         return
     }
 
-    $stateFile = "state.txt"
+    $stateFile = "state_$($vm.vmName).txt"
     del $stateFile -ErrorAction "SilentlyContinue"
-    if ( (GetFileFromVM $vm $stateFile ".") )
+    if ( (GetFileFromVM $vm state.txt ".\$stateFile") )
     {
         if ( (test-path $stateFile) )
         {
@@ -2399,11 +2399,10 @@ function DoTestRunning([System.Xml.XmlElement] $vm, [XML] $xmlData)
         return
     }
 
-    $stateFile = "state.txt"
-
+    $stateFile = "state_$($vm.vmName).txt"
     del $stateFile -ErrorAction "SilentlyContinue"
 
-    if ( (GetFileFromVM $vm $stateFile ".") )
+    if ( (GetFileFromVM $vm state.txt ".\$stateFile") )
     {
         if (test-path $stateFile)
         {


### PR DESCRIPTION
The state file should be unique per VM.
If multiple test suites are run for multiple VMs, a conflict might appear in the state.txt file, which now we make unique for each VM.
Linux VM state.txt remains unchanged.