### PR TITLE
lsvmbus: Fix core spread issue 

### DIFF
--- a/WS2012R2/lisa/xml/hyperv_bvt.xml
+++ b/WS2012R2/lisa/xml/hyperv_bvt.xml
@@ -722,6 +722,7 @@
         <test>
         <testName>lsvmbus_target</testName>
         <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
             <file>setupScripts\DM_CONFIGURE_MEMORY.ps1</file>
             <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
             <file>setupScripts\ChangeCPU.ps1</file>

--- a/WS2012R2/lisa/xml/hyperv_fvt.xml
+++ b/WS2012R2/lisa/xml/hyperv_fvt.xml
@@ -554,6 +554,7 @@
         <test>
         <testName>lsvmbus_target</testName>
         <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
             <file>setupScripts\DM_CONFIGURE_MEMORY.ps1</file>
             <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
             <file>setupScripts\ChangeCPU.ps1</file>

--- a/WS2012R2/lisa/xml/kernel_pipeline_bvt.xml
+++ b/WS2012R2/lisa/xml/kernel_pipeline_bvt.xml
@@ -730,6 +730,7 @@
         <test>
         <testName>lsvmbus_target</testName>
         <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
             <file>setupScripts\DM_CONFIGURE_MEMORY.ps1</file>
             <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
             <file>setupScripts\ChangeCPU.ps1</file>

--- a/WS2012R2/lisa/xml/lis_pipeline_bvt.xml
+++ b/WS2012R2/lisa/xml/lis_pipeline_bvt.xml
@@ -744,6 +744,7 @@
         <test>
         <testName>lsvmbus_target</testName>
         <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
             <file>setupScripts\DM_CONFIGURE_MEMORY.ps1</file>
             <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
             <file>setupScripts\ChangeCPU.ps1</file>

--- a/WS2012R2/lisa/xml/lsvmbus.xml
+++ b/WS2012R2/lisa/xml/lsvmbus.xml
@@ -68,6 +68,7 @@
         <test>
         <testName>lsvmbus_target</testName>
         <setupScript>
+            <file>setupscripts\RevertSnapshot.ps1</file>
             <file>setupScripts\DM_CONFIGURE_MEMORY.ps1</file>
             <file>setupscripts\CORE_EnableIntegrationServices.ps1</file>
             <file>setupScripts\ChangeCPU.ps1</file>


### PR DESCRIPTION
Tested with 2 nics and without snapshot revert in setup phase : 
   **Test lsvmbus_target            : Passed**
         This script covers test case: lsvmbus-02
         Counting the cores spread only for the first NIC...
         Network driver is spread on 8 core(s) as expected, actual cpu count in os is '8'.
         Storage driver is spread on all 2 core(s) as expected.
         Test completed successfully.