### PR TITLE
Update KVP_TestRescind and NET_ipinjection for selinux check

### DIFF
--- a/WS2012R2/lisa/setupscripts/KVP_TestRescind.ps1
+++ b/WS2012R2/lisa/setupscripts/KVP_TestRescind.ps1
@@ -118,13 +118,13 @@ foreach ($p in $params)
 {
     $fields = $p.Split("=")
     switch ($fields[0].Trim())
-    {      
+    {
     "ipv4"      { $ipv4    = $fields[1].Trim() }
     "sshKey"    { $sshKey  = $fields[1].Trim() }
     "rootdir"      { $rootDir   = $fields[1].Trim() }
     "TC_COVERED"   { $tcCovered = $fields[1].Trim() }
     "CycleCount"    { $CycleCount = $fields[1].Trim() }
-    default  {}       
+    default  {}
     }
 }
 
@@ -150,81 +150,91 @@ else {
 }
 
 $checkVM = Check-Systemd
-if ($checkVM -eq "True") {
-    # Get KVP Service status
-    $gsi = Get-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
-    if ($? -ne "True") {
-        Write-Output "Error: Unable to get Key-Value Pair status on $vmName ($hvServer)" | Tee-Object -Append -file $summaryLog
-        return $Failed
-    }
-
-    # Check if VM is RedHat 7.3 or later (and if not, check external LIS exists)
-    $supportkernel = "3.10.0.514" #kernel version for RHEL 7.3
-    $isRHEL = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "yum --version 2> /dev/null"
-    if ($? -eq "True") {
-        $kernelSupport = GetVMFeatureSupportStatus $ipv4 $sshKey $supportkernel
-        if ($kernelSupport -ne "True") {
-            Write-Output "Info: Kernels older than 3.10.0-514 require LIS-4.x drivers." | Tee-Object -Append -file $summaryLog
-            $checkExternal = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "rpm -qa | grep kmod-microsoft-hyper-v && rpm -qa | grep microsoft-hyper-v"
-            if ($? -ne "True") {
-                Write-Output "Error: No LIS-4.x drivers detected. Skipping test." | Tee-Object -Append -file $summaryLog
-                return $Skipped
-            }
-        }
-    }
-
-    # If KVP is not enabled, enable it
-    if ($gsi.Enabled -ne "True") {
-        Enable-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
-        if ($? -ne "True") {
-            Write-Output "Error: Unable to enable Key-Value Pair on $vmName ($hvServer)" | Tee-Object -Append -file $summaryLog
-            return $Failed
-        }
-    }
-
-    # Disable and Enable KVP according to the given parameter
-        $counter = 0
-        while ($counter -lt $CycleCount) {
-            Disable-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
-            if ($? -ne "True") {
-                Write-Output "Error: Unable to disable VMIntegrationService on $vmName ($hvServer) on $counter run" | Tee-Object -Append -file $summaryLog
-                return $Failed
-            }
-            Start-Sleep 5
-
-            Enable-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
-            if ($? -ne "True") {
-                Write-Output "Error: Unable to enable VMIntegrationService on $vmName ($hvServer) on $counter run" | Tee-Object -Append -file $summaryLog
-                return $Failed
-            }
-            Start-Sleep 5
-            $counter += 1
-        }
-
-        Write-Output "Disabled and Enabled KVP Exchange $counter times" | Tee-Object -Append -file $summaryLog
-
-    #Check KVP service status after disable/enable
-    $gsi = Get-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
-    if ($gsi.PrimaryOperationalStatus -ne "OK") {
-        Write-Output "Error: Key-Value Pair service is not operational after disable/enable cycle. `
-        Current status: $gsi.PrimaryOperationalStatus" | Tee-Object -Append -file $summaryLog
-        return $Failed
-    } else {
-        # Daemon name might vary. Get the correct daemon name based on systemctl output
-        $daemonName = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "systemctl list-unit-files | grep kvp"
-        $daemonName = $daemonName.Split(".")[0]
-
-        #If the KVP service is OK, check the KVP daemon on the VM
-        $checkProcess = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "systemctl is-active $daemonName"
-        if ($checkProcess -ne "active") {
-             Write-Output "Error: $daemonName is not running on $vmName after disable/enable cycle" | Tee-Object -Append -file $summaryLog
-             return $Failed
-        } else {
-            Write-Output "Info: KVP service and $daemonName are operational after disable/enable cycle" | Tee-Object -Append -file $summaryLog
-            return $Passed
-        }
-    }
-} else {
+if ( -not $checkVM[-1]) {
     Write-Output "Systemd is not being used. Test Skipped" | Tee-Object -Append -file $summaryLog
     return $Skipped
 }
+
+# Get KVP Service status
+$gsi = Get-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
+if ($? -ne "True") {
+    Write-Output "Error: Unable to get Key-Value Pair status on $vmName ($hvServer)" | Tee-Object -Append -file $summaryLog
+    return $Failed
+}
+
+# Check if VM is RedHat 7.3 or later (and if not, check external LIS exists)
+$supportkernel = "3.10.0.514" #kernel version for RHEL 7.3
+$isRHEL = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "yum --version 2> /dev/null"
+if ($? -eq "True") {
+    $kernelSupport = GetVMFeatureSupportStatus $ipv4 $sshKey $supportkernel
+    if ($kernelSupport -ne "True") {
+        Write-Output "Info: Kernels older than 3.10.0-514 require LIS-4.x drivers." | Tee-Object -Append -file $summaryLog
+        $checkExternal = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "rpm -qa | grep kmod-microsoft-hyper-v && rpm -qa | grep microsoft-hyper-v"
+        if ($? -ne "True") {
+            Write-Output "Error: No LIS-4.x drivers detected. Skipping test." | Tee-Object -Append -file $summaryLog
+            return $Skipped
+        }
+    }
+}
+
+# If KVP is not enabled, enable it
+if ($gsi.Enabled -ne "True") {
+    Enable-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
+    if ($? -ne "True") {
+        Write-Output "Error: Unable to enable Key-Value Pair on $vmName ($hvServer)" | Tee-Object -Append -file $summaryLog
+        return $Failed
+    }
+}
+
+# Disable and Enable KVP according to the given parameter
+$counter = 0
+while ($counter -lt $CycleCount) {
+    Disable-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
+    if ($? -ne "True") {
+        Write-Output "Error: Unable to disable VMIntegrationService on $vmName ($hvServer) on $counter run" | Tee-Object -Append -file $summaryLog
+        return $Failed
+    }
+    Start-Sleep 5
+
+    Enable-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
+    if ($? -ne "True") {
+        Write-Output "Error: Unable to enable VMIntegrationService on $vmName ($hvServer) on $counter run" | Tee-Object -Append -file $summaryLog
+        return $Failed
+    }
+    Start-Sleep 5
+    $counter += 1
+}
+
+Write-Output "Disabled and Enabled KVP Exchange $counter times" | Tee-Object -Append -file $summaryLog
+
+#Check KVP service status after disable/enable
+$gsi = Get-VMIntegrationService -Name "Key-Value Pair Exchange" -vmName $vmName -ComputerName $hvServer
+if ($gsi.PrimaryOperationalStatus -ne "OK") {
+    Write-Output "Error: Key-Value Pair service is not operational after disable/enable cycle. `
+    Current status: $gsi.PrimaryOperationalStatus" | Tee-Object -Append -file $summaryLog
+    return $Failed
+} else {
+    # Daemon name might vary. Get the correct daemon name based on systemctl output
+    $daemonName = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "systemctl list-unit-files | grep kvp"
+    $daemonName = $daemonName.Split(".")[0]
+
+    #If the KVP service is OK, check the KVP daemon on the VM
+    $checkProcess = .\bin\plink.exe -i ssh\${sshKey} root@${ipv4} "systemctl is-active $daemonName"
+    if ($checkProcess -ne "active") {
+         Write-Output "Error: $daemonName is not running on $vmName after disable/enable cycle" | Tee-Object -Append -file $summaryLog
+         return $Failed
+    } else {
+        Write-Output "Info: KVP service and $daemonName are operational after disable/enable cycle" | Tee-Object -Append -file $summaryLog
+    }
+}
+
+# check selinux denied log after ip injection.
+$sts = GetSelinuxAVCLog
+if ($sts[-1]) {
+    "Error: There is selinux avc denied log in audit log after disable/enable kvp"
+     return $Failed
+}
+else {
+    "Info: no selinux avc deny log in audit logs after disable/enable kvp"
+}
+return $Passed

--- a/WS2012R2/lisa/setupscripts/KVP_TestRescind.ps1
+++ b/WS2012R2/lisa/setupscripts/KVP_TestRescind.ps1
@@ -229,12 +229,10 @@ if ($gsi.PrimaryOperationalStatus -ne "OK") {
 }
 
 # check selinux denied log after ip injection.
-$sts = GetSelinuxAVCLog
+$sts = GetSelinuxAVCLog $ipv4 $sshkey
+write-output $sts[-2] | Tee-Object -Append -file $summaryLog
 if ($sts[-1]) {
-    "Error: There is selinux avc denied log in audit log after disable/enable kvp"
      return $Failed
 }
-else {
-    "Info: no selinux avc deny log in audit logs after disable/enable kvp"
-}
+
 return $Passed

--- a/WS2012R2/lisa/setupscripts/NET_ipinjection.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_ipinjection.ps1
@@ -465,10 +465,20 @@ for ($i=0; $i -le 2; $i++)
     }
 }
 
