### PR TITLE
Update Core_StressReloadModules to deeper stress

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/CORE_StressReloadModules.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/CORE_StressReloadModules.sh
@@ -146,22 +146,35 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
+# if not set the LoopCount, set as 100 by default
+if [ "${LoopCount:-UNDEFINED}" = "UNDEFINED" ]; then
+    LoopCount=100
+fi
+
+# if not set the sleep duration, set as 1 second by default
+if [ "${Duration:-UNDEFINED}" = "UNDEFINED" ]; then
+    Duration=1
+fi
+msg="Info: module unload/load loop count set as $LoopCount"
+LogMsg "${msg}"
+echo "$msg" >> ~/summary.log
+
 pass=0
 START=$(date +%s)
-while [ $pass -lt 100 ]
+while [ $pass -lt $LoopCount ]
 do
     modprobe -r hv_netvsc
-    sleep 1
+    sleep $Duration
     modprobe hv_netvsc
-    sleep 1
+    sleep $Duration
     modprobe -r hv_utils
-    sleep 1
+    sleep $Duration
     modprobe hv_utils
-    sleep 1
+    sleep $Duration
     modprobe -r hid_hyperv
-    sleep 1
+    sleep $Duration
     modprobe hid_hyperv
-    sleep 1
+    sleep $Duration
     pass=$((pass+1))
     echo $pass
 done

--- a/WS2012R2/lisa/remote-scripts/ica/CORE_StressReloadModules.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/CORE_StressReloadModules.sh
@@ -24,6 +24,7 @@
 ########################################################################
 #
 # CORE_StressReloadModules.sh
+#
 # Description:
 #    This script will first check the existence of Hyper-V kernel modules.
 #    Then it will reload the modules in a loop in order to stress the system.
@@ -155,6 +156,7 @@ fi
 if [ "${Duration:-UNDEFINED}" = "UNDEFINED" ]; then
     Duration=1
 fi
+
 msg="Info: module unload/load loop count set as $LoopCount"
 LogMsg "${msg}"
 echo "$msg" >> ~/summary.log
@@ -182,8 +184,7 @@ END=$(date +%s)
 DIFF=$(echo "$END - $START" | bc)
 
 echo "Info: Finished testing, bringing up eth0"
-ifdown eth0
-ifup eth0
+ifdown eth0 && ifup eth0
 dhclient
 if [[ $? -ne 0 ]]; then
     msg="Error: dhclient exited with an error"
@@ -194,11 +195,10 @@ if [[ $? -ne 0 ]]; then
 fi
 VerifyModules
 
-#ipAddress=$(ifconfig | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | cut -d' ' -f1 | sed -n 1p)
 # inet\b only shows the IPv4 address of the interface
 ipAddress=$(ip addr show eth0 | grep "inet\b")
-if [[ ${ipAddress} -eq '' ]]; then
-    LogMsg "Info: Waiting for interface to receive an IP"
+if [ -z "$ipAddress" ]; then
+    LogMsg "Info: Waiting 30 seconds for interface to receive an IP"
     sleep 30
 fi
 

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -52,7 +52,7 @@
             <suiteTest>TimeSync_PausedVM_ChronyOff</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
             <suiteTest>FloppyDisk</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -197,13 +197,17 @@
             <noReboot>False</noReboot>
         </test>
         <test>
-            <testName>StressReloadModules</testName>
-            <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
+            <testName>StressReloadModules_SMP</testName>
+            <setupScript>
+                <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+            </setupScript>
             <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=CORE-18</param>
+                <param>TC_COVERED=CORE-18b</param>
+                <param>vCPU=4</param>
             </testParams>
-            <timeout>3600</timeout>
+            <timeout>1200</timeout>
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>

--- a/WS2012R2/lisa/xml/StressTests.xml
+++ b/WS2012R2/lisa/xml/StressTests.xml
@@ -23,6 +23,7 @@
                 <suiteTest>Sysbench</suiteTest>
                 <suiteTest>ChangeMTU_ReloadNetvsc</suiteTest>
                 <suiteTest>BootVM_LargeMemory</suiteTest>
+                <suiteTest>StressReloadModules_UP</suiteTest>
             </suiteTests>
         </suite>
     </testSuites>
@@ -95,6 +96,23 @@
             </testParams>
             <timeout>600</timeout>
             <onError>Continue</onError>
+        </test>
+
+        <test>
+            <testName>StressReloadModules_UP</testName>
+            <setupScript>
+                <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=CORE-18a</param>
+                <param>vCPU=1</param>
+                <param>LoopCount=1500</param>
+            </testParams>
+            <timeout>10000</timeout>
+            <onError>Continue</onError>
+            <noReboot>False</noReboot>
         </test>
     </testCases>
 

