### PR TITLE
Add dvd hotadd

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Core_LIS_CD.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Core_LIS_CD.sh
@@ -29,49 +29,27 @@
 #
 ################################################################
 
-LogMsg()
-{
-    echo `date "+%a %b %d %T %Y"` : ${1}    # To add the timestamp to the log file
+dos2unix utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    exit 1
 }
 
-UpdateTestState()
-{
-    echo $1 > $HOME/state.txt
-}
+#
+# Source constants file and initialize most common variables
+#
+UtilsInit
 
-UpdateSummary()
-{
-    echo $1 >> ~/summary.log
-}
-
-cd ~
-UpdateTestState "TestRunning"
-
-if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
-    rm -rf ~/summary.log
-fi
-
-if [ -e $HOME/constants.sh ]; then
-    . $HOME/constants.sh
-else
-    LogMsg "ERROR: Unable to source the constants file."
-    UpdateTestState "TestAborted"
+GetGuestGeneration
+if [ $os_GENERATION -eq 1 ] && [ $HotAdd = "True" ]; then
+    SetTestStateSkipped
     exit 1
 fi
-
-#Check for Testcase count
-if [ ! ${TC_COVERED} ]; then
-    LogMsg "Error: The TC_COVERED variable is not defined."
-    echo "Error: The TC_COVERED variable is not defined." >> ~/summary.log
-fi
-
-echo "Covers: ${TC_COVERED}" >> ~/summary.log
 
 #
 # Check if the CDROM module is loaded
 #
-if [[ -x $(which lsb_release 2>/dev/null) ]]; then 
+if [[ -x $(which lsb_release 2>/dev/null) ]]; then
     os_VENDOR=$(lsb_release -i -s)
 fi
 if [ $os_VENDOR != "Ubuntu" ] && [ $os_VENDOR != "Debian" ]; then
@@ -88,7 +66,7 @@ if [ $os_VENDOR != "Ubuntu" ] && [ $os_VENDOR != "Debian" ]; then
             LogMsg "Unable to load ata_piix module"
             LogMsg "Aborting test."
             UpdateSummary "ata_piix load : Failed"
-            UpdateTestState "TestFailed"
+            SetTestStateFailed
             exit 1
         else
             LogMsg "ata_piix module loaded inside the VM"
@@ -105,13 +83,13 @@ do
         LogMsg "Mount the CDROM ${drive}"
         break
     fi
-done    
+done
 sts=$?
 if [ 0 -ne ${sts} ]; then
     LogMsg "Unable to mount the CDROM"
     LogMsg "Mount CDROM failed: ${sts}"
     LogMsg "Aborting test."
-    UpdateTestState "TestFailed"
+    SetTestStateFailed
     exit 1
 else
     LogMsg  "CDROM is mounted successfully inside the VM"
@@ -126,7 +104,7 @@ sts=$?
 if [ 0 -ne ${sts} ]; then
     LogMsg "Unable to read data from the CDROM"
     LogMsg "Read data from CDROM failed: ${sts}"
-    UpdateTestState "TestFailed"
+    SetTestStateFailed
     exit 1
 else
     LogMsg "Data read successfully from the CDROM"
@@ -139,12 +117,27 @@ if [ 0 -ne ${sts} ]; then
     LogMsg "Unable to unmount the CDROM"
     LogMsg "umount failed: ${sts}"
     LogMsg "Aborting test."
-    UpdateTestState "TestFailed"
+    SetTestStateFailed
     exit 1
 else
     LogMsg  "CDROM unmounted successfully"
 fi
 
 UpdateSummary "CDROM mount, read and remove operations returned no errors."
+
+#
+# Check without multiple "medium not present" in dmesg log
+# Refer to https://lkml.org/lkml/2016/5/23/332
+#
+logNum=`dmesg | grep -i "Medium not present" | wc -l`
+if [ $logNum -gt 1 ];then
+    LogMsg  "Multiple medium not present log show in the dmesg"
+    SetTestStateFailed
+    exit 1
+fi
+
+# Check for Call traces
+CheckCallTracesWithDelay 20
+
 LogMsg "Result: Test Completed Successfully"
-UpdateTestState "TestCompleted"
+SetTestStateCompleted

--- a/WS2012R2/lisa/setupscripts/InsertIsoInDvd.ps1
+++ b/WS2012R2/lisa/setupscripts/InsertIsoInDvd.ps1
@@ -44,7 +44,7 @@ param ([String] $vmName, [String] $hvServer, [String] $testParams)
 $retVal = $False
 $isoFilename = $null
 $vmGeneration = $null
