### PR TITLE
lisa-parser: Fixed regex for throughput

### DIFF
--- a/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser/file_parser.py
+++ b/WS2012R2/lisa/Infrastructure/lisa-parser/lisa_parser/file_parser.py
@@ -425,7 +425,7 @@ class NTTTCPLogsReader(BaseLogsReader):
         with open(log_file, 'r') as fl:
             for x in fl:
                 if not log_dict.get('Throughput_Gbps', None):
-                    throughput = re.match('.+throughput.+:([0-9.]+)', x)
+                    throughput = re.match('.+INFO.+throughput.+:([0-9.]+)', x)
                     if throughput:
                         log_dict['Throughput_Gbps'] = throughput.group(1).strip()
                 if not log_dict.get('SenderCyclesPerByte', None):


### PR DESCRIPTION
ntttcp for linux tool v.1.3.4 has a new logging format, with multiple throughput fields.
Changing the parser to continue to use only the average throughput value.