### PR TITLE
KVP basic test case - permissions and lsof checks additions

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/KVP_BasicTest.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/KVP_BasicTest.sh
@@ -1,107 +1,141 @@
 #!/bin/bash
 
 ################################################################
-# 
 # KVP_BasicTest.sh
-# This script will verify that the KVP daemon is started at the boot of the VM. 
-# This script will install and run the KVP client tool to verify that the KVP
-# pools are created and accessible.
-# Make sure we have kvptool.tar.gz file in Automation\..\lisa\Tools folder 
-# 
+# Description:
+# 1. verify that the KVP Daemon is running
+# 2. run the KVP client tool and verify that the data pools are created and accessible
+# 3. check kvp_pool file permission is 644
+# 4. check kernel version supports hv_kvp
+# 5. check lsof number for kvp after sleep 2 minutes
 ################################################################
-ICA_TESTRUNNING="TestRunning"      # The test is running
-ICA_TESTCOMPLETED="TestCompleted"  # The test completed successfully
-ICA_TESTABORTED="TestAborted"      # Error during setup of test
-ICA_TESTFAILED="TestFailed"        # Error while performing the test
-
-CONSTANTS_FILE="constants.sh"
-
-LogMsg()
+InstallLsof()
 {
-    echo `date "+%a %b %d %T %Y"` : ${1}    # To add the timestamp to the log file
+    case $DISTRO in
+
+        redhat*|centos*|fedora*)
+            yum install lsof -y
+            ;;
+        ubuntu* )
+            apt-get install -y lsof
+            ;;
+        suse* )
+            zypper install -y lsof
+                ;;
+        *)
+            msg="ERROR: Distro '$DISTRO' not supported"
+            LogMsg "${msg}"
+            UpdateSummary "${msg}"
+            SetTestStateFailed
+            exit 1
+            ;;
+    esac
+
+    if [ $? -ne 0 ]; then
+        LogMsg "ERROR: Failed to install lsof"
+        UpdateSummary "ERROR: Failed to install lsof"
+        SetTestStateAborted
+        exit 1
+    fi
 }
 
-cd ~
-
-UpdateTestState()
-{
-    echo $1 > $HOME/state.txt
+dos2unix utils.sh
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    exit 1
 }
-if [ -e ~/summary.log ]; then
-    LogMsg "Cleaning up previous copies of summary.log"
-    rm -rf ~/summary.log
-fi
-
-LogMsg "Updating test case state to running"
-UpdateTestState $ICA_TESTRUNNING
-
-# Source the constants file
-if [ -e ~/${CONSTANTS_FILE} ]; then
-    source ~/${CONSTANTS_FILE}
-else
-    msg="Error: no ${CONSTANTS_FILE} file"
-    echo $msg
-    echo $msg >> ~/summary.log
-    UpdateTestState $ICA_TESTABORTED
-    exit 10
-fi
-
-
 #
-# Make sure constants.sh contains the variables we expect
+# Source constants file and initialize most common variables
 #
-if [ "${TC_COVERED:-UNDEFINED}" = "UNDEFINED" ]; then
-    msg="The test parameter TC_COVERED is not defined in ${CONSTANTS_FILE}"
-    echo $msg
-    echo $msg >> ~/summary.log
-    UpdateTestState $ICA_TESTABORTED
-    exit 30
-fi
-
+UtilsInit
 #
-# Echo TCs we cover
+# 1. verify that the KVP Daemon is running
 #
-echo "Covers ${TC_COVERED}" > ~/summary.log
-
-#
-# Verify that the KVP Daemon is running
-#
-pgrep -lf "hypervkvpd|hv_kvp_daemon"
+pid=`pgrep "hypervkvpd|hv_kvp_daemon"`
 if [ $? -ne 0 ]; then
 	LogMsg "KVP Daemon is not running by default"
-	echo "KVP daemon not running, basic test: Failed" >> ~/summary.log
-	UpdateTestState $ICA_TESTFAILED
+	UpdateSummary "KVP daemon not running by default, basic test: Failed"
+	SetTestStateFailed
 	exit 10
-fi	
+fi
 LogMsg "KVP Daemon is started on boot and it is running"
 
 #
-# Extract and install the KVP client tool.
+# 2. run the KVP client tool and verify that the data pools are created and accessible
 #
