### PR TITLE
Kdump_Config.sh: fix can not find kernel command in grub.cfg issue an…

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Kdump_Execute.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Kdump_Execute.sh
@@ -164,7 +164,8 @@ Ubuntu()
 kdump_loaded()
 {
     UpdateSummary "Checking if kdump is loaded after reboot..."
-    CRASHKERNEL=`grep -i crashkernel= /proc/cmdline`;
+    # CRASHKERNEL=`grep -i crashkernel= /proc/cmdline`;
+    CRASHKERNEL=$(grep -o '\bcrashkernel=[^ ]*' /proc/cmdline)
 
     if [ ! -e $sys_kexec_crash ] && [ -z "$CRASHKERNEL" ] ; then
         LogMsg "FAILED: kdump is not enabled after reboot."
@@ -172,8 +173,8 @@ kdump_loaded()
         SetTestStateFailed
         exit 1
     else
-        LogMsg "Kdump is loaded after reboot."
-        UpdateSummary "Success: Kdump is loaded after reboot."
+        LogMsg "Kdump is loaded after reboot, actual is '$CRASHKERNEL', expected 'crashkernel=$crashkernel'"
+        UpdateSummary "Success: Kdump is loaded after reboot, actual is '$CRASHKERNEL', expected 'crashkernel=$crashkernel'"
     fi
 }
 


### PR DESCRIPTION
1. Fix kdump config issue: if can not find kernel command in grub.cfg, need to update /etc/default/grub and then regenerate the config file
2. Print the actual crashkernel value in /proc/cmdline