### PR TITLE
Update FC_Tests.xml to support multiple fc adapters

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/FC_WWN.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/FC_WWN.sh
@@ -122,9 +122,11 @@ NODE_NAME_VM=$(cat /sys/class/fc_host/host*/node_name)
 PORT_NAME_VM=$(cat /sys/class/fc_host/host*/port_name)
 
 #
-# We do a pattern wildcard matching on the values, as the host system doesn't use the 0x notation
+# as the host system doesn't use the 0x notation, remove 0x and replace space to comma
 #
-if ! [[ $NODE_NAME_VM =~ ($expectedWWNN) ]]; then
+NODE_NAME_VM_WWNN=$(echo $NODE_NAME_VM | sed 's/\s/,/g' | sed 's/0x//g')
+PORT_NAME_VM_WWNP=$(echo $PORT_NAME_VM | sed 's/\s/,/g' | sed 's/0x//g')
+if ! [[ $NODE_NAME_VM_WWNN = $expectedWWNN ]]; then
 	echo "Error: Guest VM presented value $NODE_NAME_VM and the host has $expectedWWNN . Test Failed!"
     SetTestStateFailed
     exit 1
@@ -132,7 +134,7 @@ else
     echo "Info: WWNN value is matching with the host. VM presented value is $NODE_NAME_VM"
 fi
 
-if ! [[ $PORT_NAME_VM =~ ($expectedWWNP) ]]; then
+if ! [[ $PORT_NAME_VM_WWNP = $expectedWWNP ]]; then
 	echo "Error: Guest VM presented value $PORT_NAME_VM and the host has $expectedWWNP . Test Failed!"
     SetTestStateFailed
     exit 1

--- a/WS2012R2/lisa/remote-scripts/ica/FC_disks.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/FC_disks.sh
@@ -38,62 +38,18 @@
 #
 ################################################################
 
-ICA_TESTRUNNING="TestRunning"      # The test is running
-ICA_TESTCOMPLETED="TestCompleted"  # The test completed successfully
-ICA_TESTABORTED="TestAborted"      # Error during setup of test
-ICA_TESTFAILED="TestFailed"        # Error during execution of test
+dos2unix utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    exit 1
+}
 
-CONSTANTS_FILE="constants.sh"
+#
+# Source constants file and initialize most common variables
+#
+UtilsInit
+
 sdCount=0
-
-LogMsg()
-{
-    echo `date "+%a %b %d %T %Y"` : ${1}    # To add the timestamp to the log file
-}
-
-UpdateTestState()
-{
-    echo $1 > $HOME/state.txt
-}
-
-#
-# Update LISA with the current status
-#
-cd ~
-UpdateTestState $ICA_TESTRUNNING
-LogMsg "Updating test case state to running"
-
-#
-# Source the constants file
-#
-if [ -e ./${CONSTANTS_FILE} ]; then
-    source ${CONSTANTS_FILE}
-else
-    ERRmsg="Error: no ${CONSTANTS_FILE} file"
-    LogMsg $ERRmsg
-    echo $ERRmsg >> ~/summary.log
-    UpdateTestState $ICA_TESTABORTED
-    exit 10
-fi
-
-if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
-    rm -rf ~/summary.log
-fi
-
-#
-# Identifying the test-case ID
-#
-if [ ! ${TC_COVERED} ]; then
-    LogMsg "The TC_COVERED variable is not defined!"
-    echo "The TC_COVERED variable is not defined!" >> ~/summary.log
-fi
-
-#
-# Echo TCs we cover
-#
-echo "Covers ${TC_COVERED}" > ~/summary.log
-
 #
 # Compute the number of sd* drives on the system.
 #
@@ -110,7 +66,7 @@ echo "/dev/sd* disk count = $sdCount"
 
 if [ $sdCount -lt 1 ]; then
     echo " disk count from /dev/sd* ($sdCount) returns only the boot disk"
-    UpdateTestState $ICA_TESTABORTED
+    SetTestStateAborted
     exit 1
 fi
 
@@ -132,7 +88,7 @@ do
     if [ "$?" != "0" ]; then
         LogMsg "Error in executing fdisk on ${driveName} !"
         echo "Error in executing fdisk on ${driveName} !" >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
+        SetTestStateFailed
         exit 60
     fi
 
@@ -157,32 +113,36 @@ do
                             LogMsg "Drive unmounted successfully..."
                      fi
                         LogMsg "Disk test completed for ${driveName}1"
-                        echo "Disk test is completed for ${driveName}1" >> ~/summary.log
+                        UpdateSummary "Disk test is completed for ${driveName}1"
                     else
                         LogMsg "Error in creating directory /mnt/Example!"