-if ($isPassed -eq $false){
+# check selinux denied log after ip injection.
+$sts = GetSelinuxAVCLog
+if ($sts[-1]) {
+    "Error: There is selinux avc denied log in audit log after ip injection"
+    $isPassed = $false
+}
+else {
+    "Info: no selinux avc deny log in audit logs after ip injection"
+}
+
+if ($isPassed -eq $false) {
     "Error: All attempts failed"
     exit 1
 }
 
-"Info : IP Injection test passed"
+"Info: IP Injection test passed"
 return $True

--- a/WS2012R2/lisa/setupscripts/NET_ipinjection.ps1
+++ b/WS2012R2/lisa/setupscripts/NET_ipinjection.ps1
@@ -465,16 +465,6 @@ for ($i=0; $i -le 2; $i++)
     }
 }
 
-# check selinux denied log after ip injection.
-$sts = GetSelinuxAVCLog
-if ($sts[-1]) {
-    "Error: There is selinux avc denied log in audit log after ip injection"
-    $isPassed = $false
-}
-else {
-    "Info: no selinux avc deny log in audit logs after ip injection"
-}
-
 if ($isPassed -eq $false) {
     "Error: All attempts failed"
     exit 1

--- a/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
+++ b/WS2012R2/lisa/setupscripts/STOR_VSS_Utils.ps1
@@ -177,7 +177,7 @@ function checkResults([string] $vmName, [string] $hvServer)
 	if ($vmState -eq "Running")
 	{
 		if ($ip_address -eq $null)
-		{  
+		{
 			$logger.info("Restarting VM to bring up network")
 			Restart-VM -vmName $vmName -ComputerName $hvServer -Force
 			WaitForVMToStartKVP $vmName $hvServer $timeout
@@ -214,15 +214,15 @@ function checkResults([string] $vmName, [string] $hvServer)
 	}
 	$logger.info("VM IP is $ip_address")
 
-	$sts= GetSelinuxAVCLog
+	$sts= GetSelinuxAVCLog $ip_address $sshkey
 	if ($sts[-1])
     {
-		$logger.error("There is selinux avc denied log in audit log")
+		$logger.error("$($sts[-2])")
 		return $False
     }
     else
     {
-		$logger.info("no selinux avc deny log in audit logs")
+		$logger.info("$($sts[-2])")
     }
 	# only check restore file when ip available
 	$stsipv4 = Test-NetConnection $ipv4 -Port 22 -WarningAction SilentlyContinue

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -2126,26 +2126,28 @@ function GetSelinuxAVCLog([String] $ipv4, [String] $sshKey)
     $filename = ".\audit.log"
     $text_hv = "hyperv"
     $text_avc = "type=avc"
-    echo y | .\bin\pscp -i ssh\${sshKey}  root@${ipv4}:/var/log/audit.log $filename
 
+    echo y | .\bin\plink -i ssh\${sshKey} root@${ipv4} "ls /var/log/audit/audit.log"
+    if (-not $?) {
+        Write-Output "Warning: Unable to find audit.log from the VM, ignore audit log check"
+        return $False
+    }
+
+    .\bin\pscp -i ssh\${sshKey} root@${ipv4}:/var/log/audit/audit.log $filename
     if (-not $?) {
         Write-Output "ERROR: Unable to copy audit.log from the VM"
         return $False
     }
 
     $file = Get-Content $filename
-    if (-not $file) {
-        Write-Error -Message "Error: Unable to read file" -Category InvalidArgument -ErrorAction SilentlyContinue
-        return $null
-    }
-
-     foreach ($line in $file) {
+    del $filename
+    foreach ($line in $file) {
         if ($line -match $text_hv -and $line -match $text_avc){
-            write-output "Warning: get the avc denied log: $line"
+            write-output "ERROR: get the avc denied log: $line"
             return $True
         }
     }
-    del $filename
+    write-output "Info: no avc denied log in audit log as expected"
     return $False
 }
 
@@ -2236,7 +2238,7 @@ function CheckCallTracesWithDelay ([String]$sshKey, [String]$ipv4)
     $ErrorActionPreference = 'silentlycontinue'
     $sts = .\bin\plink.exe -i ssh\$sshKey root@${ipv4} "cat ~/check_traces.log | grep ERROR"
     if ($sts.Contains("ERROR")) {
-        return $false 
+        return $false
     }
     if ($sts -eq $NULL) {
         return $true


### PR DESCRIPTION
Minor update existing test cases KVPTestRescind and NET_ipinjection to add the selinux log check, refer to https://bugzilla.redhat.com/show_bug.cgi?id=1347659, after enable/disable kvp and do ip-injection, then check ausearch -m avc and ausearch -m user_avc. The original bug reproduce rate is not 100%, here only cover the test scenario, but not same steps with the bug's steps.
Meanwhile, only move original script out of checkVM's else branch for KVPTestRescind.ps1, not change the script itself.

Thank you so much.