### PR TITLE
Small XML fixes

### DIFF
--- a/WS2012R2/lisa/xml/STOR_VHDX.xml
+++ b/WS2012R2/lisa/xml/STOR_VHDX.xml
@@ -4,11 +4,10 @@
     <global>
         <logfileRootDir>TestResults</logfileRootDir>
         <defaultSnapshot>ICABase</defaultSnapshot>
-        <defaultSnapshot>ICABase</defaultSnapshot>
         <LisaInitScript>
             <file>.\setupScripts\CreateVMs.ps1</file>
         </LisaInitScript>
-	<imageStoreDir>\\unc\path</imageStoreDir>
+        <imageStoreDir>\\unc\path</imageStoreDir>
         <dependency>
             <!-- Only Windows Server 2012 and newer supports this feature -->
             <hostVersion>6.2.9200</hostVersion>
@@ -530,7 +529,7 @@
     </testCases>
 
     <VMs>
-    <vm>
+        <vm>
             <hvServer>localhost</hvServer>
             <vmName>vmName</vmName>
             <os>Linux</os>


### PR DESCRIPTION
Due to duplicate line of defaultSnapshot tag LISA would search for
"ICABase ICABase" snapshot name.