-                        echo "Error in creating directory /mnt/Example!" >> ~/summary.log
-                        UpdateTestState $ICA_TESTFAILED
+                        UpdateSummary "Error in creating directory /mnt/Example!"
+                        SetTestStateFailed
                         exit 60
                     fi
                 else
                     LogMsg "Error in mounting drive!"
-                    echo "Drive mount : Failed!" >> ~/summary.log
-                    UpdateTestState $ICA_TESTFAILED
+                    UpdateSummary "Drive mount : Failed!"
+                    SetTestStateFailed
                     exit 70
                 fi
         else
             LogMsg "Error in creating file-system!"
-            echo "Creating file-system has failed!" >> ~/summary.log
-            UpdateTestState $ICA_TESTFAILED
+            UpdateSummary "Creating file-system has failed!"
+            SetTestStateFailed
             exit 80
         fi
     else
         LogMsg "Error in executing fdisk  ${driveName}1"
-        echo "Error in executing fdisk  ${driveName}1" >> ~/summary.log
-        UpdateTestState $ICA_TESTFAILED
+        UpdateSummary "Error in executing fdisk  ${driveName}1"
+        SetTestStateFailed
         exit 90
     fi
-UpdateTestState $ICA_TESTCOMPLETED
+
+# Check for Call traces
+CheckCallTracesWithDelay 20
+
+SetTestStateCompleted
 
 exit 0
 done

