### PR TITLE
deploy_scenarios: renamed validation script

### DIFF
--- a/WS2012R2/lisa/setupscripts/deploy_scenarios_pipeline.ps1
+++ b/WS2012R2/lisa/setupscripts/deploy_scenarios_pipeline.ps1
@@ -56,7 +56,7 @@ function InstallLIS() {
 
 function VerifyDaemons() {
     # Verify LIS Modules and daemons
-    $remoteScript = "CORE_LISmodules_version.sh"
+    $remoteScript = "CORE_LIS_modules.sh"
     $sts = RunRemoteScript $remoteScript
     if (-not $sts[-1]) {
         Write-Output "Error: Cannot verify LIS modules version on ${vmName}" | Tee-Object -Append -file $summaryLog


### PR DESCRIPTION
This is a needed fix because CORE_LISmodules_version.sh was renamed to
CORE_LIS_modules.sh