### PR TITLE
lsvmbus: fix cpu count issue about network driver and scsi controller

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/lsvmbus_basic.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/lsvmbus_basic.sh
@@ -90,7 +90,7 @@ case $DISTRO in
     ;;
 esac
 
-if [[ "$DISTRO" =~ "redhat" ]] || [[ "$DISTRO" =~ "centos" ]]; then
+if [[ "$DISTRO" =~ "redhat" ]] || [[ "$DISTRO" =~ "centos" ]] || [[ "$DISTRO" =~ "fedora" ]]; then
     rpm -q hyperv-tools
     if [ $? -ne 0 ]; then
         yum install -y hyperv-tools


### PR DESCRIPTION
1. From my test, the cpu count that attached to the network driver is less than 8, and the cpu count that attached to the scsi controller is (N+3)/4.

Not sure about the cpu count is right, the result is only the same as my test. If it is wrong, feel free to correct me. Thanks!

2. Add fedora support.