### PR TITLE
Fixed cpio unpacking for initrd TC

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
@@ -174,7 +174,10 @@ LogMsg "Info: Unpacking the image..."
 
 case $img_type in
     *ASCII*cpio*)
-        /usr/lib/dracut/skipcpio boot.img |zcat| cpio -id --no-absolute-filenames
+        cpio -id -F boot.img &> out.file
+        skip_block_size=$(cat out.file | awk '{print $1}')
+        dd if=boot.img of=finalInitrd.img bs=512 skip=$skip_block_size
+        /usr/lib/dracut/skipcpio finalInitrd.img |zcat| cpio -id --no-absolute-filenames
         if [ $? -eq 0 ]; then
             LogMsg "Info: Successfully unpacked the image."
         else


### PR DESCRIPTION
On ubuntu distros the initrd image is made from 2 separate archives
(microcode & initrd) and the old unpacking failed. We skip the microcode
archive and unpack the actual initrd image.