### PR TITLE
Minor update HV_SOCK_Basic Test_Type since local have different TC_Co…

### DIFF
--- a/WS2012R2/lisa/setupscripts/HV_Sock_Basic.ps1
+++ b/WS2012R2/lisa/setupscripts/HV_Sock_Basic.ps1
@@ -307,6 +307,9 @@ foreach ($p in $params) {
     if ($fields[0].Trim() -eq "TC_COVERED") {
         $TC_COVERED = $fields[1].Trim()
     }
+    if ($fields[0].Trim() -eq "TEST_TYPE") {
+        $TEST_TYPE = $fields[1].Trim()
+    }
     if ($fields[0].Trim() -eq "rootDir") {
         $rootDir = $fields[1].Trim()
     }
@@ -404,7 +407,7 @@ if (@($ReturnCode)[-1] -ne $True) {
 #   Main Test
 ################################################
 
-switch ($TC_COVERED[-1])
+switch ($TEST_TYPE)
 {
     # Test Part I: Client app on guest connects server app on host
     1 { $retVal = Test_Part_I; break }

--- a/WS2012R2/lisa/xml/HV_Sock.xml
+++ b/WS2012R2/lisa/xml/HV_Sock.xml
@@ -55,6 +55,7 @@
             <files>tools/hv-sock/client_on_vm.c</files>
             <testParams>
                 <param>TC_COVERED=HV-Sock-01</param>
+                <param>TEST_TYPE=1</param>
             </testParams>
             <timeout>400</timeout>
         </test>
@@ -65,6 +66,7 @@
             <files>tools/hv-sock/server_on_vm.c</files>
             <testParams>
                 <param>TC_COVERED=HV-Sock-02</param>
+                <param>TEST_TYPE=2</param>
             </testParams>
             <timeout>400</timeout>
         </test>


### PR DESCRIPTION
…vered value

Locally have random test case ID (without 1,2 at the end of name), cannot use TC_COVERED to select test part, so add TEST_TYPE here.