### PR TITLE
Add sleep prameter after network restart

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/NET_TEST_NETWORK.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/NET_TEST_NETWORK.sh
@@ -22,53 +22,53 @@
 #####################################################################
 
 # Description:
-#	This script verifies that all synthetic interfaces can ping an IP Address and cannot ping at least one IP Address.
-#	Usually there is one ping-able address specified, that is on the same network as the interface(s) and two for
-#	the other two network adapter types, which should not be ping-able.
+#    This script verifies that all synthetic interfaces can ping an IP Address and cannot ping at least one IP Address.
+#    Usually there is one ping-able address specified, that is on the same network as the interface(s) and two for
+#    the other two network adapter types, which should not be ping-able.
 #
-#	Steps:
-#	1. Verify configuration file constants.sh
-#	2. Determine synthetic network interfaces
-#	3. Set static IPs on interfaces
-#		3a. If static IP is not configured, get address(es) via dhcp
-#	4. Ping IPs
+#    Steps:
+#    1. Verify configuration file constants.sh
+#    2. Determine synthetic network interfaces
+#    3. Set static IPs on interfaces
+#        3a. If static IP is not configured, get address(es) via dhcp
+#    4. Ping IPs
 #
-#	The test is successful if all available synthetic interfaces are able to ping the $PING_SUCC IP address
-#	and fail to ping the $PING_FAIL IP address(es). One common test-scenario is to have an external network adapter
-#	be able to ping an IP on the same external network, but fails to ping the internal network and the guest-only network.
+#    The test is successful if all available synthetic interfaces are able to ping the $PING_SUCC IP address
+#    and fail to ping the $PING_FAIL IP address(es). One common test-scenario is to have an external network adapter
+#    be able to ping an IP on the same external network, but fails to ping the internal network and the guest-only network.
 #
-#	Parameters required:
-#		PING_SUCC
-#		PING_FAIL
+#    Parameters required:
+#        PING_SUCC
+#        PING_FAIL
 #
-#	Optional parameters:
-#		STATIC_IP
-#		TC_COVERED
-#		NETMASK
-#		PING_FAIL2
-#		DISABLE_NM
-#		GATEWAY
-#		TC_COVERED
+#    Optional parameters:
+#        STATIC_IP
+#        TC_COVERED
+#        NETMASK
+#        PING_FAIL2
+#        DISABLE_NM
+#        GATEWAY
+#        TC_COVERED
 #
-#	Parameter explanation:
-#	STATIC_IP is the address that will be assigned to the VM's synthetic network adapter. Multiple Addresses can be specified
-#	separated by , (comma) and they will be assigned in order to each interface found.
-#	NETMASK of this VM's subnet. Defaults to /24 if not set.
-#	PING_SUCC is an IP address of a ping-able machine, which should succeed
-#	PING_FAIL is an IP address of a non-ping-able machine
-#	PING_FAIL2 is an IP address of a non-ping-able machine
-#	DISABLE_NM can be set to 'yes' to disable the NetworkManager.
-#	GATEWAY is the IP Address of the default gateway
-#	TC_COVERED is the LIS testcase number
+#    Parameter explanation:
+#    STATIC_IP is the address that will be assigned to the VM's synthetic network adapter. Multiple Addresses can be specified
+#    separated by , (comma) and they will be assigned in order to each interface found.
+#    NETMASK of this VM's subnet. Defaults to /24 if not set.
+#    PING_SUCC is an IP address of a ping-able machine, which should succeed
+#    PING_FAIL is an IP address of a non-ping-able machine
+#    PING_FAIL2 is an IP address of a non-ping-able machine
+#    DISABLE_NM can be set to 'yes' to disable the NetworkManager.
+#    GATEWAY is the IP Address of the default gateway
+#    TC_COVERED is the LIS testcase number
 #############################################################################################################
 # Convert eol
 dos2unix utils.sh
 
 # Source utils.sh
 . utils.sh || {
-	echo "Error: unable to source utils.sh!"
-	echo "TestAborted" > state.txt
-	exit 2
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
 }
 
 # Source constants file and initialize most common variables
@@ -76,67 +76,67 @@ UtilsInit
 
 # In case of error
 case $? in
