### PR TITLE
Fix Kdump results checking on NFS

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Results.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Results.sh
@@ -59,7 +59,7 @@ CheckVmcore()
 VerifyRemoteStatus()
 {
     array_status=( $status )
-    exit_code=${array_status[1]}
+    exit_code=${array_status[-1]}
     if [ $exit_code -eq 0 ]; then
         LogMsg "Test Successful. Proper file was found on nfs server."
         UpdateSummary "Test Successful. Proper file was found on nfs server."


### PR DESCRIPTION
If there is more than one file with size over 10MB, the array index
doesn't point to the exit code. Changed the code to use the last
element of the array for status checking.