--- a/WS2012R2/lisa/xml/hyperv_bvt.xml
+++ b/WS2012R2/lisa/xml/hyperv_bvt.xml
@@ -38,7 +38,7 @@
             <suiteTest>TimeSync_NTP</suiteTest>
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -131,7 +131,7 @@
         <files>remote-scripts/ica/vmbus_protocol_version.sh</files>
         <timeout>300</timeout>
         <onError>Continue</onError>
-        <noReboot>False</noReboot>  
+        <noReboot>False</noReboot>
         <testParams>
             <param>TC_COVERED=VMBus-01</param>
         </testParams>
@@ -204,13 +204,17 @@
         </test>
 
         <test>
-            <testName>StressReloadModules</testName>
-            <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
+            <testName>StressReloadModules_SMP</testName>
+            <setupScript>
+                <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+            </setupScript>
             <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=CORE-18</param>
+                <param>TC_COVERED=CORE-18b</param>
+                <param>vCPU=4</param>
             </testParams>
-            <timeout>3600</timeout>
+            <timeout>1200</timeout>
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
@@ -738,7 +742,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-01</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-01</param>
                 <param>startupMem=2GB</param>
                 <param>testMem=4GB</param>
             </testParams>
@@ -750,7 +754,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-02</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-02</param>
                 <param>startupMem=4GB</param>
                 <param>testMem=2GB</param>
             </testParams>
@@ -762,7 +766,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd_reboot.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-09</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-09</param>
                 <param>startupMem=5000MB</param>
             </testParams>
             <timeout>1200</timeout>

--- a/WS2012R2/lisa/xml/hyperv_fvt.xml
+++ b/WS2012R2/lisa/xml/hyperv_fvt.xml
@@ -41,7 +41,7 @@
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>TimeSync_PausedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -362,16 +362,19 @@
          <noReboot>False</noReboot>
       </test>
       <test>
-         <testName>StressReloadModules</testName>
-         <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
-         <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
-         <files>remote-scripts/ica/utils.sh</files>
-         <testParams>
-            <param>TC_COVERED=CORE-18</param>
-         </testParams>
-         <timeout>3600</timeout>
-         <onError>Continue</onError>
-         <noReboot>False</noReboot>
+          <testName>StressReloadModules_SMP</testName>
+          <setupScript>
+              <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+              <file>setupScripts\ChangeCPU.ps1</file>
+          </setupScript>
+          <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
+          <testParams>
+              <param>TC_COVERED=CORE-18b</param>
+              <param>vCPU=4</param>
+          </testParams>
+          <timeout>1200</timeout>
+          <onError>Continue</onError>
+          <noReboot>False</noReboot>
       </test>
       <test>
          <testName>VCPU_verify_online</testName>

--- a/WS2012R2/lisa/xml/kernel_pipeline_bvt.xml
+++ b/WS2012R2/lisa/xml/kernel_pipeline_bvt.xml
@@ -40,7 +40,7 @@
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
 
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -142,7 +142,7 @@
         <files>remote-scripts/ica/vmbus_protocol_version.sh</files>
         <timeout>300</timeout>
         <onError>Continue</onError>
-        <noReboot>False</noReboot>	
+        <noReboot>False</noReboot>
         <testParams>
             <param>TC_COVERED=VMBus-01</param>
         </testParams>
@@ -206,14 +206,19 @@
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
+
         <test>
-            <testName>StressReloadModules</testName>
-            <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
+            <testName>StressReloadModules_SMP</testName>
+            <setupScript>
+                <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+            </setupScript>
             <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=CORE-18</param>
+                <param>TC_COVERED=CORE-18b</param>
+                <param>vCPU=4</param>
             </testParams>
-            <timeout>3600</timeout>
+            <timeout>1200</timeout>
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
@@ -740,7 +745,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-01</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-01</param>
                 <param>startupMem=2GB</param>
                 <param>testMem=4GB</param>
             </testParams>
@@ -752,7 +757,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-02</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-02</param>
                 <param>startupMem=4GB</param>
                 <param>testMem=2GB</param>
             </testParams>
@@ -764,7 +769,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd_reboot.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-09</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-09</param>
                 <param>startupMem=5000MB</param>
             </testParams>
             <timeout>1200</timeout>

--- a/WS2012R2/lisa/xml/kernel_pipeline_fvt.xml
+++ b/WS2012R2/lisa/xml/kernel_pipeline_fvt.xml
@@ -42,7 +42,7 @@
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>TimeSync_PausedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -196,9 +196,9 @@
             <suiteTest>HotAdd_Verify_udev</suiteTest>
             <!-- Basic Hot Add tests -->
             <suiteTest>HotAdd</suiteTest>