-mkdir kvptool
-tar -xvf kvp*.gz -C kvptool
-if [ $? -ne 0 ]; then
-	LogMsg "Failed to extract the KVP tool tar file"
-	echo "Installing KVP tool: Failed" >> ~/summary.log
-	UpdateTestState $ICA_TESTFAILED
+uname -a | grep x86_64
+if [ $? -eq 0 ]; then
+    LogMsg "64 bit architecture was detected"
+    kvp_client="kvp_client64"
+else
+    uname -a | grep i686
+    if [ $? -eq 0 ]; then
+        LogMsg "32 bit architecture was detected"
+        kvp_client="kvp_client32"
+    else
+        LogMsg "Error: Unable to detect OS architecture"
+        SetTestStateAborted
+        exit 60
+    fi
+fi
+
+chmod +x /root/kvp_client*
+poolCount=`/root/$kvp_client | grep -i pool | wc -l`
+if [ $poolCount -ne 5 ]; then
+	LogMsg "pools are not created properly"
+	UpdateSummary "Pools are not listed properly, KVP Basic test: Failed"
+	SetTestStateFailed
 	exit 10
 fi
-gcc -o kvptool/kvp_client kvptool/kvp_client.c
-mv ~/kvptool/kvp_client ~/
-chmod 755 ~/kvp_client
+LogMsg "Verified that the 0-4 all the 5 data pools are listed properly"
 
 #
-# Run the KVP client tool and verify that the data pools are created and accessible
+# 3. check kvp_pool file permission is 644
 #
-poolcount="`~/kvp_client | grep Pool | wc -l`"
-if [ $poolcount -ne 5 ]; then
-	LogMsg "pools are not created properly"
-	echo "Pools are not listed properly, KVP Basic test: Failed" >> ~/summary.log
-	UpdateTestState $ICA_TESTFAILED
-	exit 10
+permCount=`stat -c %a /var/lib/hyperv/.kvp_pool* | grep 644 | wc -l`
+if [ $permCount -ne 5 ]; then
+        LogMsg ".kvp_pool file permission is incorrect "
+    	UpdateSummary ".kvp_pool file permission is incorrect"
+    	SetTestStateFailed
+        exit 10
 fi
-LogMsg "Verified that the 0-4 all the 5 data pools are listed properly"  
-echo "KVP Daemon is running and data pools are listed -KVP Basic test : Passed" >>  ~/summary.log
-LogMsg "Updating test case state to completed"
-UpdateTestState $ICA_TESTCOMPLETED
+LogMsg "Verified that .kvp_pool file permission is 644"
+
+#
+# 4. check kernel version supports hv_kvp
+#
+CheckVMFeatureSupportStatus "3.10.0-514"
+if [ $? -eq 0 ]; then
+    ls -la /proc/$pid/fd | grep /dev/vmbus/hv_kvp
+    if [ $? -ne 0 ]; then
+        LogMsg "ERROR: there is no hv_kvp in the /proc/$pid/fd "
+        UpdateSummary "ERROR: there is no hv_kvp in the /proc/$pid/fd"
+        SetTestStateFailed
+        exit 1
+    fi
+else
+    LogMsg "This kernel version does not support /dev/vmbus/hv_kvp, skip this step"
+fi
+
+#
+# 5. check lsof number for kvp after sleep 2 minutes
+#
+GetDistro
+InstallLsof
+
+lsofCountBegin=`lsof | grep -c kvp`
+sleep 120
+lsofCountEnd=`lsof | grep -c kvp`
+if [ $lsofCountBegin -ne $lsofCountEnd ]; then
+        msg="ERROR: kvp file number has changed from $lsofCountBegin to $lsofCountEnd"
+        LogMsg "${msg}"
+        UpdateSummary "${msg}"
+    	SetTestStateFailed
+        exit 10
+fi
+LogMsg "Verified that lsof for kvp is $lsofCountBegin, after 2 minutes is $lsofCountEnd"
+
+UpdateSummary "KVP Daemon running, correct data pools permissions and reasonable lsof number of kvp"
+SetTestStateCompleted
 exit 0

--- a/WS2012R2/lisa/remote-scripts/ica/KVP_BasicTest.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/KVP_BasicTest.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ################################################################
+#
 # KVP_BasicTest.sh
 # Description:
 # 1. verify that the KVP Daemon is running
@@ -8,18 +9,20 @@
 # 3. check kvp_pool file permission is 644
 # 4. check kernel version supports hv_kvp
 # 5. Use lsof to check the opened file number belonging to hypervkvp process does not increase
-#    continually. If this number increased, maybe file descriptor is not closed properly.
-#    Here check duraiton is 2 minutes.
+#    continually. If this number increases, maybe file descriptors are not closed properly.
+#    Here check duration is after 2 minutes.
+#
 ################################################################
+
 InstallLsof()
 {
     case $DISTRO in
 
-        redhat*|centos*|fedora*)
+        redhat* | centos* | fedora*)
             yum install lsof -y
             ;;
-        ubuntu* )
-            apt-get install -y lsof
+        ubuntu* | debian*)
+            apt update; apt install -y lsof
             ;;
         suse* )
             zypper install -y lsof
