### PR TITLE
Fixed the init image check

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
@@ -153,7 +153,17 @@ fi
 if [ -f /boot/initramfs-0-rescue* ]; then
     img=/boot/initramfs-0-rescue*
 else
-    [[ -f "/boot/initrd-`uname -r`" ]] && img="/boot/initrd-`uname -r`" || [[ -f "/boot/initramfs-`uname -r`.img" ]] && img="/boot/initramfs-`uname -r`.img" || img="/boot/initrd.img-`uname -r`"
+  if [ -f "/boot/initrd-`uname -r`" ]; then
+    img="/boot/initrd-`uname -r`"
+  fi
+
+  if [ -f "/boot/initramfs-`uname -r`.img" ]; then
+    img="/boot/initramfs-`uname -r`.img"
+  fi
+
+  if [ -f "/boot/initrd.img-`uname -r`" ]; then
+    img="/boot/initrd.img-`uname -r`"
+  fi
 fi
 
 echo "The initrd test image is: $img" >> summary.log

--- a/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
@@ -200,7 +200,7 @@ case $img_type in
         if [ $? -eq 0 ]; then
             LogMsg "Info: Successfully unpacked the image."
         else
-            LogMsg "Error: Failed to unpack the initramfs image with gunzip."
+            LogMsg "Error: Failed to unpack the initramfs image with xzcat."
             echo "Error: Failed to unpack the initramfs image." >> /root/summary.log
             SetTestStateFailed
             exit 1


### PR DESCRIPTION
This commit fixes the way modules_check.sh checks for the init
image. Instead of having one 'IF' structure with multiple conditions
chained with logical 'OR' operators, the check is done using
multitple 'IF' instructions.
This prevents the error showing up in the log, in case the first
condition isn't true.