### PR TITLE
Skip Heartbeat_PausedCritical on WS2012

### DIFF
--- a/WS2012R2/lisa/setupscripts/Core_Heartbeat_PausedCritical.ps1
+++ b/WS2012R2/lisa/setupscripts/Core_Heartbeat_PausedCritical.ps1
@@ -108,6 +108,13 @@ Write-Output "This script covers test case: ${tcCovered}" | Tee-Object -Append -
 # Source the TCUtils.ps1 file
 . .\setupscripts\TCUtils.ps1
 
+# Check host version and skipp TC in case of WS2012 or older
+$hostVersion = GetHostBuildNumber $hvServer
+if ($hostVersion -le 9200) {
+    Write-Output "Info: Host is WS2012 or older. Skipping test case." | Tee-Object -Append -file $summaryLog
+    return $Skipped
+}
+
 # check what drive letter is available and pick one randomly
 $driveletter = ls function:[g-y]: -n | ?{ !(test-path $_) } | random
 
@@ -200,7 +207,7 @@ if (-not $?)
 }
 
 #Get VM Generation
-$vm_gen = Get-VM $vmName -ComputerName $hvServer | select -ExpandProperty Generation -ErrorAction SilentlyContinue
+$vm_gen = GetVMGeneration $vmName $hvServer
 
 $vmName1 = "${vmName}_ChildVM"
 # Remove old VM

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -1597,7 +1597,8 @@ function GetParentVHD($vmName, $hvServer)
        return $False
     }
 
-    if ( $VmInfo.Generation -eq "" -or $VmInfo.Generation -eq 1  ) {
+    $vmGen = GetVMGeneration $vmName $hvServer
+    if ( $vmGen -eq 1  ) {
         $Disks = $VmInfo.HardDrives
         foreach ($VHD in $Disks) {
             if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "IDE"  )) {
@@ -1613,7 +1614,7 @@ function GetParentVHD($vmName, $hvServer)
             }
         }
     }
-    if ( $VmInfo.Generation -eq 2 ) {
+    if ( $vmGen -eq 2 ) {
         $Disks = $VmInfo.HardDrives
         foreach ($VHD in $Disks) {
             if ( ($VHD.ControllerLocation -eq 0 ) -and ($VHD.ControllerType -eq "SCSI"  )) {


### PR DESCRIPTION
Skipping Heartbeat_PausedCritical TC on WS2012. Changed GetParentVHD
to use GetVMGeneration method for better VM generation handling.