### PR TITLE
SR-IOV: Call trace check for various TCs

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_DisableVF.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_DisableVF.sh
@@ -177,6 +177,9 @@ while [ $__iterator -le $vfCount ]; do
     : $((__iterator++))
 done
 
+# Check for Call traces
+CheckCallTracesWithDelay 120
+
 LogMsg "Updating test case state to completed"
 SetTestStateCompleted
 exit 0

--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_MaxNIC.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_MaxNIC.sh
@@ -120,4 +120,7 @@ LogMsg $msg
 UpdateSummary "$msg"
 sleep 5
 
+# Check for Call traces
+CheckCallTracesWithDelay 120
+
 SetTestStateCompleted

--- a/WS2012R2/lisa/remote-scripts/ica/SR-IOV_ModuleReload.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/SR-IOV_ModuleReload.sh
@@ -217,6 +217,9 @@ if [ 0 -ne $? ]; then
     SetTestStateFailed
 fi
 
+# Check for Call traces
+CheckCallTracesWithDelay 120
+
 # Ping the remote host after bringing down the VF
 ping -I "eth1" -c 10 "$VF_IP2" >/dev/null 2>&1
 if [ 0 -eq $? ]; then

--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -2228,3 +2228,23 @@ ListInterfaces()
     fi
     LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
 }
+
+# Function that will check for Call Traces on VM after 2 minutes
+# This function assumes that check_traces.sh is already on the VM
+CheckCallTracesWithDelay()
+{
+    dos2unix -q check_traces.sh
+    echo 'sleep 5 && bash ~/check_traces.sh ~/check_traces.log &' > runtest_traces.sh
+    bash runtest_traces.sh > check_traces.log 2>&1
+    sleep $1
+    cat ~/check_traces.log | grep ERROR
+    if [ $? -eq 0 ]; then
+        msg="ERROR: Call traces have been found on VM after the test run"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 1
+    else
+        return 0
+    fi
+}

--- a/WS2012R2/lisa/setupscripts/SR-IOV_Deattach_NIC.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_Deattach_NIC.ps1
@@ -244,4 +244,13 @@ if ($finalRTT -gt $initialRTT) {
     return $false 
 }
 
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
+
 return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_DisableNIC.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_DisableNIC.ps1
@@ -273,4 +273,13 @@ if ($vfFinalThroughput -lt  $vfInitialThroughput) {
     return $false 
 }
 
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
+
 return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_Host_Disable.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_Host_Disable.ps1
@@ -254,7 +254,7 @@ if (-not $?) {
     return $false 
 }
 
-Start-Sleep -s 50
+Start-Sleep -s 70
 
 # Read the throughput again, it should be higher than before
 # We should see a throughput at least 70% higher
@@ -271,4 +271,12 @@ if ($vfFinalThroughput -lt  $vfInitialThroughput) {
     return $false 
 }
 
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
 return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_Ping_DisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_Ping_DisableVF.ps1
@@ -240,4 +240,13 @@ if ($vfFinalRTT -gt $vfEnabledRTT) {
     return $false 
 }
 
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
+
 return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_SavePauseVM.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_SavePauseVM.ps1
@@ -294,4 +294,14 @@ if (-not $retVal)
 
 Start-Sleep -s 10
 "File was successfully sent from VM1 to VM2 after resuming VM" | Tee-Object -Append -file $summaryLog
+
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
+
 return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_Stress_SavePause.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_Stress_SavePause.ps1
@@ -331,5 +331,14 @@ while ($isDone -eq $False)
     "Run $counter :: Time to switch between netvsc and VF was $timeToSwitch seconds. Throughput was $vfAfterThroughput gbps"
 }
 
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
+
 "VM $vmName changed its state for $counter times and no issues were encountered" | Tee-Object -Append -file $summaryLog
 return $true

--- a/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_DisableVF.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_iPerf_DisableVF.ps1
@@ -252,4 +252,13 @@ if ($vfEnabledThroughput -gt $vfFinalThroughput ) {
     return $false 
 }
 
+# Wait 2 minutes and check call traces
+$retVal = CheckCallTracesWithDelay $sshKey $ipv4
+if (-not $retVal) {
+    Write-Output "ERROR: Call traces have been found on VM after the test run" | Tee-Object -Append -file $summaryLog
+    return $false
+} else {
+    Write-Output "Info: No Call Traces have been found on VM" | Tee-Object -Append -file $summaryLog
+}
+
 return $true

--- a/WS2012R2/lisa/xml/SR-IOV.xml
+++ b/WS2012R2/lisa/xml/SR-IOV.xml
@@ -138,7 +138,7 @@
         <test>
             <testName>DisableVF</testName>
             <testScript>SR-IOV_DisableVF.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_DisableVF.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/SR-IOV_DisableVF.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -154,7 +154,7 @@
         <test>
             <testName>ModuleReload</testName>
             <testScript>SR-IOV_ModuleReload.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_ModuleReload.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/SR-IOV_ModuleReload.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -170,7 +170,7 @@
         <test>
             <testName>Ping_DisableVF</testName>
             <testScript>setupscripts\SR-IOV_Ping_DisableVF.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files>  
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -186,7 +186,7 @@
         <test>
             <testName>iPerf_DisableVF</testName>
             <testScript>setupscripts\SR-IOV_iPerf_DisableVF.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files>  
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -202,7 +202,7 @@
         <test>
             <testName>Deattach_Attach_NIC</testName>
             <testScript>setupscripts\SR-IOV_Deattach_NIC.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files>  
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -218,7 +218,7 @@
         <test>
             <testName>Host_Disable_SRIOV</testName>
             <testScript>setupscripts\SR-IOV_Host_Disable.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -234,7 +234,7 @@
         <test>
             <testName>DisableNIC</testName>
             <testScript>setupscripts\SR-IOV_DisableNIC.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -489,7 +489,7 @@
         <test>
             <testName>MaxNICS</testName>
             <testScript>SR-IOV_MaxNIC.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_MaxNIC.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/SR-IOV_MaxNIC.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -507,7 +507,7 @@
         <test>
             <testName>MaxNICS_vCPU</testName>
             <testScript>SR-IOV_MaxNIC.sh</testScript>
-            <files>remote-scripts/ica/SR-IOV_MaxNIC.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh</files> 
+            <files>remote-scripts/ica/SR-IOV_MaxNIC.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/SR-IOV_Utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupScripts\ChangeCPU.ps1</file>
@@ -529,7 +529,7 @@
         <test>
             <testName>Single_PauseVM</testName>
             <testScript>setupScripts\SR-IOV_SavePauseVM.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files>  
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -548,7 +548,7 @@
         <test>
             <testName>Stress_PauseVM</testName>
             <testScript>setupScripts\SR-IOV_Stress_SavePause.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -566,7 +566,7 @@
         <test>
             <testName>Single_SaveVM</testName>
             <testScript>setupScripts\SR-IOV_SavePauseVM.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files>  
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>
@@ -584,7 +584,7 @@
         <test>
             <testName>Stress_SaveVM</testName>
             <testScript>setupScripts\SR-IOV_Stress_SavePause.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh</files> 
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files> 
             <setupScript>
                 <file>setupscripts\RevertSnapshot.ps1</file>
                 <file>setupscripts\SR-IOV_enable.ps1</file>


### PR DESCRIPTION
In some kernels, failback and max NICs TCs triggered a call trace
that wasn't logged. This adds a check for this.