### PR TITLE
Fix LiveMigration for generation 2 VMs

### DIFF
--- a/WS2012R2/lisa/xml/NET_LIVEMIG.xml
+++ b/WS2012R2/lisa/xml/NET_LIVEMIG.xml
@@ -222,6 +222,7 @@
                 <memSize>2048</memSize>
                 <disableDiff>True</disableDiff>
                 <nic>VMBus,External</nic>
+                <generation>1</generation>
             </hardware>
         </vm>
     </VMs>


### PR DESCRIPTION
Added missing generation tag for LiveMigration XML.