### PR TITLE
Minor update fc Set-VMSecurity for gen2 vm in 2016 host

### DIFF
--- a/WS2012R2/lisa/setupscripts/FC_AddFibreChannelHba.ps1
+++ b/WS2012R2/lisa/setupscripts/FC_AddFibreChannelHba.ps1
@@ -129,6 +129,15 @@ if (-not $vSANName) {
 #
 #############################################################
 
+# Set-VMSecurity to add FC adapter for Generation 2 vm on Hyper-v 2016 host
+Get-Command "Set-VMSecurity" -ErrorAction SilentlyContinue
+if ($?) {
+    $gen = (Get-VM -Name $vmName -ComputerName $hvserver).Generation
+    if ($gen -eq 2){
+        Set-VMSecurity -VmName $vmName -ComputerName $hvServer -VirtualizationBasedSecurityOptOut $true
+    }
+}
+
 # Add the FC adapter, if the command is successful there is no output
 Write-Output "Adding the Fibre Channel adapter..."
 if ((Add-VMFibreChannelHba -VmName $vmName -SanName $vSANName -ComputerName $hvServer)-ne $null) {
@@ -138,7 +147,7 @@ if ((Add-VMFibreChannelHba -VmName $vmName -SanName $vSANName -ComputerName $hvS
 
 # If specific port addresses are used check to see if they are available
 if (($WWNN -ne $null) -and ($WWPN -ne $null)) {
-    $FCList = Get-VMFibreChannelHba -VMName (Get-VM).name -ComputerName $hvServer
+    $FCList = Get-VMFibreChannelHba -VMName (Get-VM -ComputerName $hvServer).name -ComputerName $hvServer
     foreach ($fcNIC in $FCList) {
         if ($WWPN -contains $fcNIC.WorldWidePortNameSetA) {
             $usedVM = $fcNIC.VMName

--- a/WS2012R2/lisa/setupscripts/FC_SaveRestoreVM.ps1
+++ b/WS2012R2/lisa/setupscripts/FC_SaveRestoreVM.ps1
@@ -24,7 +24,7 @@
     Saves and restores a VM while the fibre channel is connected.
 
 .Description
-    This is a postTest script to check for save/restore VM operation 
+    This is a postTest script to check for save/restore VM operation
     functionality.
 
 .Parameter vmName
@@ -73,9 +73,9 @@ while ((Get-VM -ComputerName $hvServer -Name $vmName).State -eq "On") {
    Start-Sleep -Seconds 5
 }
 do {
-	Start-Sleep -Seconds 5 
+	Start-Sleep -Seconds 5
 }
-until ((Get-VMIntegrationService $vmName | ?{$_.name -eq "Heartbeat"}).PrimaryStatusDescription -eq "OK")
+until ((Get-VMIntegrationService -ComputerName $hvServer -VMName $vmName | ?{$_.name -eq "Heartbeat"}).PrimaryStatusDescription -eq "OK")
 
 try {
 	# Saving the VM
@@ -90,7 +90,7 @@ try {
         Start-Sleep -Seconds 5
     }
 }
-catch [system.exception] 
+catch [system.exception]
 {
        Write-Host "Error: VM $vmName could not be saved!" | Tee-Object -Append -file $summaryLog
        return $False
@@ -98,7 +98,7 @@ catch [system.exception]
 
 if ((Get-VM -ComputerName $hvServer -Name $vmName).State -ne "On") {
     #Resuming VM from saved state
-    Start-VM -ComputerName $hvServer -Name $vmName 
+    Start-VM -ComputerName $hvServer -Name $vmName
     if (-not $?) {
         write-output "Error: Unable to resume VM $vmName"
         return $False
@@ -111,8 +111,8 @@ while ((Get-VM -ComputerName $hvServer -Name $vmName).State -eq "On") {
    Start-Sleep -Seconds 5
 }
 do {
-    Start-Sleep -Seconds 5 
+    Start-Sleep -Seconds 5
 }
-until ((Get-VMIntegrationService $vmName | ?{$_.name -eq "Heartbeat"}).PrimaryStatusDescription -eq "OK")
+until ((Get-VMIntegrationService -ComputerName $hvServer -VMName $vmName | ?{$_.name -eq "Heartbeat"}).PrimaryStatusDescription -eq "OK")
 Write-Output "Machine successfully resumed."
 return $True


### PR DESCRIPTION
…ityOptOut

Two minor updates:
1) When adding FC adapter to VM, if does not set  "Set-VMSecurity -VmName $vmName -ComputerName $hvServer -VirtualizationBasedSecurityOptOut $true", will get error message about "xx" failed to add resources to "xx"
Cannot modify property without enabling VirtualizationBasedSecurityOptOut for Hyper-v 2016 host on Gen2 Vm.

2) Update get-vm to support remote machine