### PR TITLE
CDmount test case refresh

### DIFF
--- a/WS2012R2/lisa/setupscripts/RemoveIsoFromDvd.ps1
+++ b/WS2012R2/lisa/setupscripts/RemoveIsoFromDvd.ps1
@@ -24,16 +24,18 @@
 # RemoveIsoFromDvd.ps1
 #
 # Description:
-#    This script will "unmount" a .iso file in the DVD drive
+#    This script will remove all DVD drives from a VM.
 #
 #######################################################################
 
 <#
 .Synopsis
-    Remove the .iso file from the default DVD drive.
+    Remove all DVD drives from VM.
 
 .Description
-    Remove the .iso file from the default DVD drive.
+    Remove all DVD drives from VM.
+    In order to just eject any ISO, Set-VMDvdDrive path should be set
+    to null instead.
 
 .Parameter vmName
     Name of the test VM.
@@ -50,21 +52,17 @@
 
 param ([String] $vmName, [String] $hvServer, [String] $testParams)
 
-$isoFilename = $null
 $controllerNumber=$null
-$vmGeneration = $null
 
 #
 # Check arguments
 #
-if (-not $vmName)
-{
+if (-not $vmName) {
     "Error: Missing vmName argument"
     return $False
 }
 
-if (-not $hvServer)
-{
+if (-not $hvServer) {
     "Error: Missing hvServer argument"
     return $False
 }
@@ -79,35 +77,29 @@ $error.Clear()
 # Main script body
 #
 #######################################################################
-$vmGeneration = Get-VM $vmName -ComputerName $hvServer| select -ExpandProperty Generation -ErrorAction SilentlyContinue
-if ($? -eq $False)
-{
-   $vmGeneration = 1
+$vmGeneration = Get-VM $vmName -ComputerName $hvServer| Select-Object -ExpandProperty Generation -ErrorAction SilentlyContinue
+if ($? -eq $False) {
+    $vmGeneration = 1
 }
 #
 # Make sure the DVD drive exists on the VM
 #
-if ($vmGeneration -eq 1)
-{
+if ($vmGeneration -eq 1) {
     $controllerNumber=1
-}
-else
-{
+} else {
     $controllerNumber=0
 }
 
 $dvdcount = $(Get-VMDvdDrive -VMName $vmName -ComputerName $hvServer).ControllerLocation.count 
-for ($i=0; $i -le $dvdcount; $i++)
-{
+for ($i=0; $i -le $dvdcount; $i++) {
     $dvd = Get-VMDvdDrive -VMName $vmName -ComputerName $hvServer -ControllerNumber $controllerNumber -ControllerLocation $i
-    if ($dvd)
-    {
+    if ($dvd) {
         Remove-VMDvdDrive -VMName $vmName -ComputerName $hvServer -ControllerNumber $controllerNumber -ControllerLocation $i
     }
 }
-if (-not $?)
-{
-    "Error: Unable to remove the .iso from the DVD"
+
+if (-not $?) {
+    "Error: Unable to remove the .iso from the DVD!"
     return $False
 }
 

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -462,8 +462,6 @@
         <testParams>
             <param>publicKey=rhel5_id_rsa.pub</param>
             <param>snapshotName=ICABase</param>
-            <!-- Required for CDmount -->
-            <param>IsoFilename=CDTEST.iso</param>
         </testParams>
         </vm>
     </VMs>

--- a/WS2012R2/lisa/xml/lis_pipeline_fvt.xml
+++ b/WS2012R2/lisa/xml/lis_pipeline_fvt.xml
@@ -51,6 +51,7 @@
             <suiteTest>Disable_NUMA_By_Kernel</suiteTest>
             <suiteTest>PausedCritical_Heartbeat</suiteTest>
             <suiteTest>UIO_Basic</suiteTest>
+            <suiteTest>CDmount</suiteTest>
             <!-- KVP and SQM tests -->
             <suiteTest>SQM_Basic</suiteTest>
             <suiteTest>KVP_basic_checks</suiteTest>
@@ -557,6 +558,19 @@
                   <param>TC_COVERED=UIO-01</param>
               </testParams>
               <timeout>400</timeout>
+        </test>
+        <test>
+            <testName>CDmount</testName>
+            <testScript>Core_LIS_CD.sh</testScript>
+            <files>remote-scripts/ica/Core_LIS_CD.sh,remote-scripts\ica\check_traces.sh,remote-scripts/ica/utils.sh</files>
+            <setupScript>setupscripts\InsertIsoInDvd.ps1</setupScript>
+            <cleanupScript>setupScripts\RemoveIsoFromDvd.ps1</cleanupScript>
+            <testparams>
+                <param>TC_COVERED=CORE-20</param>
+            </testparams>
+            <timeout>600</timeout>
+            <onError>Continue</onError>
+            <noReboot>False</noReboot>
         </test>
       <!-- KVP_Tests -->
         <test>


### PR DESCRIPTION
No longer requires a CDTest.iso dependency file, the script will automatically download an ISO.
Fixed description for cleanup script, the test case actually is removing the DVD unit and not eject ISO only.