### PR TITLE
Update utils.sh for RemovevlanConfig by removing service network restart

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -1120,8 +1120,6 @@ RemoveVlanConfig()
 					rm -f "$__file_path"
 				fi
 			fi
-			service network restart 2>&1
-
 			# make sure the interface is down
 			ip link set "$__interface.$__vlanID" down
 			;;


### PR DESCRIPTION
When test on the network vlanTrunking case, execute line #1225 of NET_VLAN_TRUNKING.ps1, it will call RemoveVlanInterfaceConfig, and it will restart network. Sometimes, after restart vm network, "plink.exe root@ip address" does not work in the powershell script, which induces the test case abort. (even can connect by plink in the other session, e.g. try on the other windows powershell)

In the utils.sh function RemoveVlanConfig, it already has #1124 line ip link set $interface.$vlanID down, so could remove "service network restart" line. If remove the service network restart line in vm, it does not have impact to the eth0 adapter, the plink connection will keep connected. 

Thank you so much. 