### PR TITLE
Minor update DM_HotAdd_Stress_ng.ps1 to add stressLevel 3 which is lo…

### DIFF
--- a/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
+++ b/WS2012R2/lisa/setupscripts/DM_HotAdd_Stress_ng.ps1
@@ -239,6 +239,11 @@ elseif ($timeoutStress -eq 2) {
     $duration = 40
     $chunk = 1
 }
+elseif ($timeoutStress -eq 3) {
+    $sleepTime = 20
+    $duration = 40
+    $chunk = 0
+}
 else {
     $sleepTime = 20
     $duration = 40
@@ -328,6 +333,5 @@ if ($vm1AfterDemand -ge $vm1Demand)
     "Error: Demand did not go down after stress-ng finished." | Tee-Object -Append -file $summaryLog
     return $false
 }
-
 "Memory Hot Add (using stress-ng) completed successfully!" | Tee-Object -Append -file $summaryLog
 return $true

--- a/WS2012R2/lisa/setupscripts/TCUtils.ps1
+++ b/WS2012R2/lisa/setupscripts/TCUtils.ps1
@@ -2278,6 +2278,10 @@ $DM_scriptBlock = {
         elif [ $timeoutStress -eq 2 ]; then
             timeout=1000000
             duration=`$__threads
+        elif [ $timeoutStress -eq 3 ]; then
+            timeout=1000000
+            duration=`$((2*__threads))
+            __threads=`$((__threads/2))
         else
             timeout=1
             duration=30


### PR DESCRIPTION
…wer stress

Add lower stress_Level 3 by using half of threads which is used to reach the maximum memory for stress-ng and small chunks size 512. If use stress_Level 0,1,2 makes VM out of memory sometimes, it will trigger call trace, the test case will fail. 
To make test case more stable, use lower stress. If it gets call trace, means exact bug but not triggered by stress-ng.

Thank you.