-	0)
-		#do nothing, init succeeded
-		;;
-	1)
-		LogMsg "Unable to cd to $LIS_HOME. Aborting..."
-		UpdateSummary "Unable to cd to $LIS_HOME. Aborting..."
-		SetTestStateAborted
-		exit 3
-		;;
-	2)
-		LogMsg "Unable to use test state file. Aborting..."
-		UpdateSummary "Unable to use test state file. Aborting..."
-		# need to wait for test timeout to kick in
-			# hailmary try to update teststate
-			sleep 60
-			echo "TestAborted" > state.txt
-		exit 4
-		;;
-	3)
-		LogMsg "Error: unable to source constants file. Aborting..."
-		UpdateSummary "Error: unable to source constants file"
-		SetTestStateAborted
-		exit 5
-		;;
-	*)
-		# should not happen
-		LogMsg "UtilsInit returned an unknown error. Aborting..."
-		UpdateSummary "UtilsInit returned an unknown error. Aborting..."
-		SetTestStateAborted
-		exit 6
-		;;
+    0)
+        #do nothing, init succeeded
+        ;;
+    1)
+        LogMsg "Unable to cd to $LIS_HOME. Aborting..."
+        UpdateSummary "Unable to cd to $LIS_HOME. Aborting..."
+        SetTestStateAborted
+        exit 3
+        ;;
+    2)
+        LogMsg "Unable to use test state file. Aborting..."
+        UpdateSummary "Unable to use test state file. Aborting..."
+        # need to wait for test timeout to kick in
+            # hailmary try to update teststate
+            sleep 60
+            echo "TestAborted" > state.txt
+        exit 4
+        ;;
+    3)
+        LogMsg "Error: unable to source constants file. Aborting..."
+        UpdateSummary "Error: unable to source constants file"
+        SetTestStateAborted
+        exit 5
+        ;;
+    *)
+        # should not happen
+        LogMsg "UtilsInit returned an unknown error. Aborting..."
+        UpdateSummary "UtilsInit returned an unknown error. Aborting..."
+        SetTestStateAborted
+        exit 6
+        ;;
 esac
 
 # Parameter provided in constants file
 declare -a STATIC_IPS=()
 
 if [ "${STATIC_IP:-UNDEFINED}" = "UNDEFINED" ]; then
-	msg="The test parameter STATIC_IP is not defined in constants file. Will try to set addresses via dhcp"
-	LogMsg "$msg"
+    msg="The test parameter STATIC_IP is not defined in constants file. Will try to set addresses via dhcp"
+    LogMsg "$msg"
 else
 
-	# Split (if necessary) IP Adddresses based on , (comma)
-	IFS=',' read -a STATIC_IPS <<< "$STATIC_IP"
+    # Split (if necessary) IP Adddresses based on , (comma)
+    IFS=',' read -a STATIC_IPS <<< "$STATIC_IP"
 
-	declare -i __iterator
-	# Validate that $STATIC_IP is the correct format
-	for __iterator in ${!STATIC_IPS[@]}; do
+    declare -i __iterator
+    # Validate that $STATIC_IP is the correct format
+    for __iterator in ${!STATIC_IPS[@]}; do
 
-		CheckIP "${STATIC_IPS[$__iterator]}"
+        CheckIP "${STATIC_IPS[$__iterator]}"
 
-		if [ 0 -ne $? ]; then
-			msg="Variable STATIC_IP: ${STATIC_IPS[$__iterator]} does not contain a valid IPv4 address "
-			LogMsg "$msg"
-			UpdateSummary "$msg"
-			SetTestStateAborted
-			exit 30
-		fi
+        if [ 0 -ne $? ]; then
+            msg="Variable STATIC_IP: ${STATIC_IPS[$__iterator]} does not contain a valid IPv4 address "
+            LogMsg "$msg"
+            UpdateSummary "$msg"
+            SetTestStateAborted
+            exit 30
+        fi
 
-	done
+    done
 
-	unset __iterator
+    unset __iterator
 
 fi
 
