### PR TITLE
 KVP_Max_Read: skip kernel version below 3.10.3.860 (RHEL7.5)

### DIFF
--- a/WS2012R2/lisa/setupscripts/KVP_Max_Read.ps1
+++ b/WS2012R2/lisa/setupscripts/KVP_Max_Read.ps1
@@ -200,8 +200,12 @@ $logger.Summary.info("Covers: ${tcCovered}")
 # Supported in RHEL7.5 ( no official release for now, might need update )
 $FeatureSupported = GetVMFeatureSupportStatus $ipv4 $sshKey "3.10.0-860"
 if ( $FeatureSupported -ne $True ){
-    $logger.Summary.info("Guest kernel version does not support this feature, skipping")
-    return $Skipped
+    $logger.Summary.info("Kernels older than 3.10.0-514 require LIS-4.x drivers.")
+    $checkExternal = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "rpm -qa | grep kmod-microsoft-hyper-v && rpm -qa | grep microsoft-hyper-v"
+    if ($? -ne "True") {
+        $logger.Summary.info("Error: No LIS-4.x drivers detected. Skipping test.")
+        return $Skipped
+    }
 }
 
 #

--- a/WS2012R2/lisa/setupscripts/KVP_Max_Read.ps1
+++ b/WS2012R2/lisa/setupscripts/KVP_Max_Read.ps1
@@ -169,8 +169,8 @@ foreach ($p in $params)
     "TC_COVERED"   { $tcCovered = $fields[1].Trim() }
     "Pool"         { $pool = $fields[1].Trim() }
     "Entries"      { $entries = $fields[1].Trim() }
-	"sshKey"	    { $sshKey = $fields[1].Trim() }
-	"ipv4"	    { $ipv4 = $fields[1].Trim() }
+    "sshKey"       { $sshKey = $fields[1].Trim() }
+    "ipv4"         { $ipv4 = $fields[1].Trim() }
     default  {}       
     }
 }
@@ -196,6 +196,13 @@ else {
 
 $logger = [LoggerManager]::GetLoggerManager($vmName, $testParams)
 $logger.Summary.info("Covers: ${tcCovered}")
+
+# Supported in RHEL7.5 ( no official release for now, might need update )
+$FeatureSupported = GetVMFeatureSupportStatus $ipv4 $sshKey "3.10.0-860"
+if ( $FeatureSupported -ne $True ){
+    $logger.Summary.info("Guest kernel version does not support this feature, skipping")
+    return $Skipped
+}
 
 #
 # Verify the Data Exchange Service is enabled for this VM

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -2108,9 +2108,8 @@ function GetVMFeatureSupportStatus([String] $ipv4, [String] $sshKey, [String]$su
     if( $? -eq $false){
         Write-Output "Warning: Could not get kernel version".
     }
-    $sKernel = $supportKernel.split(".")
-    $cKernel = $currentKernel.replace("-",".")
-    $cKernel = $cKernel.split(".")
+    $sKernel = $supportKernel.split(".-")
+    $cKernel = $currentKernel.split(".-")
 
     for ($i=0; $i -le 3; $i++) {
         if ($cKernel[$i] -lt $sKernel[$i] ) {


### PR DESCRIPTION
 KVP_Max_Read: skip test if kernel version is below 3.10.3.860 (RHEL7.5)
This version is not official release version yet, might need to update later

Some modification in function GetVMFeatureSupportStatus, makes it support both format like "10.3.0.1" and format like"10.3.0-1" 