### PR TITLE
Core Tests: Automation tweaks

### DIFF
--- a/WS2012R2/lisa/setupscripts/ChangeCPUIterated.ps1
+++ b/WS2012R2/lisa/setupscripts/ChangeCPUIterated.ps1
@@ -217,10 +217,14 @@ for ($numCPUs = $maxCPUs ;$numCPUs -gt 1 ;[int]$numCPUs = $numCPUs /2 )
 
     Start-VM -Name $vmName -ComputerName $hvServer
     #wait for ssh to start
-    if (-not (WaitForVMToStartSSH $ipv4 $timeout))
-    {
-        "Error: Test case timed out for VM to be running again!"
-        return $False
+    $new_ipv4 = GetIPv4AndWaitForSSHStart $vmName $hvServer $sshKey 300
+    if ($new_ipv4) {
+        # In some cases the IP changes after a reboot
+        Write-Output "${vmName} IP Address after reboot: ${new_ipv4}"
+        Set-Variable -Name "ipv4" -Value $new_ipv4 -Scope Global
+    } else {
+        "Error: VM $vmName failed to start after setting $numCPUs vCPUs"
+        return $False  
     }
 
     "Info: VM $vmName started with $numCPUs cores"

--- a/WS2012R2/lisa/xml/lis_pipeline_bvt.xml
+++ b/WS2012R2/lisa/xml/lis_pipeline_bvt.xml
@@ -379,7 +379,7 @@
         </testParams>
         <timeout>600</timeout>
         <onError>Continue</onError>
-        <noReboot>True</noReboot>
+        <noReboot>False</noReboot>
         </test>
 
         <!-- KVP and SQM Tests -->


### PR DESCRIPTION
1. Changed noReboot flag of VerifyIntegratedTimeSyncService TC from True
to False
2. Multi_Cpu_Test is now updating the ipv4 after a reboot to avoid
issues with ipv4 change