-
+$hotAdd = $False
 #######################################################################
 #
 # Main script body
@@ -92,19 +92,23 @@ foreach ($p in $params)
     }
 
     $tokens = $p.Trim().Split('=')
-    
+
     if ($tokens.Length -ne 2)
     {
 	# Just ignore it
 	continue
     }
-    
+
     $lValue = $tokens[0].Trim()
     $rValue = $tokens[1].Trim()
-    
+
     if ($lValue -eq "IsoFilename")
     {
         $isoFilename = $rValue
+    }
+    if ($lValue -eq "HotAdd")
+    {
+        $hotAdd = $rValue
     }
 }
 
@@ -123,6 +127,13 @@ $vmGeneration = Get-VM $vmName -ComputerName $hvServer| select -ExpandProperty G
 if ($? -eq $False)
 {
    $vmGeneration = 1
+}
+
+
+if ( $hotAdd -eq "True" -and $vmGeneration -eq 1)
+{
+    "Info: Generation 1 VM does not support hot add DVD, please skip this case in the test script"
+    return $True
 }
 
 #
@@ -153,24 +164,24 @@ if ($dvd)
 if (-not ([System.IO.Path]::IsPathRooted($isoFilename)))
 {
     $obj = Get-WmiObject -ComputerName $hvServer -Namespace "root\virtualization\v2" -Class "MsVM_VirtualSystemManagementServiceSettingData"
-        
+
     $defaultVhdPath = $obj.DefaultVirtualHardDiskPath
-	
+
     if (-not $defaultVhdPath)
     {
         "Error: Unable to determine VhdDefaultPath on Hyper-V server ${hvServer}"
         $error[0].Exception
         return $False
     }
-   
+
     if (-not $defaultVhdPath.EndsWith("\"))
     {
         $defaultVhdPath += "\"
     }
-  
+
     $isoFilename = $defaultVhdPath + $isoFilename
-   
-}   
+
+}
 
 $isoFileInfo = GetRemoteFileInfo $isoFilename $hvServer
 if (-not $isoFileInfo)

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -59,6 +59,7 @@
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
             <suiteTest>RebootDifferentMemSettings</suiteTest>
             <suiteTest>CDmount</suiteTest>
+            <suiteTest>CDmountHotAdd</suiteTest>
             <suiteTest>CheckNuma</suiteTest>
             <suiteTest>CheckNuma_Maximum</suiteTest>
             <suiteTest>Disable_NUMA_By_Kernel</suiteTest>
@@ -248,7 +249,7 @@
         <test>
             <testName>CDmount</testName>
             <testScript>Core_LIS_CD.sh</testScript>
-            <files>remote-scripts/ica/Core_LIS_CD.sh</files>
+            <files>remote-scripts/ica/Core_LIS_CD.sh,remote-scripts\ica\check_traces.sh,remote-scripts/ica/utils.sh</files>
             <setupScript>setupscripts\InsertIsoInDvd.ps1</setupScript>
             <cleanupScript>setupScripts\RemoveIsoFromDvd.ps1</cleanupScript>
             <testparams>
@@ -258,7 +259,20 @@
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
-
+        <test>
+            <testName>CDmountHotAdd</testName>
+            <testScript>Core_LIS_CD.sh</testScript>
+            <files>remote-scripts/ica/Core_LIS_CD.sh,remote-scripts\ica\check_traces.sh,remote-scripts/ica/utils.sh</files>
+            <preTest>setupscripts\InsertIsoInDvd.ps1</preTest>
+            <cleanupScript>setupScripts\RemoveIsoFromDvd.ps1</cleanupScript>
+            <testparams>
+                <param>TC_COVERED=CORE-35</param>
+                <param>HotAdd=True</param>
+            </testparams>
+            <timeout>600</timeout>
+            <onError>Continue</onError>
+            <noReboot>False</noReboot>
+        </test>
         <test>
             <testName>VCPU_verify_online</testName>
             <testScript>vcpu_verify_online.sh</testScript>


### PR DESCRIPTION
Created this case based on bug https://bugzilla.redhat.com/show_bug.cgi?id=1338687
[Hyper-V][RHEL 7.2] storvsc messages for CD-ROM medium not present - tray closed 

Test steps:
1. Create a Generation 2 VM 
2. Start VM, add a dvd drive to scsi controller(ISO attached or not) 
3. Check dmesg log to make sure it does not have multiple "medium not present" log, and add the call trace check.

Thank you so much.
