### PR TITLE
Update utils.sh CreateIfupConfigFile to remove NM_Controlled as No

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/utils.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/utils.sh
@@ -1510,7 +1510,6 @@ CreateIfupConfigFile()
 						BOOTPROTO=none
 						IPADDR="$__ip"
 						NETMASK="$__netmask"
-						NM_CONTROLLED=no
 					EOF
 				else
 					cat <<-EOF > "$__file_path"
@@ -1519,7 +1518,6 @@ CreateIfupConfigFile()
 						IPV6ADDR="$__ip"
 						IPV6INIT=yes
 						PREFIX="$__netmask"
-						NM_CONTROLLED=no
 					EOF
 				fi
 


### PR DESCRIPTION
Hi Chris,
Generally during testing, NetworkManager service is disabled, I see it disable in the aio.sh. In our local test, we disable NetworkManager too, most of our network test cases run as network status enabled 

If disable network service, only enable NetworkManager, it needs to remove "NM_CONTROLLED=no" line to make the NIC created successfully.
Related test cases:
GuestOnlyNetwork
ChangeNetTypeGuest
JumboFrame
VlanTagging
Note: VlanTrunking_ipv6 cannot pass if disable network and only NetworkManager enabled, I try using  "nmcli con add type vlan con-name VLAN20 dev eth0 id 20 ip6 xxxx" in createVlanConfig, still need debug, only share information.

Thank you so much.