### PR TITLE
Add new balloon case about checking top load average value

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/DM_Top_LoadAverage.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/DM_Top_LoadAverage.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+# Description:
+#	This script verifies that the Dynamic Memory enabled, load average number is lower than 1.
+#
+#####################################################################
+
+# Convert eol
+dos2unix utils.sh
+
+# Source utils.sh
+. utils.sh || {
+	echo "Error: unable to source utils.sh!"
+	echo "TestAborted" > state.txt
+	exit 2
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+# sleep 8 minutes then check result
+sleep 480
+# Check load aveage value of top command
+load_average=(`top|head -n 1 | awk -F 'load average:' '{print $2}' | awk -F ',' '{print $1,$2,$3}'`)
+
+threshold=1
+for value in "${load_average[@]}"; do
+	# use awk to compare the value and 1, if value < 1, return 0, else return 1
+	echo "value is $value, threshold=$threshold"
+	st=`echo "$value $threshold" | awk '{if ($1 < $2) print 0; else print 1}'`
+    if [ $st -eq 1 ]; then
+		msg="The load avearage value of top is too high: $value"
+		LogMsg "$msg"
+		UpdateSummary "$msg"
+		SetTestStateFailed
+		exit 1
+	fi
+done
+
+UpdateSummary "Test successful"
+LogMsg "Updating test case state to completed"
+SetTestStateCompleted
+exit 0

--- a/WS2012R2/lisa/remote-scripts/ica/DM_Top_LoadAverage.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/DM_Top_LoadAverage.sh
@@ -22,7 +22,10 @@
 #####################################################################
 
 # Description:
-#	This script verifies that the Dynamic Memory enabled, load average number is lower than 1.
+#	This script verifies that with the Dynamic Memory enabled,
+#	load average is lower than 1.
+#	This is a regression test based on upstream commit
+#	"Drivers: hv: Ballon: Make pressure posting thread sleep interruptibly"
 #
 #####################################################################
 
@@ -38,8 +41,10 @@ dos2unix utils.sh
 
 # Source constants file and initialize most common variables
 UtilsInit
+
 # sleep 8 minutes then check result
 sleep 480
+
 # Check load aveage value of top command
 load_average=(`top|head -n 1 | awk -F 'load average:' '{print $2}' | awk -F ',' '{print $1,$2,$3}'`)
 

--- a/WS2012R2/lisa/xml/DM_Tests.xml
+++ b/WS2012R2/lisa/xml/DM_Tests.xml
@@ -28,6 +28,7 @@
 			<suiteName>DM</suiteName>
 			<suiteTests>
 				<suiteTest>DM_loaded</suiteTest>
+				<suiteTest>DM_Top_LoadAverage</suiteTest>
 				<suiteTest>HotAdd_Verify_udev</suiteTest>
 				<!--Dynamic Memory – Hot Add-->
 				<!-- Basic Hot Add tests -->
@@ -67,6 +68,23 @@
 			</testParams>
 			<testScript>DM_VERIFY_LOADED.sh</testScript>
 			<files>remote-scripts/ica/DM_VERIFY_LOADED.sh,remote-scripts/ica/utils.sh</files>
+			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
+			<timeout>800</timeout>
+		</test>
+		<test>
+			<testName>DM_Top_LoadAverage</testName>
+			<setupScript>SetupScripts\DM_CONFIGURE_MEMORY.ps1</setupScript>
+			<testParams>
+				<param>TC_COVERED=DM-18</param>
+				<param>enableDM=yes</param>
+				<param>minMem=1024MB</param>
+				<param>maxMem=2GB</param>
+				<param>startupMem=1024MB</param>
+				<param>memWeight=0</param>
+				<param>staticMem=1024MB</param>
+			</testParams>
+			<testScript>DM_Top_LoadAverage.sh</testScript>
+			<files>remote-scripts/ica/DM_Top_LoadAverage.sh,remote-scripts/ica/utils.sh</files>
 			<cleanupScript>SetupScripts\DM_DISABLE.ps1</cleanupScript>
 			<timeout>800</timeout>
 		</test>


### PR DESCRIPTION
This case covers bug https://bugzilla.redhat.com/show_bug.cgi?id=1065107, verify that load average value of top command is smaller than 1 when dynamic memory is enabled.

Test steps:
1. Enable dynamic memory with Hyper-V manager.
2. Start the guest, check the top metrics after waiting for several minutes.
#top
top - 14:31:23 up 6 min,  2 users,  load average: 0.00, 0.07, 0.05
Tasks: 267 total,   2 running, 265 sleeping,   0 stopped,   0 zombie
%Cpu0  :  0.0 us,  0.3 sy,  0.0 ni, 98.3 id,  0.0 wa,  0.0 hi,  1.3 si,  0.0 st
KiB Mem:   1406544 total,   468852 used,   937692 free,     1240 buffers
KiB Swap:  2129916 total,        0 used,  2129916 free.   176240 cached Mem
3. Check load average value of past minutes.

Verify results:
The load average value is smaller than 1.

Thank you so much.