-            <!--<suiteTest>HotAddStressapptest</suiteTest> 
+            <!--<suiteTest>HotAddStressapptest</suiteTest>
 			<suiteTest>DemandPressure</suiteTest>-->
-			<!-- Complex Hot Add tests 
+			<!-- Complex Hot Add tests
 			<suiteTest>HotRemove</suiteTest>-->
 			<!-- Dynamic Memory – Ballooning
 			<suiteTest>StartupLowCompete</suiteTest>
@@ -375,18 +375,21 @@
          <timeout>1600</timeout>
          <noReboot>False</noReboot>
         </test>
-      <test>
-         <testName>StressReloadModules</testName>
-         <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
-         <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
-         <files>remote-scripts/ica/utils.sh</files>
-         <testParams>
-            <param>TC_COVERED=CORE-18</param>
-         </testParams>
-         <timeout>3600</timeout>
-         <onError>Continue</onError>
-         <noReboot>False</noReboot>
-      </test>
+        <test>
+            <testName>StressReloadModules_SMP</testName>
+            <setupScript>
+                <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
+            <testParams>
+                <param>TC_COVERED=CORE-18b</param>
+                <param>vCPU=4</param>
+            </testParams>
+            <timeout>1200</timeout>
+            <onError>Continue</onError>
+            <noReboot>False</noReboot>
+        </test>
       <test>
          <testName>VCPU_verify_online</testName>
          <testScript>vcpu_verify_online.sh</testScript>
@@ -2647,7 +2650,7 @@
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
-	   
+
       <test>
          <testName>Crash_single_core</testName>
          <setupScript>

--- a/WS2012R2/lisa/xml/lis_pipeline_bvt.xml
+++ b/WS2012R2/lisa/xml/lis_pipeline_bvt.xml
@@ -39,7 +39,7 @@
             <suiteTest>TimeSync_NTP</suiteTest>
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -145,7 +145,7 @@
         <files>remote-scripts/ica/vmbus_protocol_version.sh</files>
         <timeout>300</timeout>
         <onError>Continue</onError>
-        <noReboot>False</noReboot>  
+        <noReboot>False</noReboot>
         <testParams>
             <param>TC_COVERED=VMBus-01</param>
         </testParams>
@@ -222,13 +222,17 @@
         </test>
 
         <test>
-            <testName>StressReloadModules</testName>
-            <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
+            <testName>StressReloadModules_SMP</testName>
+            <setupScript>
+                <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+                <file>setupScripts\ChangeCPU.ps1</file>
+            </setupScript>
             <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=CORE-18</param>
+                <param>TC_COVERED=CORE-18b</param>
+                <param>vCPU=4</param>
             </testParams>
-            <timeout>3600</timeout>
+            <timeout>1200</timeout>
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
@@ -755,7 +759,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-01</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-01</param>
                 <param>startupMem=2GB</param>
                 <param>testMem=4GB</param>
             </testParams>
@@ -767,7 +771,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-02</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-02</param>
                 <param>startupMem=4GB</param>
                 <param>testMem=2GB</param>
             </testParams>
@@ -779,7 +783,7 @@
             <setupScript>setupscripts\Runtime_Mem_Configure.ps1</setupScript>
             <testScript>setupscripts\Runtime_Mem_HotAdd_reboot.ps1</testScript>
             <testParams>
-                <param>TC_COVERED=Runtime_Mem_Resize-09</param>                                   
+                <param>TC_COVERED=Runtime_Mem_Resize-09</param>
                 <param>startupMem=5000MB</param>
             </testParams>
             <timeout>1200</timeout>

--- a/WS2012R2/lisa/xml/lis_pipeline_fvt.xml
+++ b/WS2012R2/lisa/xml/lis_pipeline_fvt.xml
@@ -42,7 +42,7 @@
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>TimeSync_PausedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -195,9 +195,9 @@
             <suiteTest>HotAdd_Verify_udev</suiteTest>
             <!-- Basic Hot Add tests -->
             <suiteTest>HotAdd</suiteTest>
-            <!--<suiteTest>HotAddStressapptest</suiteTest> 
+            <!--<suiteTest>HotAddStressapptest</suiteTest>
 		<suiteTest>DemandPressure</suiteTest>-->
-            <!-- Complex Hot Add tests 
+            <!-- Complex Hot Add tests
 		<suiteTest>HotRemove</suiteTest>-->
             <!-- Dynamic Memory – Ballooning
 		<suiteTest>StartupLowCompete</suiteTest>
@@ -378,16 +378,19 @@
          <noReboot>False</noReboot>
       </test>
       <test>
