### PR TITLE
UIO: fix unable to skip case for low kernel version

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/UIO_Basic.sh
@@ -42,7 +42,7 @@ CheckVMFeatureSupportStatus "3.10.0-692"
 if [ $? -ne 0 ]; then
     LogMsg "INFO: this kernel version does not support uio feature, skip test"
     UpdateSummary "INFO: this kernel version does not support uio feature, skip test"
-    UpdateTestState $ICA_TESTSKIPPED
+    SetTestStateSkipped
     exit 1
 fi
 


### PR DESCRIPTION
I used wrong function for the skipping, my apologies.