@@ -145,23 +145,23 @@ IFS=',' read -a networkType <<< "$NIC"
 if [ "${NETMASK:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter NETMASK is not defined in constants file . Defaulting to 255.255.255.0"
     LogMsg "$msg"
-	NETMASK=255.255.255.0
+    NETMASK=255.255.255.0
 fi
 
 if [ "${PING_SUCC:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter PING_SUCC is not defined in constants file"
     LogMsg "$msg"
-	UpdateSummary "$msg"
-	SetTestStateAborted
-	exit 30
+    UpdateSummary "$msg"
+    SetTestStateAborted
+    exit 30
 fi
 
 if [ "${PING_FAIL:-UNDEFINED}" = "UNDEFINED" ]; then
     msg="The test parameter PING_FAIL is not defined in constants file"
     LogMsg "$msg"
-	UpdateSummary "$msg"
-	SetTestStateAborted
-	exit 30
+    UpdateSummary "$msg"
+    SetTestStateAborted
+    exit 30
 fi
 
 #
@@ -191,78 +191,78 @@ fi
 # set gateway parameter
 if [ "${GATEWAY:-UNDEFINED}" = "UNDEFINED" ]; then
     if [ "${networkType[2]}" = "External" ]; then
-    	msg="The test parameter GATEWAY is not defined in constants file . The default gateway will be set for all interfaces."
-    	LogMsg "$msg"
-		GATEWAY=$(/sbin/ip route | awk '/default/ { print $3 }')
-	else
-		msg="The test parameter GATEWAY is not defined in constants file . No gateway will be set."
-		LogMsg "$msg"
-		GATEWAY=''
-	fi
+        msg="The test parameter GATEWAY is not defined in constants file . The default gateway will be set for all interfaces."
+        LogMsg "$msg"
+        GATEWAY=$(/sbin/ip route | awk '/default/ { print $3 }')
+    else
+        msg="The test parameter GATEWAY is not defined in constants file . No gateway will be set."
+        LogMsg "$msg"
+        GATEWAY=''
+    fi
 else
-	CheckIP "$GATEWAY"
+    CheckIP "$GATEWAY"
 
-	if [ 0 -ne $? ]; then
-		msg=""
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateAborted
-		exit 10
-	fi
+    if [ 0 -ne $? ]; then
+        msg=""
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateAborted
+        exit 10
+    fi
 fi
 
 declare __iface_ignore
 
 # Parameter provided in constants file
-#	ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
-#	it is not touched during this test (no dhcp or static ip assigned to it)
+#    ipv4 is the IP Address of the interface used to communicate with the VM, which needs to remain unchanged
+#    it is not touched during this test (no dhcp or static ip assigned to it)
 
 if [ "${ipv4:-UNDEFINED}" = "UNDEFINED" ]; then
-	msg="The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
-	LogMsg "$msg"
-	UpdateSummary "$msg"
-	SetTestStateAborted
-	exit 30
+    msg="The test parameter ipv4 is not defined in constants file! Make sure you are using the latest LIS code."
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateAborted
+    exit 30
 else
 
-	CheckIP "$ipv4"
+    CheckIP "$ipv4"
 
-	if [ 0 -ne $? ]; then
-		msg="Test parameter ipv4 = $ipv4 is not a valid IP Address"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateAborted
-		exit 10
-	fi
+    if [ 0 -ne $? ]; then
+        msg="Test parameter ipv4 = $ipv4 is not a valid IP Address"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateAborted
+        exit 10
+    fi
 
-	# Get the interface associated with the given ipv4
-	__iface_ignore=$(ip -o addr show | grep "$ipv4" | cut -d ' ' -f2)
+    # Get the interface associated with the given ipv4
+    __iface_ignore=$(ip -o addr show | grep "$ipv4" | cut -d ' ' -f2)
 fi
 
 if [ "${DISABLE_NM:-UNDEFINED}" = "UNDEFINED" ]; then
-	msg="The test parameter DISABLE_NM is not defined in constants file. If the NetworkManager is running it could interfere with the test."
-	LogMsg "$msg"
+    msg="The test parameter DISABLE_NM is not defined in constants file. If the NetworkManager is running it could interfere with the test."
+    LogMsg "$msg"
 else
-	if [[ "$DISABLE_NM" =~ [Yy][Ee][Ss] ]]; then
+    if [[ "$DISABLE_NM" =~ [Yy][Ee][Ss] ]]; then
 
-		# work-around for suse where the network gets restarted in order to shutdown networkmanager.
-		declare __orig_netmask
-		GetDistro
-		case "$DISTRO" in
-			suse*)
-				__orig_netmask=$(ip -o addr show | grep "$ipv4" | cut -d '/' -f2 | cut -d ' ' -f1)
-				;;
-		esac
-		DisableNetworkManager
-		case "$DISTRO" in
-			suse*)
-				ip link set "$__iface_ignore" down
-				ip addr flush dev "$__iface_ignore"
-				ip addr add "$ipv4"/"$__orig_netmask" dev "$__iface_ignore"
-				ip link set "$__iface_ignore" up
-				;;
-		esac
-	fi
+        # work-around for suse where the network gets restarted in order to shutdown networkmanager.
+        declare __orig_netmask
+        GetDistro
+        case "$DISTRO" in
+            suse*)
+                __orig_netmask=$(ip -o addr show | grep "$ipv4" | cut -d '/' -f2 | cut -d ' ' -f1)
+                ;;
+        esac
+        DisableNetworkManager
+        case "$DISTRO" in
+            suse*)
+                ip link set "$__iface_ignore" down
+                ip addr flush dev "$__iface_ignore"
+                ip addr add "$ipv4"/"$__orig_netmask" dev "$__iface_ignore"
+                ip link set "$__iface_ignore" up
+                ;;
+        esac
+    fi
 fi
 
 # Retrieve synthetic network interfaces