-         <testName>StressReloadModules</testName>
-         <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
-         <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
-         <files>remote-scripts/ica/utils.sh</files>
-         <testParams>
-            <param>TC_COVERED=CORE-18</param>
-         </testParams>
-         <timeout>3600</timeout>
-         <onError>Continue</onError>
-         <noReboot>False</noReboot>
+          <testName>StressReloadModules_SMP</testName>
+          <setupScript>
+              <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+              <file>setupScripts\ChangeCPU.ps1</file>
+          </setupScript>
+          <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
+          <testParams>
+              <param>TC_COVERED=CORE-18b</param>
+              <param>vCPU=4</param>
+          </testParams>
+          <timeout>1200</timeout>
+          <onError>Continue</onError>
+          <noReboot>False</noReboot>
       </test>
       <test>
          <testName>VCPU_verify_online</testName>
@@ -2635,7 +2638,7 @@
             <onError>Continue</onError>
             <noReboot>False</noReboot>
         </test>
-	   
+
       <test>
          <testName>Crash_single_core</testName>
          <setupScript>

--- a/WS2012R2/lisa/xml/ubuntu_azure_kernel_fvt.xml
+++ b/WS2012R2/lisa/xml/ubuntu_azure_kernel_fvt.xml
@@ -42,7 +42,7 @@
             <suiteTest>TimeSync_SavedVM</suiteTest>
             <suiteTest>TimeSync_PausedVM</suiteTest>
             <suiteTest>VerifyIntegratedTimeSyncService</suiteTest>
-            <suiteTest>StressReloadModules</suiteTest>
+            <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
@@ -87,7 +87,7 @@
             <!-- VHD Resize tests -->
             <suiteTest>VHDxResizeToBigger512</suiteTest>
             <suiteTest>VHDxResizeToBigger4096</suiteTest>
-            <suiteTest>VHDxResizeToBigger512_Dynamic_IDE</suiteTest> 
+            <suiteTest>VHDxResizeToBigger512_Dynamic_IDE</suiteTest>
             <suiteTest>VHDxResizeToBigger512_Fixed_IDE</suiteTest>
             <suiteTest>VHDxResizeToSmaller512</suiteTest>
             <suiteTest>VHDxResizeToSmaller4096</suiteTest>
@@ -193,10 +193,10 @@
             <suiteTest>DM_loaded</suiteTest>
             <suiteTest>HotAdd_Verify_udev</suiteTest>
             <!-- Basic Hot Add tests-->
-            <suiteTest>HotAdd</suiteTest> 
-            <!--<suiteTest>HotAddStressapptest</suiteTest> 
+            <suiteTest>HotAdd</suiteTest>
+            <!--<suiteTest>HotAddStressapptest</suiteTest>
             <suiteTest>DemandPressure</suiteTest>-->
-            <!-- Complex Hot Add tests 
+            <!-- Complex Hot Add tests
             <suiteTest>HotRemove</suiteTest>-->
             <!-- Dynamic Memory Ballooning
             <suiteTest>StartupLowCompete</suiteTest>
@@ -374,16 +374,19 @@
       <noReboot>False</noReboot>
     </test>
     <test>
-      <testName>StressReloadModules</testName>
-      <setupscript>setupscripts\CORE_EnableIntegrationServices.ps1</setupscript>
-      <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
-      <files>remote-scripts/ica/utils.sh</files>
-      <testParams>
-        <param>TC_COVERED=CORE-18</param>
-      </testParams>
-      <timeout>3600</timeout>
-      <onError>Continue</onError>
-      <noReboot>False</noReboot>
+        <testName>StressReloadModules_SMP</testName>
+        <setupScript>
+            <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
+            <file>setupScripts\ChangeCPU.ps1</file>
+        </setupScript>
+        <testScript>setupscripts\CORE_reload_modules.ps1</testScript>
+        <testParams>
+            <param>TC_COVERED=CORE-18b</param>
+            <param>vCPU=4</param>
+        </testParams>
+        <timeout>1200</timeout>
+        <onError>Continue</onError>
+        <noReboot>False</noReboot>
     </test>
     <test>
       <testName>VCPU_verify_online</testName>


### PR DESCRIPTION
Hi Chris,

Currently there is one bug https://bugzilla.redhat.com/show_bug.cgi?id=1613655, if use original #100 times and sleep 1 for six times, it cannot catch the bug like https://bugzilla.redhat.com/show_bug.cgi?id=1613655, this case only reproduces on SMP, but not UP, so may need to add two cases. Do you want to change related cases.xml to add new test cases about StressReloadModules_UP and StressReloadModules_SMP? If yes, I will change it too?

Thank you so much.

