### PR TITLE
lis_install.sh - removed check that failed on 6.x

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/lis_install.sh
@@ -45,16 +45,6 @@ dos2unix utils.sh
 UtilsInit
 
 function download_archive {
-	# Check URL
-	wget -q --spider "$LIS_URL$AZURE_TOKEN"
-	if [ $? -ne 0 ]; then
-		msg="ERROR: Archive URL is not valid"
-		LogMsg "$msg"
-		UpdateSummary "$msg"
-		SetTestStateFailed
-		exit 1
-	fi
-
 	# Download file
 	TAR_NAME="${LIS_URL##*/}"
 	wget "$LIS_URL$AZURE_TOKEN" -O "$TAR_NAME"


### PR DESCRIPTION
The removed wget check gave a false positive on 6.x centos/rhel versions