@@ -280,11 +280,11 @@ fi
 SYNTH_NET_INTERFACES=(${SYNTH_NET_INTERFACES[@]/$__iface_ignore/})
 
 if [ ${#SYNTH_NET_INTERFACES[@]} -eq 0 ]; then
-	msg="The only synthetic interface is the one which LIS uses to send files/commands to the VM."
-	LogMsg "$msg"
-	UpdateSummary "$msg"
-	SetTestStateAborted
-	exit 10
+    msg="The only synthetic interface is the one which LIS uses to send files/commands to the VM."
+    LogMsg "$msg"
+    UpdateSummary "$msg"
+    SetTestStateAborted
+    exit 10
 fi
 
 LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_INTERFACES[*]} in VM"
@@ -293,34 +293,34 @@ LogMsg "Found ${#SYNTH_NET_INTERFACES[@]} synthetic interface(s): ${SYNTH_NET_IN
 # First, verify if an interface with a given MAC address exists on the VM
 if [ "${MAC:-UNDEFINED}" != "UNDEFINED" ]; then
 
-	__sys_interface=$(grep -il "$MAC" /sys/class/net/*/address)
-	if [ 0 -ne $? ]; then
-		msg="MAC Address $MAC does not belong to any interface."
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 10
-	else
-		msg="MAC Address $MAC was found on the VM"
-		UpdateSummary "$msg"
-		LogMsg "$msg"	
-	fi
+    __sys_interface=$(grep -il "$MAC" /sys/class/net/*/address)
+    if [ 0 -ne $? ]; then
+        msg="MAC Address $MAC does not belong to any interface."
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 10
+    else
+        msg="MAC Address $MAC was found on the VM"
+        UpdateSummary "$msg"
+        LogMsg "$msg"    
+    fi
 fi
 
 declare -i __iterator
 for __iterator in "${!SYNTH_NET_INTERFACES[@]}"; do
-	ip link show "${SYNTH_NET_INTERFACES[$__iterator]}" >/dev/null 2>&1
-	if [ 0 -ne $? ]; then
-		msg="Invalid synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 20
-	fi
+    ip link show "${SYNTH_NET_INTERFACES[$__iterator]}" >/dev/null 2>&1
+    if [ 0 -ne $? ]; then
+        msg="Invalid synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 20
+    fi
 done
 
 if [ ${#SYNTH_NET_INTERFACES[@]} -gt ${#STATIC_IPS[@]} ]; then
-	LogMsg "No. of synthetic interfaces is greater than number of static IPs specified in constants file. Will use dhcp for ${SYNTH_NET_INTERFACES[@]:${#STATIC_IPS[@]}}"
+    LogMsg "No. of synthetic interfaces is greater than number of static IPs specified in constants file. Will use dhcp for ${SYNTH_NET_INTERFACES[@]:${#STATIC_IPS[@]}}"
 fi
 
 declare -i __iterator=0
@@ -328,26 +328,26 @@ declare -i __iterator=0
 # set static ips
 for __iterator in ${!STATIC_IPS[@]} ; do
 
-	# if number of static ips is greater than number of interfaces, just break.
-	if [ "$__iterator" -ge "${#SYNTH_NET_INTERFACES[@]}" ]; then
-		LogMsg "Number of static IP addresses in constants.sh is greater than number of concerned interfaces. All extra IP addresses are ignored."
-		break
-	fi
+    # if number of static ips is greater than number of interfaces, just break.
+    if [ "$__iterator" -ge "${#SYNTH_NET_INTERFACES[@]}" ]; then
+        LogMsg "Number of static IP addresses in constants.sh is greater than number of concerned interfaces. All extra IP addresses are ignored."
+        break
+    fi
 
-	SetIPstatic "${STATIC_IPS[$__iterator]}" "${SYNTH_NET_INTERFACES[$__iterator]}" "$NETMASK"
-	# if failed to assigned address
-	if [ 0 -ne $? ]; then
-		msg="Failed to assign static ip ${STATIC_IPS[$__iterator]} netmask $NETMASK on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 20
-	fi
+    SetIPstatic "${STATIC_IPS[$__iterator]}" "${SYNTH_NET_INTERFACES[$__iterator]}" "$NETMASK"
+    # if failed to assigned address
+    if [ 0 -ne $? ]; then
+        msg="Failed to assign static ip ${STATIC_IPS[$__iterator]} netmask $NETMASK on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 20
+    fi
 
-	UpdateSummary "Successfully assigned ${STATIC_IPS[$__iterator]} ($NETMASK) to synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-	LogMsg "Successfully assigned ${STATIC_IPS[$__iterator]} ($NETMASK) to synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-	# add some interface output
-	LogMsg "$(ip -o addr show ${SYNTH_NET_INTERFACES[$__iterator]} | grep -vi inet6)"
+    UpdateSummary "Successfully assigned ${STATIC_IPS[$__iterator]} ($NETMASK) to synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+    LogMsg "Successfully assigned ${STATIC_IPS[$__iterator]} ($NETMASK) to synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+    # add some interface output
+    LogMsg "$(ip -o addr show ${SYNTH_NET_INTERFACES[$__iterator]} | grep -vi inet6)"
 done
 
 # set the iterator to point to the next element in the SYNTH_NET_INTERFACES array
@@ -356,22 +356,22 @@ __iterator=${#STATIC_IPS[@]}
 # set dhcp ips for remaining interfaces
 while [ $__iterator -lt ${#SYNTH_NET_INTERFACES[@]} ]; do
 
-	LogMsg "Trying to get an IP Address via DHCP on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+    LogMsg "Trying to get an IP Address via DHCP on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
 
-	CreateIfupConfigFile "${SYNTH_NET_INTERFACES[$__iterator]}" "dhcp"
+    CreateIfupConfigFile "${SYNTH_NET_INTERFACES[$__iterator]}" "dhcp"
 
-	if [ 0 -ne $? ]; then
-		msg="Unable to get address for ${SYNTH_NET_INTERFACES[$__iterator]} through DHCP"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 10
-	fi
+    if [ 0 -ne $? ]; then
+        msg="Unable to get address for ${SYNTH_NET_INTERFACES[$__iterator]} through DHCP"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 10
+    fi
 
-	# add some interface output
-	LogMsg "$(ip -o addr show ${SYNTH_NET_INTERFACES[$__iterator]} | grep -vi inet6)"
+    # add some interface output
+    LogMsg "$(ip -o addr show ${SYNTH_NET_INTERFACES[$__iterator]} | grep -vi inet6)"
 
-	: $((__iterator++))
+    : $((__iterator++))
 
 done
 
@@ -383,69 +383,70 @@ sleep 5
 
 for __iterator in ${!SYNTH_NET_INTERFACES[@]}; do
 
-	if [ -n "$GATEWAY" ]; then
-		LogMsg "Setting $GATEWAY as default gateway on dev ${SYNTH_NET_INTERFACES[$__iterator]}"
-		CreateDefaultGateway "$GATEWAY" "${SYNTH_NET_INTERFACES[$__iterator]}"
-		if [ 0 -ne $? ]; then
-			LogMsg "Warning! Failed to set default gateway!"
-		fi
-	fi
+    if [ -n "$GATEWAY" ]; then
+        LogMsg "Setting $GATEWAY as default gateway on dev ${SYNTH_NET_INTERFACES[$__iterator]}"
+        CreateDefaultGateway "$GATEWAY" "${SYNTH_NET_INTERFACES[$__iterator]}"
+        if [ 0 -ne $? ]; then
+            LogMsg "Warning! Failed to set default gateway!"
+        fi
+    fi
 
 # In some cases eth1 and eth2 would fail to ping6, restarting the network solves the issue
-if [ "$pingVersion" == "ping6" ] && [ ${#SYNTH_NET_INTERFACES[@]} -ge 1 ]; then
+if [ "$pingVersion" == "ping6" ] && [ ${#SYNTH_NET_INTERFACES[@]} -gt 1 ]; then
     GetDistro
     if [[ "$DISTRO" == "redhat"* || "$DISTRO" == "centos"* ]]; then
         service network restart
+        sleep 5
         if [ $? -ne 0 ]; then
-			msg="Unable to restart network service."
-			LogMsg "$msg"
-			UpdateSummary "$msg"
-		fi
+            msg="Unable to restart network service."
+            LogMsg "$msg"
+            UpdateSummary "$msg"
+        fi
     fi
 fi
 
-	__hex_interface_name=$(echo -n "${__packet_size[$__packet_iterator]}" | od -A n -t x1 | sed 's/ //g' | cut -c1-12)
+    __hex_interface_name=$(echo -n "${__packet_size[$__packet_iterator]}" | od -A n -t x1 | sed 's/ //g' | cut -c1-12)
 
-	LogMsg "Trying to ping $PING_SUCC on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-	# ping the right address with pattern 0xcafed00d`null`test`null`dhcp`null`
-	"$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 -p "cafed00d007465737400${__hex_interface_name}00" "$PING_SUCC"
+    LogMsg "Trying to ping $PING_SUCC on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+    # ping the right address with pattern 0xcafed00d`null`test`null`dhcp`null`
+    "$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 -p "cafed00d007465737400${__hex_interface_name}00" "$PING_SUCC"
 
-	if [ 0 -ne $? ]; then
-		msg="Failed to ping $PING_SUCC on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 10
-	fi
+    if [ 0 -ne $? ]; then
+        msg="Failed to ping $PING_SUCC on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 10
+    fi
 
-	UpdateSummary "Successfully pinged $PING_SUCC on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+    UpdateSummary "Successfully pinged $PING_SUCC on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]}"
 
-	# ping the wrong address. should not succeed
-	LogMsg "Trying to ping $PING_FAIL on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-	"$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$PING_FAIL"
-	if [ 0 -eq $? ]; then
-		msg="Succeeded to ping $PING_FAIL on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} . Make sure you have the right PING_FAIL constant set"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 10
-	fi
+    # ping the wrong address. should not succeed
+    LogMsg "Trying to ping $PING_FAIL on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+    "$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$PING_FAIL"
+    if [ 0 -eq $? ]; then
+        msg="Succeeded to ping $PING_FAIL on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} . Make sure you have the right PING_FAIL constant set"
+        LogMsg "$msg"
+        UpdateSummary "$msg"
+        SetTestStateFailed
+        exit 10
+    fi
 
-	UpdateSummary "Failed to ping $PING_FAIL on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} (as expected)"
+    UpdateSummary "Failed to ping $PING_FAIL on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} (as expected)"
 
-	# ping the second wrong address, fi specified. should also not succeed
-	if [ "${PING_FAIL2:-UNDEFINED}" != "UNDEFINED" ]; then
-		LogMsg "Trying to ping $PING_FAIL on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
-		"$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$PING_FAIL2"
-		if [ 0 -eq $? ]; then
-			msg="Succeeded to ping $PING_FAIL2 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} . Make sure you have the right PING_FAIL2 constant set"
-			LogMsg "$msg"
-			UpdateSummary "$msg"
-			SetTestStateFailed
-			exit 10
-		fi
-		UpdateSummary "Failed to ping $PING_FAIL2 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} (as expected)"
-	fi
+    # ping the second wrong address, fi specified. should also not succeed
+    if [ "${PING_FAIL2:-UNDEFINED}" != "UNDEFINED" ]; then
+        LogMsg "Trying to ping $PING_FAIL on interface ${SYNTH_NET_INTERFACES[$__iterator]}"
+        "$pingVersion" -I ${SYNTH_NET_INTERFACES[$__iterator]} -c 10 "$PING_FAIL2"
+        if [ 0 -eq $? ]; then
+            msg="Succeeded to ping $PING_FAIL2 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} . Make sure you have the right PING_FAIL2 constant set"
+            LogMsg "$msg"
+            UpdateSummary "$msg"
+            SetTestStateFailed
+            exit 10
+        fi
+        UpdateSummary "Failed to ping $PING_FAIL2 on synthetic interface ${SYNTH_NET_INTERFACES[$__iterator]} (as expected)"
+    fi
 
 done
 


### PR DESCRIPTION
There is a small delay after the network restart until the IPv6 is
initialized. The 5 seconds sleep allows for the VM to acquire the IP
address. Fix code indentation.