### PR TITLE
New-PSSession: Work around "Kerberos Double Hop" issue

### DIFF
--- a/WS2012R2/lisa/setupscripts/SR-IOV_GetMLNXInfo.ps1
+++ b/WS2012R2/lisa/setupscripts/SR-IOV_GetMLNXInfo.ps1
@@ -61,7 +61,16 @@ if (Test-Path $summaryLog) {
     del $summaryLog
 }
 
-$remoteSession = New-PSSession -ComputerName $hvServer
+# Work around "Kerberos Double Hop" issue
+# Use fresh identity (if defined in environment) instead of delegation
+if($env:HostUser -and $env:HostPassword){
+    $SecurePass = $env:HostPassword| ConvertTo-SecureString -AsPlainText -Force
+    $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $env:HostUser, $SecurePass
+    $remoteSession = New-PSSession -ComputerName $hvServer -Credential $cred
+}
+else{
+    $remoteSession = New-PSSession -ComputerName $hvServer
+}
 
 $checkModule = Get-Module -ListAvailable -PSSession $remoteSession | Select-String -Pattern MLNXProvider -quiet
 if ($checkModule) {


### PR DESCRIPTION
We currently use kerberos authentication in AD, If LISA is run inside a
PSSession, creating a new pssession in the test would require delegation
configured (and even it is configured, double hop to localhost is not
allowed). This patch use fresh identity to create PSSession instead of
using delegation (only if $env:HostUser and $env:HostPassword are defined,
otherwise the behaviour is not changed).

Our case is that our CI uses PSSession to connect to test host and run lisa. Creating a PSSession in the test case would results in this the kerberos double hop issue. And delegation does not work correctly with PSSession to "localhost". This patch is the best solution I can find, otherwise we will need to do modification on the framework to allow passing credential, which is quite a lot more modification.

**Ref.**
https://blogs.technet.microsoft.com/ashleymcglone/2016/08/30/powershell-remoting-kerberos-double-hop-solved-securely/