--- a/WS2012R2/lisa/setupscripts/FC_WWN.ps1
+++ b/WS2012R2/lisa/setupscripts/FC_WWN.ps1
@@ -100,7 +100,7 @@ if (-not $testParams) {
 $params = $testParams.Split(";")
 foreach ($p in $params) {
     $fields = $p.Split("=")
-    
+
     if ($fields[0].Trim() -eq "TC_COVERED") {
         $TC_COVERED = $fields[1].Trim()
     }
@@ -149,6 +149,8 @@ $retVal = $True
 $WorldWideNodeNameSet = Get-VMFibreChannelHba -VMName $vmName -ComputerName $hvServer | Select -ExpandProperty WorldWideNodeNameSetA
 $WorldWidePortNameSet = Get-VMFibreChannelHba -VMName $vmName -ComputerName $hvServer | Select -ExpandProperty WorldWidePortNameSetA
 
+$WorldWideNodeNameSet=[system.string]::Join(",",$WorldWideNodeNameSet)
+$WorldWidePortNameSet=[system.string]::Join(",",$WorldWidePortNameSet)
 #
 # Send the WWNN and WWNP values from the host to the guest VM
 #

--- a/WS2012R2/lisa/xml/FC_Tests.xml
+++ b/WS2012R2/lisa/xml/FC_Tests.xml
@@ -38,19 +38,21 @@
 		<suite>
 		<suiteName>FC</suiteName>
 		<suiteTests>
-			<suiteTest>FC_disks_detection</suiteTest>
-			<suiteTest>FC_stressTest</suiteTest>
+			<suiteTest>FC_Disks_Detection</suiteTest>
+			<suiteTest>FC_StressTest</suiteTest>
 			<suiteTest>FC_SaveRestore_VM</suiteTest>
-			<suiteTest>FC_disks_multipath_detection</suiteTest>
-			<suiteTest>FC_WWN_basic</suiteTest>
+			<suiteTest>FC_Disks_Multipath_Detection</suiteTest>
+			<suiteTest>FC_WWN_Basic</suiteTest>
+			<suiteTest>FC_WWN_Basic_Multi_Adapters</suiteTest>
+			<suiteTest>FC_Disks_Detection_Multi_Adapters</suiteTest>
 		</suiteTests>
 		</suite>
 	</testSuites>
 	<testCases>
 		<test>
-		<testName>FC_disks_detection</testName>
+		<testName>FC_Disks_Detection</testName>
 		<testScript>FC_disks.sh</testScript>
-		<files>remote-scripts\ica\FC_disks.sh</files>
+		<files>remote-scripts\ica\FC_disks.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files>
 		<setupScript>setupscripts\FC_AddFibreChannelHba.ps1</setupScript>
 		<cleanupScript>setupScripts\FC_RemoveFibreChannelHba.ps1</cleanupScript>
 		<timeout>3600</timeout>
@@ -58,8 +60,9 @@
 			<param>TC_COVERED=FC-01,FC-02</param>
 		</testParams>
 		</test>
+
 		<test>
-		<testName>FC_stressTest</testName>
+		<testName>FC_StressTest</testName>
 		<testScript>FC_stressTest.sh</testScript>
 		<files>remote-scripts\ica\FC_stressTest.sh</files>
 		<files>Tools/iozone3_420.tar</files>
@@ -71,10 +74,11 @@
 			<param>FILE_NAME=iozone3_420.tar</param>
 		</testParams>
 		</test>
+
 		<test>
 		<testName>FC_SaveRestore_VM</testName>
 		<testScript>FC_disks.sh</testScript>
-		<files>remote-scripts\ica\FC_disks.sh</files>
+		<files>remote-scripts\ica\FC_disks.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files>
 		<setupScript>setupscripts\FC_AddFibreChannelHba.ps1</setupScript>
 		<posttest>setupScripts\FC_SaveRestoreVM.ps1</posttest>
 		<cleanupScript>setupScripts\FC_RemoveFibreChannelHba.ps1</cleanupScript>
@@ -83,8 +87,9 @@
 			<param>TC_COVERED=FC-07</param>
 		</testParams>
 		</test>
+
 		<test>
-		<testName>FC_disks_multipath_detection</testName>
+		<testName>FC_Disks_Multipath_Detection</testName>
 		<testScript>setupscripts\FC_MultipathDetection.ps1</testScript>
 		<setupScript>setupscripts\FC_AddFibreChannelHba.ps1</setupScript>
 		<cleanupScript>setupScripts\FC_RemoveFibreChannelHba.ps1</cleanupScript>
@@ -94,8 +99,9 @@
 			<param>TC_COVERED=FC-08</param>
 		</testParams>
 		</test>
+
 		<test>
-		<testName>FC_WWN_basic</testName>
+		<testName>FC_WWN_Basic</testName>
 		<testScript>setupScripts\FC_WWN.ps1</testScript>
 		<files>remote-scripts\ica\fc_wwn.sh,remote-scripts/ica/utils.sh</files>
 		<setupScript>setupscripts\FC_AddFibreChannelHba.ps1</setupScript>
@@ -105,6 +111,47 @@
 			<param>TC_COVERED=FC-09</param>
 		</testParams>
 		</test>
+
+		<test>
+			<testName>FC_Disks_Detection_Multi_Adapters</testName>
+			<testScript>FC_disks.sh</testScript>
+			<files>remote-scripts\ica\FC_disks.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/check_traces.sh</files>
+			<setupScript>
+				<file>setupscripts\FC_AddFibreChannelHba.ps1</file>
+				<file>setupScripts\ChangeCPU.ps1</file>
+			</setupScript>
+			<cleanupScript>setupScripts\FC_RemoveFibreChannelHba.ps1</cleanupScript>
+			<timeout>3600</timeout>
+			<testParams>
+				<param>TC_COVERED=FC-10</param>
+				<param>WWNN1=C003FFCBF9850025</param>
+				<param>WWPN1=C003FFCBF9850025</param>
+				<param>WWNN2=C003FFCBF9850027</param>
+				<param>WWPN2=C003FFCBF9850027</param>
+				<param>WWNN3=C003FFCBF9850029</param>
+				<param>WWPN3=C003FFCBF9850029</param>
+				<param>vCPU=4</param>
+			</testParams>
+		</test>
+
+		<test>
+			<testName>FC_WWN_Basic_Multi_Adapters</testName>
+			<testScript>setupScripts\FC_WWN.ps1</testScript>
+			<files>remote-scripts\ica\fc_wwn.sh,remote-scripts/ica/utils.sh</files>
+			<setupScript>setupscripts\FC_AddFibreChannelHba.ps1</setupScript>
+			<cleanupScript>setupScripts\FC_RemoveFibreChannelHba.ps1</cleanupScript>
+			<timeout>800</timeout>
+			<testParams>
+				<param>TC_COVERED=FC-11</param>
+				<param>WWNN1=C003FFCBF9850025</param>
+				<param>WWPN1=C003FFCBF9850025</param>
+				<param>WWNN2=C003FFCBF9850027</param>
+				<param>WWPN2=C003FFCBF9850027</param>
+				<param>WWNN3=C003FFCBF9850029</param>
+				<param>WWPN3=C003FFCBF9850029</param>
+			</testParams>
+		</test>
+
 	</testCases>
 	<VMs>
 		<vm>


### PR DESCRIPTION
Based on existing FC two test cases, FC_WWN_Basic and FC_Disks_Detection to add two new test cases, including FC_WWN_Basic_Multi_Adapters and FC_Disks_Detection_Multi_Adapters.

1.  FC_Disks_Detection_Multi_Adapters -- since the vm can add 4 FC adapters as maximum number, locally we have case to cover this test point, add new case here.
2.   FC_WWN_Basic_Multi_Adapters -- this is based on bug https://bugzilla.redhat.com/show_bug.cgi?id=1308632,  check /sys/class/fc_host/hostx,  already have auto case FC_WWN_Basic to cover one adapter, locally we have test case to cover multiple adapters. 

Any comment or suggestion, will update.

Thank you so much.
Best Regards,
Xuemin