### PR TITLE
Minor update SR-IOV_GetMLNXInfo and SR-IOV_Host_Disable to support ru…

### DIFF
--- a/WS2012R2/lisa/setupscripts/SR-IOV_GetMLNXInfo.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_GetMLNXInfo.ps1
@@ -19,7 +19,7 @@
 #
 ########################################################################
 
-<# 
+<#
 .Synopsis
  This script will gather information about the Mellanox driver from the host.
 
@@ -27,14 +27,20 @@
  This script will use the MLNXProvider module to collect information about the
  Mellanox driver installed on the host and will output it to HostMellanoxInfo.log
 
+ .Parameter vmName
+     Name of the test VM.
+
+ .Parameter hvServer
+     Name of the Hyper-V server hosting the VM.
+
 .Parameter testParams
  Test data for this test case
 
 .Example
- setupScripts\SR-IOV_GetMLNXInfo.ps1 -testParams "rootDir=C:\myFolder\"
+ setupScripts\SR-IOV_GetMLNXInfo.ps1 -vmName vmNmae -hvServer hvserver -testParams "rootDir=C:\myFolder\"
 #>
 
-param([string] $testParams)
+param ([String] $vmName, [String] $hvServer, [string] $testParams)
 
 $params = $testParams.Split(";")
 foreach ($p in $params) {
@@ -55,14 +61,18 @@ if (Test-Path $summaryLog) {
     del $summaryLog
 }
 
-$checkModule = Get-Module -ListAvailable | Select-String -Pattern MLNXProvider -quiet
+$remoteSession = New-PSSession -ComputerName $hvServer
+
+$checkModule = Get-Module -ListAvailable -PSSession $remoteSession | Select-String -Pattern MLNXProvider -quiet
 if ($checkModule) {
-    Import-Module MLNXProvider
+    Import-Module MLNXProvider -PSSession $remoteSession
 } else {
     Write-Output "Error: No Mellanox module found."
+    Remove-PSSession $remoteSession -ErrorAction SilentlyContinue
     Exit 0
 }
 
+# After import-module, the imported commands run implicitly in the current session
 $driverVersion = (Get-MLNXPCIDevice).DriverVersion
 if ($? -ne "True") {
     $driverVersion = "Error: Cannot get driver version."
@@ -94,4 +104,5 @@ if ($? -ne "True") {
     $vmFriendlyName = "Error: Cannot get VM Friendly name."
 }
 
+Remove-PSSession $remoteSession -ErrorAction SilentlyContinue
 return $true


### PR DESCRIPTION
…n on remote machine

In order to debug SR-IOV test case in remote machine, minor update SR-IOV_GetMLNXInfo.ps1 and SR-IOV_Host_Disable.ps1.

1) import-module support parameter -PSSession
 Refer to https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/import-module?view=powershell-6
To manage remote computers that run the Windows operating system that have Windows PowerShell and Windows PowerShell remoting enabled, create a PSSession on the remote computer and then use the PSSession parameter of Get-Module to get the Windows PowerShell modules in the PSSession. When you import the modules, and then use the imported commands in the current session, the commands run implicitly in the PSSession on the remote computer. You can use this strategy to manage the remote computer.

2) Enable-netAdapterSRIOV - CIMSession 
Refer to https://docs.microsoft.com/en-us/powershell/module/netadapter/enable-netadaptersriov?view=win10-ps
Runs the cmdlet in a remote session or on a remote computer. Enter a computer name or a session object, such as the output of a New-CimSession or Get-CimSession cmdlet. The default is the current session on the local computer.

Thank you so much.
