### PR TITLE
Add new test case for setting valid mmio value based on existing case

### DIFF
--- a/WS2012R2/lisa/xml/retired_xml/MMIO_Tests.xml
+++ b/WS2012R2/lisa/xml/retired_xml/MMIO_Tests.xml
@@ -38,8 +38,9 @@
             <suiteName>MMIO</suiteName>
             <suiteTests>
                 <suiteTest>MMIO_Set_Invalid_GapSize</suiteTest>
+                <suiteTest>MMIO_Set_Valid_GapSize</suiteTest>
 			</suiteTests>
-		</suite> 
+		</suite>
 	</testSuites>
 
 	<testCases>
@@ -54,9 +55,21 @@
 			<noReboot>True</noReboot>
 		</test>
 
+        <test>
+         <testName>MMIO_Set_Valid_GapSize</testName>
+         <testScript>setupscripts\MMIO_Set_Valid_GapSize.ps1</testScript>
+         <timeout>600</timeout>
+         <onError>Continue</onError>
+         <testParams>
+             <param>TC_COVERED=MMIO-03</param>
+         </testParams>
+         <noReboot>False</noReboot>
+     </test>
+
+
 	</testCases>
 
-	<VMs>        
+	<VMs>
 		<vm>
 			<hvServer>localhost</hvServer>
 			<vmName>VMName</vmName>


### PR DESCRIPTION
Add one new test case MMIO_Set_Valid_GapSize, before already had MMIO_Set_InValid_GapSize, which was moved to retired xml.

Locally we have this MMIO_Set_Valid_GapSize manual case, so automate it based on MMIO_Set_InValid_GapSize.

Fix minor bug do - until to avoid endless loop.
Thank you.