### PR TITLE
Update eventid_18602_regression to fix return value bug

### DIFF
--- a/WS2012R2/lisa/setupscripts/eventid_18602_regression.ps1
+++ b/WS2012R2/lisa/setupscripts/eventid_18602_regression.ps1
@@ -185,9 +185,9 @@ function Trigger-MultipleReboots {
                 Out-File -Append $summaryLog
             return $False
         }
-
-        if ((Wait-VMEvent -VMName $vmName -HvServer $hvServer -StartTime $testStartTime `
-                -EventCode 18602 -RetryCount 2 -RetryInterval 1)) {
+        $resultEvent = Wait-VMEvent -VMName $vmName -HvServer $hvServer -StartTime $testStartTime `
+                -EventCode 18602 -RetryCount 2 -RetryInterval 1
+        if ( $resultEvent[-1] ) {
             Write-Output "Error: VM $vmName triggered a critical event 18602 on the host" | `
                 Out-File -Append $summaryLog
             return $False


### PR DESCRIPTION

Change checking Wait-VMEvent method's return value directly as checking $resultEvent[-1].
 After change write-host to write-output, it also changes the return value of Wait-VMEvent. So do minor change to fix this newly induced bug.

Thank you.