### PR TITLE
stateEngine: Fix two incorrect xml references

### DIFF
--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -1646,7 +1646,7 @@ function DoDiagnoseHungSystem([System.Xml.XmlElement] $vm, [XML] $xmlData, [Stri
                         # UpdateState $vm $ForceShutdown
                         UpdateState $vm $Disabled
                     }
-                    SetTestResult $vm.suite $currentTest $completionCode $xmlData
+                    SetTestResult $vm.suite $vm.currentTest $completionCode $xmlData
                     $vm.emailSummary += ("    Test {0,-25} : {1}<br />" -f $testName, $completionCode)
                     UpdateState $vm $ForceShutdown
                 }
@@ -2086,7 +2086,7 @@ function DoRunPreTestScript([System.Xml.XmlElement] $vm, [XML] $xmlData)
                     }
                     else # Original syntax of <pretest>setupscripts\myPretest.ps1</pretest>
                     {
-                        LogMsg 3 "Info : $($vm.vmName) - starting preTest script $($testData.setupScript)"
+                        LogMsg 3 "Info : $($vm.vmName) - starting preTest script $($testData.preTest)"
 
                         $sts = RunPSScript $vm $($testData.preTest) $xmlData "PreTest"
                         if (-not $sts)

--- a/WS2012R2/lisa/stateEngine.ps1
+++ b/WS2012R2/lisa/stateEngine.ps1
@@ -1571,7 +1571,8 @@ function DoDiagnoseHungSystem([System.Xml.XmlElement] $vm, [XML] $xmlData, [Stri
             LogMsg 0 "Warn : Test is set to abort on error. Exiting"
             $vm.currentTest = "done"
         }
-        SetTestResult $currentTest $completionCode $xmlData
+        SetTestResult $vm.suite $vm.currentTest $completionCode $xmlData
+        $vm.emailSummary += ("    Test {0,-25} : {1}<br />" -f $testName, $completionCode)
         UpdateState $vm $Finished
     }
     else


### PR DESCRIPTION
When starting a preTest script, console output would be like
"starting preTest script System.XML.XmlElement"

If VM become unable to start after running setupScript, test case
name in test result will be set to "System.XML.XmlElement"