@@ -85,13 +88,13 @@ fi
 chmod +x /root/kvp_client*
 poolCount=`/root/$kvp_client | grep -i pool | wc -l`
 if [ $poolCount -ne 5 ]; then
-    msg="Error: Could not find a total of 5 KVP pools"
+    msg="Error: Could not find a total of 5 KVP data pools"
     LogMsg $msg
     UpdateSummary $msg
     SetTestStateFailed
     exit 10
 fi
-LogMsg "Verified that the 0-4 all the 5 data pools are listed properly"
+LogMsg "Verified that all 5 KVP data pools are listed properly"
 
 #
 # 3. check kvp_pool file permission is 644
@@ -103,7 +106,7 @@ if [ $permCount -ne 5 ]; then
     SetTestStateFailed
     exit 10
 fi
-LogMsg "Verified that .kvp_pool file permission is 644"
+LogMsg "Verified that .kvp_pool files permission is 644"
 
 #
 # 4. check kernel version supports hv_kvp
@@ -134,7 +137,7 @@ lsofCountBegin=`lsof | grep -c kvp`
 sleep 120
 lsofCountEnd=`lsof | grep -c kvp`
 if [ $lsofCountBegin -ne $lsofCountEnd ]; then
-    msg="ERROR: hypervkvp opend file number has changed from $lsofCountBegin to $lsofCountEnd"
+    msg="ERROR: hypervkvp opened file number has changed from $lsofCountBegin to $lsofCountEnd"
     LogMsg "${msg}"
     UpdateSummary "${msg}"
     SetTestStateFailed

--- a/WS2012R2/lisa/xml/KvpTests.xml
+++ b/WS2012R2/lisa/xml/KvpTests.xml
@@ -42,6 +42,7 @@
             <suiteTests>
                 <suiteTest>SQM_Basic</suiteTest>
                 <suiteTest>KVP_Basic</suiteTest>
+                <suiteTest>ReadKVPData_BasicTest</suiteTest>
                 <suiteTest>KVP_Add_Key_Values</suiteTest>
                 <suiteTest>KVP_Modify_Key_Values</suiteTest>
                 <suiteTest>KVP_Remove_Key_Values</suiteTest>
@@ -75,6 +76,19 @@
             <noReboot>True</noReboot>
             <testparams>
                 <param>TC_COVERED=KVP-01</param>
+            </testparams>
+        </test>
+
+        <test>
+            <testName>ReadKVPData_BasicTest</testName>
+            <testScript>KVP_BasicTest.sh</testScript>
+            <files>remote-scripts\ica\KVP_BasicTest.sh,remote-scripts/ica/utils.sh,
+                tools/KVP/kvp_client64,tools/KVP/kvp_client32</files>
+            <timeout>600</timeout>
+            <onError>Continue</onError>
+            <noReboot>False</noReboot>
+            <testparams>
+                <param>TC_COVERED=BVT-21</param>
             </testparams>
         </test>
 
@@ -206,7 +220,7 @@
             <testparams>
                 <param>TC_COVERED=KVP-12</param>
                 <param>Pool=1</param>
-                <!-- Number of key pairs to be added in the kvp pool -->  
+                <!-- Number of key pairs to be added in the kvp pool -->
                 <param>Entries=250</param>
             </testparams>
         </test>

--- a/WS2012R2/lisa/xml/RDOS_WS2012.xml
+++ b/WS2012R2/lisa/xml/RDOS_WS2012.xml
@@ -113,8 +113,8 @@
 		<test>
 			<testName>ReadKVPData_BasicTest</testName>
 			<testScript>KVP_BasicTest.sh</testScript>
-			<files>remote-scripts\ica\KVP_BasicTest.sh</files>
-			<files>Tools\kvptool.tar.gz</files>
+			<files>remote-scripts\ica\KVP_BasicTest.sh,remote-scripts/ica/utils.sh,
+				tools/KVP/kvp_client64,tools/KVP/kvp_client32</files>
 			<timeout>600</timeout>
 			<onError>Abort</onError>
 			<noReboot>False</noReboot>
@@ -122,7 +122,7 @@
 				<param>TC_COVERED=BVT-21</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>WriteKVPDataToGuest</testName>
 			<testScript>KVP_VerifyKeyValue.sh</testScript>
@@ -138,7 +138,7 @@
 				<param>Pool=0</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>ModifyPool0KVPDataOnGuest</testName>
 			<testScript>KVP_VerifyKeyValue.sh</testScript>
@@ -154,7 +154,7 @@
 				<param>Pool=0</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>WriteNonIntrinsicKVPData</testName>
 			<testScript>KVP_AddKeyValue.sh</testScript>
@@ -169,7 +169,7 @@
 				<param>Pool=1</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>ReadNonIntrinsicKVPData</testName>
 			<testScript>setupScripts\KVP_Basic.ps1</testScript>
