### PR TITLE
install_kernel: remove grub-legacy-ec2 on Debian

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/install_kernel.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/install_kernel.sh
@@ -96,7 +96,7 @@ function prepare_rhel {
 }
 
 function install_kernel_debian {
-    apt remove -y linux-cloud-tools-common
+    apt remove -y linux-cloud-tools-common grub-legacy-ec2
     dpkg --force-all -i *.deb
     if [[ $? -ne 0 ]];then
         msg="Error: deb install failed."


### PR DESCRIPTION
grub-legacy-ec2 is breaking the kernel installation due to some incompatibility in kdump with recent kernels.
EC2 integration and support is not required, thus removing the package for easy fix.