### PR TITLE
kdump_nfs: check modules for kdump.img before execute kdump, skip che…

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/modules_check.sh
@@ -155,20 +155,31 @@ case $DISTRO in
     ;;
 esac
 
-if [ -f /boot/initramfs-0-rescue* ]; then
-    img=/boot/initramfs-0-rescue*
+if [ "${img:-UNDEFINED}" = "UNDEFINED" ]; then
+    if [ -f /boot/initramfs-0-rescue* ]; then
+        img=/boot/initramfs-0-rescue*
+    else
+    if [ -f "/boot/initrd-`uname -r`" ]; then
+        img="/boot/initrd-`uname -r`"
+    fi
+
+    if [ -f "/boot/initramfs-`uname -r`.img" ]; then
+        img="/boot/initramfs-`uname -r`.img"
+    fi
+
+    if [ -f "/boot/initrd.img-`uname -r`" ]; then
+        img="/boot/initrd.img-`uname -r`"
+    fi
+    fi
 else
-  if [ -f "/boot/initrd-`uname -r`" ]; then
-    img="/boot/initrd-`uname -r`"
-  fi
-
-  if [ -f "/boot/initramfs-`uname -r`.img" ]; then
-    img="/boot/initramfs-`uname -r`.img"
-  fi
-
-  if [ -f "/boot/initrd.img-`uname -r`" ]; then
-    img="/boot/initrd.img-`uname -r`"
-  fi
+    if [ $img == "kdump.img" ] && [ -f /boot/initramfs-`uname -r`kdump.img ]; then
+        img=/boot/initramfs-`uname -r`kdump.img
+    else 
+        LogMsg "Error: Failed to find $img."
+        echo "Error: Failed to find $img." >> /root/summary.log
+        SetTestStateFailed
+        exit 1
+    fi
 fi
 echo "The initrd test image is: $img" >> summary.log
 

--- a/WS2012R2/lisa/setupscripts/Kdump.ps1
+++ b/WS2012R2/lisa/setupscripts/Kdump.ps1
@@ -214,6 +214,30 @@ else{
     return $Failed
 }
 
+# check hyperv modules
+$kernel_supported = $false
+$kernel_supported = GetVMFeatureSupportStatus $ipv4 $sshKey "3.10.0-957"
+if ($kernel_supported)
+{
+    if ($vm2Name -And $use_nfs -eq "yes")
+    {
+        $retVal = RunRemoteScript "modules_check.sh"
+        if ($retVal[-1] -eq $false )
+        {
+            bin\pscp -q -i ssh\${sshKey} root@${ipv4}:summary.log $logdir/${TC_COVERED}_modules_check_fail_summary.log
+            Get-content  $logdir/${TC_COVERED}_modules_check_fail_summary.log | Tee-Object -Append -file $summaryLog
+            return $Failed
+        }
+        else {
+            bin\pscp -q -i ssh\${sshKey} root@${ipv4}:summary.log $logdir/${TC_COVERED}_modules_check_pass_summary.log
+            Get-content  $logdir/${TC_COVERED}_modules_check_pass_summary.log | Tee-Object -Append -file $summaryLog
+        }
+    }
+}
+else
+{
+    Write-Output "Info: modules check skipped becuase of kernel not supported" | Tee-Object -Append -file $summaryLog
+}
 #
 # Prepare the kdump related
 #

--- a/WS2012R2/lisa/xml/Kdump_Tests.xml
+++ b/WS2012R2/lisa/xml/Kdump_Tests.xml
@@ -171,13 +171,16 @@
                 <file>setupScripts\SetVMMemory.ps1</file>
             </setupScript>
             <testScript>setupScripts\kdump.ps1</testScript>
-            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/kdump_config.sh,remote-scripts/ica/kdump_results.sh,remote-scripts/ica/kdump_execute.sh,remote-scripts/ica/kdump_nfs_config.sh</files>
+            <files>remote-scripts/ica/modules_check.sh,remote-scripts/ica/utils.sh,remote-scripts/ica/kdump_config.sh,remote-scripts/ica/kdump_results.sh,remote-scripts/ica/kdump_execute.sh,remote-scripts/ica/kdump_nfs_config.sh</files>
             <testParams>
                 <param>crashkernel=384M</param>
                 <param>TC_COVERED=KDUMP-06</param>
                 <param>use_nfs=yes</param>
                 <param>VCPU=1</param>
                 <param>VMMemory=4GB</param>
+                <param>img=kdump.img</param>
+                <param>gen1_hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv_fb.ko)</param>
+                <param>gen2_hv_modules=(hv_vmbus.ko hv_storvsc.ko hv_netvsc.ko hyperv-keyboard.ko hyperv_fb.ko)</param>
             </testParams>
             <timeout>1000</timeout>
         </test>


### PR DESCRIPTION
1. Add modules check based on bug https://bugzilla.redhat.com/show_bug.cgi?id=1603017
2. Skip modules check when kernel version older than kernel-3.10.0-957.el7