### PR TITLE
Changed TargetIP and IQN handling in pass_offline

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/STOR_pass_offline.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/STOR_pass_offline.sh
@@ -24,6 +24,7 @@
 ICA_TESTRUNNING="TestRunning"
 ICA_TESTCOMPLETED="TestCompleted"
 ICA_TESTABORTED="TestAborted"
+ICA_TESTSKIPPED="TestSkipped"
 count=0
 
 #######################################################################
@@ -211,18 +212,12 @@ else
     exit 1
 fi
 
-if [ ! ${TargetIP} ]; then
-    LogMsg "No TargetIP variable in constants.sh"
-    UpdateTestState "TestAborted"
-    exit 1
-else
-    LogMsg "Target IP: ${TargetIP}"
-fi
-
-if [ ! ${IQN} ]; then
-    LogMsg "No IQN variable in constants.sh. Will try to autodiscover it"
-else
-    LogMsg "IQN: ${IQN}"
+if [[ ( ! ${TargetIP} ) && ( ! ${IQN} ) ]];
+then
+    LogMsg "INFO: No TargetIP and IQN have been specified. Skipping tests."
+    UpdateSummary "INFO: No TargetIP and IQN have been specified."
+    UpdateTestState $ICA_TESTSKIPPED
+    exit 0
 fi
 
 # Connect to the iSCSI Target

--- a/WS2012R2/lisa/xml/STOR_VHD.xml
+++ b/WS2012R2/lisa/xml/STOR_VHD.xml
@@ -50,8 +50,10 @@
             <cleanupScript>SetupScripts\Remove-VHDXHardDisk.ps1</cleanupScript>
             <testParams>
                 <param>TC_COVERED=STOR-21</param>
+                <!--
                 <param>TargetIP=valid_iscsi_target_ip</param>
                 <param>IQN=valid_iqn</param>
+                -->
                 <param>SSH_PRIVATE_KEY=sshKey</param>
             </testParams>
             <testScript>STOR_pass_offline.sh</testScript>


### PR DESCRIPTION
This commit changes the way STOR_pass_offline handles the TargetIP
and IQN parameters.
More specifically if those are not present inside the xml file the
test will be skipped and the logs will be set accordingly.
The options are now commented by default in the STOR_VHD xml file
so the test will be skipped.