### PR TITLE
Fix test cases for middleware_bench

### DIFF
--- a/WS2012R2/lisa/tools/middleware_bench/report/results_parser.py
+++ b/WS2012R2/lisa/tools/middleware_bench/report/results_parser.py
@@ -1421,7 +1421,7 @@ class PostgreSQLLogsReader(BaseLogsReader):
         with open(log_file, 'r') as fl:
             for f_line in fl:
                 if not log_dict.get('TransactionType', None):
-                    transaction = re.match('\s*transaction\s*type:\s*(.+)', f_line)
+                    transaction = re.match('\s*transaction\s*type:\s*<builtin:\s*(\S+\s*\S+|\S+)(\s*\(.*|\s*)>', f_line)
                     if transaction:
                         log_dict['TransactionType'] = transaction.group(1).strip()
                 if not log_dict.get('ScalingFactor', None):

--- a/WS2012R2/lisa/tools/middleware_bench/tests/run_orion.sh
+++ b/WS2012R2/lisa/tools/middleware_bench/tests/run_orion.sh
@@ -40,6 +40,10 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
+if [ $# -gt 1 ]; then
+    sudo mdadm --stop /dev/md0
+    sudo umount /raid
+fi
 
 declare -a DISKS=("${@:1}")
 ORION_SCENARIO_FILE="orion"
@@ -98,7 +102,11 @@ chmod 755 /tmp/orion_linux_x86-64
 mkdir -p /tmp/orion
 for i in "${!DISKS[@]}"
 do
-    sudo mkfs.ext4 ${DISKS[$i]}
+    if [ $# -gt 1 ]; then
+        sudo sh -c 'echo y | mkfs.ext4 '"${DISKS[$i]}"''
+    else
+        sudo mkfs.ext4 ${DISKS[$i]}
+    fi
     sudo mkdir /stor${i}
     sudo mount ${DISKS[$i]} /stor${i}
     echo ${DISKS[$i]} >> /tmp/${ORION_SCENARIO_FILE}.lun

--- a/WS2012R2/lisa/tools/middleware_bench/tests/run_postgresql.sh
+++ b/WS2012R2/lisa/tools/middleware_bench/tests/run_postgresql.sh
@@ -62,6 +62,7 @@ if [[ ${distro} == *"Ubuntu"* ]]
 then
     echo -e "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" | sudo tee --append /etc/apt/sources.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+    sudo apt-get update
     sudo apt -y install bc sysstat zip postgresql-client-${POSTGRES_VERSION} postgresql-contrib-${POSTGRES_VERSION} >> ${LOG_FILE}
     ssh -T -o StrictHostKeyChecking=no ${USER}@${SERVER} "sudo apt -y install sysstat zip"
     ssh -T -o StrictHostKeyChecking=no ${USER}@${SERVER} "echo -e 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' | sudo tee --append /etc/apt/sources.list"

--- a/WS2012R2/lisa/tools/middleware_bench/tests/run_terasort.sh
+++ b/WS2012R2/lisa/tools/middleware_bench/tests/run_terasort.sh
@@ -33,6 +33,7 @@ fi
 
 USER="$1"
 STORE="$2"
+
 declare -a SLAVES=("${@:3}")
 LogMsg "slaves are: ${SLAVES}"
 teragen_records=500000000
@@ -57,6 +58,7 @@ if [[ ${distro} == *"Ubuntu"* ]]
 then
     sudo apt update
     sudo apt install -y zip maven libssl-dev build-essential rsync pkgconf cmake protobuf-compiler libprotobuf-dev default-jdk openjdk-8-jdk-headless bc
+    sudo sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
     if [ $? != 0 ]; then
         LogMsg "ERROR: Dependencies install failed."
     fi
@@ -307,6 +309,7 @@ do
         if [ $? != 0 ]; then
             LogMsg "ERROR: Dependencies install failed."
         fi
+        ssh -T -o StrictHostKeyChecking=no ${USER}@${SLAVES[$i]} "sudo sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' dist-upgrade" >> ${LOG_FILE}
         ssh -T -o StrictHostKeyChecking=no ${USER}@${SLAVES[$i]} "sudo apt upgrade -y procps" >> ${LOG_FILE}
     elif [[ ${distro} == *"Amazon"* ]]
     then

--- a/WS2012R2/lisa/tools/middleware_bench/tests/run_terasort.sh
+++ b/WS2012R2/lisa/tools/middleware_bench/tests/run_terasort.sh
@@ -36,7 +36,7 @@ STORE="$2"
 declare -a SLAVES=("${@:3}")
 LogMsg "slaves are: ${SLAVES}"
 teragen_records=500000000
-hadoop_version="hadoop-2.8.2"
+hadoop_version="hadoop-2.8.3"
 hadoop_store="/hadoop_store"
 hadoop_tmp="${hadoop_store}/hdfs/tmp"
 hadoop_namenode="${hadoop_store}/hdfs/namenode"

--- a/WS2012R2/lisa/tools/middleware_bench/utils/setup.py
+++ b/WS2012R2/lisa/tools/middleware_bench/utils/setup.py
@@ -108,6 +108,7 @@ class SetupTestEnv:
             self.device = self.get_disk_devices()
             self.ssh_client, self.vm_ips = self.get_instance_details()
             self.perf_tuning()
+            self.reconnect_sshclient()
         except Exception as e:
             log.exception(e)
             if self.connector:
@@ -151,6 +152,12 @@ class SetupTestEnv:
         for i in xrange(1, self.vm_count + 1):
             vms[i] = self.connector.create_vm()
         return vms
+
+    def reconnect_sshclient(self):
+        if self.provider == constants.AWS:
+            log.info('The provider is AWS, reconnect sshclient')
+            for i in xrange(1, self.vm_count + 1):
+                self.ssh_client[i].connect()
 
     def get_instance_details(self):
         """
@@ -237,6 +244,7 @@ class SetupTestEnv:
         current_path = os.path.dirname(sys.modules['__main__'].__file__)
         for i in range(1, self.vm_count + 1):
             log.info('Running perf tuning on {}'.format(self.vm_ips[i]))
+            self.ssh_client[i].connect()
             self.ssh_client[i].put_file(os.path.join(current_path, 'tests', 'perf_tuning.sh'),
                                         '/tmp/perf_tuning.sh')
             self.ssh_client[i].run('chmod +x /tmp/perf_tuning.sh')


### PR DESCRIPTION
Fix case issues for 
•test_postgresql
•test_orion_raid
•test_terasort
•test_zookeeper (only fail against AWS)
•test_terasort on AWS platform need interaction when run command apt upgrade -y procps 