@@ -181,7 +181,7 @@
 				<param>nonintrinsic</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>ReadIntrinsicKVPData</testName>
 			<testScript>setupScripts\KVP_Basic.ps1</testScript>
@@ -192,7 +192,7 @@
 				<param>TC_COVERED=36</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>HostCanWriteKVPToOnly_P0</testName>
 			<testScript>KVP_VerifyKeyValue.sh</testScript>
@@ -208,7 +208,7 @@
 				<param>Pool=0</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>DeletePool0KVPDataOnGuest</testName>
 			<testScript>setupScripts\KVP_DeleteKeyValue.ps1</testScript>
@@ -222,7 +222,7 @@
 				<param>Pool=0</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>ReadHostKVPDataOnGuest</testName>
 			<testScript>KVP_VerifyKeyValue.sh</testScript>
@@ -237,7 +237,7 @@
 				<param>Pool=3</param>
 			</testparams>
 		</test>
-		
+
 		<test>
 			<testName>DeleteNonExistKVPOnGuest</testName>
 			<testScript>setupscripts\KVP_DeleteNonExistKeyValue.ps1</testScript>
@@ -250,8 +250,8 @@
 				<param>Value=000</param>
 				<param>Pool=0</param>
 			</testparams>
-		</test>	
-		
+		</test>
+
 		<test>
 			<testName>ModifyNonExistKVPOnGuest</testName>
 			<testScript>setupscripts\KVP_ModifyNonExistKeyValue.ps1</testScript>
@@ -273,7 +273,7 @@
 			<onError>Continue</onError>
 			<noReboot>True</noReboot>
 		</test>
-		
+
 		<test>
 			<testName>TimeSync_SavedVM</testName>
 			<testScript>setupScripts\INST_timesync_savedVM.ps1</testScript>
@@ -282,16 +282,16 @@
 			<noReboot>True</noReboot>
 		</test>
 
-		<!-- VHD disk Tests -->               
+		<!-- VHD disk Tests -->
 		<test>
 			<testName>AddDisk_SCSI_DYNAMIC</testName>
 			<setupScript>SetupScripts\AddHardDisk.ps1</setupScript>
-			<testParams>              
+			<testParams>
 				<param>SCSI=0,1,Dynamic</param>
 				<param>NO=1</param>
 				<param>TEST_DEVICE1=/dev/sdb</param>
 				<param>TC_COVERED=DSK_VHD-37</param>
-			</testParams> 	  
+			</testParams>
 			<testScript>STOR_Lis_Disk.sh</testScript>
 			<files>remote-scripts/ica/STOR_Lis_Disk.sh</files>
             <files>remote-scripts/ica/check_traces.sh</files>
@@ -543,7 +543,7 @@
 			<timeout>18000</timeout>
 			<testparams>
 				<param>SCSI=0,0,Fixed</param>
-				<param>SCSI=0,1,Fixed</param> 
+				<param>SCSI=0,1,Fixed</param>
 				<param>TC_COVERED=DSK_VHD-51,DSK_VHD-53</param>
 				<param>NO=2</param>
 				<param>TEST_DEVICE1=/dev/sdb</param>
@@ -563,7 +563,7 @@
 			<timeout>18000</timeout>
 			<testparams>
 				<param>SCSI=0,0,Fixed</param>
-				<param>SCSI=0,1,Fixed</param> 
+				<param>SCSI=0,1,Fixed</param>
 				<param>TC_COVERED=DSK_VHD-52,DSK_VHD-54</param>
 			</testparams>
 			<onError>Continue</onError>
@@ -580,7 +580,7 @@
 			<timeout>18000</timeout>
 			<testparams>
 				<param>SCSI=0,0,Dynamic</param>
-				<param>SCSI=0,1,Dynamic</param>  
+				<param>SCSI=0,1,Dynamic</param>
 				<param>NO=2</param>
 				<param>TEST_DEVICE1=/dev/sdb</param>
 				<param>TEST_DEVICE2=/dev/sdc</param>


### PR DESCRIPTION
…of check

Update existing ReadKVPData_BasicTest test case, locally we have manual test cases: 
1. check hypervkvpd pool file directory and file permission
#ls /var/lib/hyperv/.kvp_pool_*

2.  check number of opened file descriptors by hypervkvpd  #lsof \|grep -c kvp 
 check the number of process two minutes later #lsof \| grep -c kvp
Refer to bug https://bugzilla.redhat.com/show_bug.cgi?id=949664.

3. After RHEL7.3, ls -la /proc/`pidof hypervkvpd`/fd \| grep hv_kvp 

This case includes more test points, any comment, suggestions will update. Thank you so much.
  
 


