### PR TITLE
Minor update CORE_max_cpus.ps1 to fix bug

### DIFF
--- a/WS2012R2/lisa/setupscripts/CORE_max_cpus.ps1
+++ b/WS2012R2/lisa/setupscripts/CORE_max_cpus.ps1
@@ -149,6 +149,7 @@ if ($OSInfo) {
     if ($guest_max_cpus -gt $maxCPUs) {
         "VM maximum cores is limited by the number of Logical cores: $maxCPUs" | `
         Tee-Object -Append -file $summaryLog
+        $guest_max_cpus = $maxCPUs
     }
 }
 
@@ -188,7 +189,7 @@ if ($new_ipv4) {
 } else {
     "Error: VM $vmName failed to start after setting $guest_max_cpus vCPUs" | `
     Tee-Object -Append -file $summaryLog
-    return $False  
+    return $False
 }
 
 #


### PR DESCRIPTION
Minor change: if $guest_max_cpus is larger than host supported locical cores, set $guest_max_cpus as maxCpus.