### PR TITLE
Minor update sleep time make case more robust

### DIFF
--- a/WS2012R2/lisa/setupscripts/INST_LIS_TimeSyncServiceDisableEnable.ps1
+++ b/WS2012R2/lisa/setupscripts/INST_LIS_TimeSyncServiceDisableEnable.ps1
@@ -139,7 +139,7 @@ del $summaryLog -ErrorAction SilentlyContinue
 Write-Output "Info: Covers ${tcCovered}" | Out-File $summaryLog
 
 $retVal = ConfigTimeSync -sshKey $sshKey -ipv4 $ipv4
-if (-not $retVal) 
+if (-not $retVal)
 {
     Write-Output "Error: Failed to config time sync."
     return $False
@@ -202,6 +202,7 @@ if ($status.PrimaryOperationalStatus -ne "Ok")
 }
 "Info : Integrated Time Sync Service successfully Enabled"
 
+Start-Sleep -seconds 5
 #
 # Now also save the VM for 60 seconds
 #

--- a/WS2012R2/lisa/setupscripts/Kdump.ps1
+++ b/WS2012R2/lisa/setupscripts/Kdump.ps1
@@ -214,6 +214,9 @@ do {
     sleep 5
 } until(Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue | ? { $_.TcpTestSucceeded } )
 
+#sleep more time
+sleep 5
+
 #
 # Prepare the kdump related
 #
@@ -281,6 +284,8 @@ do {
     sleep 5
 } until(Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue | ? { $_.TcpTestSucceeded } )
 
+#sleep more time
+sleep 5
 #
 # Verifying if the kernel panic process creates a vmcore file of size 10M+
 #


### PR DESCRIPTION
1. For case Crash_NMI, get the error message as below, rerun pass, considering add more sleep here to make it robust.

Creating Log File for : setupscripts\kdump.ps1
Rebooting the VM.
Waiting the VM to have a connection...
Error: Configuration is not correct. Check logs for details.
False

2. For test case INST_LIS_TimeSyncServiceDisableEnable.ps1, get failure as below, rerun pass, add sleep before save-vm to make it more robust.

Creating Log File for : setupscripts\INST_LIS_TimeSyncServiceDisableEnable.ps1
The operation on computer '2016-auto' failed: Provider load failure 
Parsing testParams
Info : Verify the Integrated Services Time Sync Service is enabled
Info : Disabling the Integrated Services Time Sync Service
Info : Integrated Time Sync Service successfully disabled
Info : Enabling the Integrated Services Time Sync Service
Info : Integrated Time Sync Service successfully Enabled
Info : Saving the VM
Error: Unable to save the VM
False
