### PR TITLE
Quick fix for reverting snapshot issue

### DIFF
--- a/WS2012R2/lisa/setupscripts/RevertSnapshot.ps1
+++ b/WS2012R2/lisa/setupscripts/RevertSnapshot.ps1
@@ -126,7 +126,7 @@ foreach ($vmName in $vms)
 {
     $snap = Get-VMSnapshot -ComputerName $hvServer -VMName $VmName -Name $Snapshot
 
-    Restore-VMSnapshot $snap -Confirm:$false -Verbose
+    Restore-VMSnapshot $snap[-1] -Confirm:$false -Verbose
     if ($? -ne "True")
     {
     write-host "Error while reverting VM snapshot on $vmName"


### PR DESCRIPTION
When running the full test suite additional snapshots get created
enven if they already exist. This causes the Restote-VMSnapshot
commandlet to receive a System.Object[], list that contains more
than a a single snapshot. This, in turn, causes all the tests that
use the RevertSnapshot.ps1 setup script to fail.

This commit fixes that issue.