### PR TITLE
update Kdump_Config.sh for blacklist in hyper-v 2012 host

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Config.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Config.sh
@@ -186,7 +186,7 @@ ConfigRhel()
     # Extra config for WS2012 - RHEL7
     if [[ $os_RELEASE.$os_UPDATE =~ ^7.* ]] && [[ $BuildNumber == "9200" ]] ; then
         echo "extra_modules ata_piix sr_mod sd_mod" >> /etc/kdump.conf
-        echo "KDUMP_COMMANDLINE_APPEND=\"ata_piix.prefer_ms_hyperv=0 disk_timeout=100 rd.driver.blacklist=hv_vmbus,hv_storvsc,hv_utils,hv_netvsc,hid-hyperv\"" >> /etc/sysconfig/kdump
+        echo "KDUMP_COMMANDLINE_APPEND=\"ata_piix.prefer_ms_hyperv=0 disk_timeout=100 rd.driver.blacklist=hv_vmbus,hv_storvsc,hv_utils,hv_netvsc,hid-hyperv,hyperv_fb\"" >> /etc/sysconfig/kdump
     fi
 
     GetGuestGeneration


### PR DESCRIPTION
Minor update kdump_config.sh to add hyperv_fb in the blacklist for hyper-v 2012 host.
If do not blacklist it, kdump will fail in the latest rhel.

Thank you so much.

