### PR TITLE
Add new case about verifying CPU can be offline permanently

### DIFF
--- a/WS2012R2/lisa/remote-scripts/ica/Core_Offline_CPU_SMP.sh
+++ b/WS2012R2/lisa/remote-scripts/ica/Core_Offline_CPU_SMP.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+########################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+########################################################################
+
+UpdateTestState(){
+    echo $1 > ~/state.txt
+}
+
+#Source utils.sh
+dos2unix utils.sh
+. utils.sh || {
+    UpdateTestState "TestAborted"
+    UpdateSummary "Error: unable to source utils.sh!"
+    exit 2
+}
+
+# Source constants.sh
+dos2unix constants.sh
+. constants.sh || {
+    UpdateTestState "TestAborted"
+    UpdateSummary "Error: unable to source constants.sh!"
+    exit 2
+}
+
+# Change kernel parameter for rhel
+set_rhel(){
+    cpu_num=`grep processor /proc/cpuinfo | wc -l`
+    if [ $cpu_num -eq $VCPU ]; then
+        LogMsg "CPU Number : ${cpu_num}"
+    else
+        LogMsg "ERROR: CPU Number : ${cpu_num}, expect ${VCPU}"
+        UpdateSummary "Error: CPU Number ${cpu_num} not equal to ${VCPU}"
+        UpdateTestState "TestFailed"
+        exit 1
+    fi
+
+    #Change kernel parameter in /etc/default/grub
+    sed -i "s/quiet/quiet nr_cpus=${NR_CPU}/g" /etc/default/grub
+    GetGuestGeneration
+    if [ $os_GENERATION -eq 1 ]; then
+        grub2-mkconfig -o /boot/grub2/grub.cfg
+    else
+        grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+    fi
+
+    LogMsg "Set kernel parameter sucessfully"
+}
+
+# Change kernel parameter
+setCPUNum(){
+    Version=0
+    GetDistro
+    case "$DISTRO" in
+
+        redhat*)
+            set_rhel
+            exit 0
+        ;;
+
+        *)
+        echo "Error: Distro '$DISTRO' not supported." >> ~/summary.log
+        UpdateTestState "TestAborted"
+        UpdateSummary "Error: Distro '$DISTRO' not supported."
+        exit 1
+        ;;
+    esac
+    exit 0
+}
+
+# Check cpu number by /proc/cpuinfo
+checkCPUNum(){
+    cpunum=`grep processor /proc/cpuinfo | wc -l`
+    if [ $cpunum -eq $NR_CPU ]; then
+        LogMsg "Passed: CPU number is ${NR_CPU}"
+    else
+        LogMsg "Failed: CPU number is not ${NR_CPU}"
+        UpdateSummary "Failed: CPU number is not ${NR_CPU}. (actual ${cpunum})"
+        UpdateTestState "TestFailed"
+        exit 2
+    fi
+
+    # check CPUs attached should not go offline
+    for ((i=0; i<${cpunum}; i++))
+    do
+        echo 0 > /sys/devices/system/cpu/cpu${i}/online
+        if [ $? -ne 0 ]; then
+            LogMsg "Passed: CPU ${i} cannot offline."
+        else
+            LogMsg "Failed: CPU ${i} offline unexpectedly."
+            UpdateSummary "Failed: CPU ${i} offline unexpectedly."
+            UpdateTestState "TestFailed"
+            exit 2
+        fi
+    done
+    exit 0
+}
+
+if [ $1 = "checkCPUNum" ]; then
+    checkCPUNum
+elif [ $1 = "setCPUNum" ]; then
+    setCPUNum
+fi

--- a/WS2012R2/lisa/setupscripts/Core_Offline_CPU_SMP.ps1
+++ b/WS2012R2/lisa/setupscripts/Core_Offline_CPU_SMP.ps1
@@ -1,0 +1,146 @@
+#####################################################################
+#
+# Linux on Hyper-V and Azure Test Code, ver. 1.0.0
+# Copyright (c) Microsoft Corporation
+#
+# All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the ""License"");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+# ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+#
+#####################################################################
+
+#######################################################################
+#
+# Core_Offline_CPU_SMP.ps1
+#
+# Description:
+#    This script will verify CPU can be offline permanently by boot 
+#    with nr_cpus=xx
+#
+#######################################################################
+<#
+.Synopsis
+    Verify CPU can be offline permanently by boot with nr_cpus=xx
+.Description
+    This script will verify CPU can be offline permanently by boot with nr_cpus=xx
+.Parameter vmName
+    Name of the test VM.
+.Parameter hvServer
+    Name of the Hyper-V server hosting the VM.
+.Parameter testParams
+    The amount of CPU to be set
+.Example
+
+.Link
+    None.
+#>
+
+param([string] $vmName, [string] $hvServer, [string] $testParams)
+$remotescript = ""
+
+if ($vmName -eq $null){
+    "Error: VM name is null"
+    return $False
+}
+
+ if ($hvServer -eq $null){
+    "Error: hvServer is null"
+    return $False
+}
+
+ if ($testParams -eq $null){
+    "Error: testParams is null"
+    return $False
+}
+
+# Write out test Params
+$testParams
+# sshKey used to authenticate ssh connection and send commands
+$sshKey = $null
+ # IP Address of first VM
+$ipv4 = $null
+$retVal = $False
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+
+$params = $testParams.Split(";")
+foreach ($p in $params){
+    $fields = $p.Split("=")
+
+     switch ($fields[0].Trim())
+    {
+        "ipv4"    { $ipv4    = $fields[1].Trim() }
+        "sshKey"  { $sshKey  = $fields[1].Trim() }
+        "TC_COVERED" { $TC_COVERED = $fields[1].Trim() }
+        "rootDir"       { $rootDir = $fields[1].Trim() }
+    }
+}
+
+# Change the working directory to where we need to be
+if (-not (Test-Path $rootDir)) {
+    "Error: The directory `"${rootDir}`" does not exist!"
+    return $false
+}
+cd $rootDir
+
+if (Test-Path ".\setupScripts\TCUtils.ps1"){
+    . .\setupScripts\TCUtils.ps1
+}
+else{
+    Write-Output "Error: Could not find setupScripts\TCUtils.ps1"
+    return $False
+}
+if (Test-Path ".\setupScripts\NET_UTILS.ps1") {
+    . .\setupScripts\NET_UTILS.ps1
+}
+else {
+    Write-Output "ERROR: Could not find setupScripts\NET_Utils.ps1"
+    return $False
+}
+
+$summaryLog = "${vmName}_summary.log"
+del $summaryLog -ErrorAction SilentlyContinue
+Write-Output "This script covers test case: ${TC_COVERED}" | Tee-Object -Append -file $summaryLog
+
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
+
+# Execute the setCPUNum
+SendCommandToVM $ipv4 $sshKey "cd /root && dos2unix Core_Offline_CPU_SMP.sh && chmod u+x Core_Offline_CPU_SMP.sh"
+$retVal = SendCommandToVM $ipv4 $sshKey ". /root/Core_Offline_CPU_SMP.sh setCPUNum"
+if ($retVal -eq $false){
+    Write-Output "Error: Set kernel parameter not corret."
+    return $False
+}
+# Reboot th VM
+SendCommandToVM $ipv4 $sshKey "reboot"
+Write-Output "Rebooting the VM."
+
+# Waiting the VM to start up
+$sts = GetIPv4AndWaitForSSHStart $vmName $hvServer $sshKey 300
+if (-not $sts){
+    Throw "Error: VM not detected after restart."
+}
+
+# Excute the checkCPUNum
+$retVal = SendCommandToVM $ipv4 $sshKey ". /root/Core_Offline_CPU_SMP.sh checkCPUNum"
+if ($retVal -eq $false){
+    Write-Output "Error: Checking CPU number not corret."
+    return $False
+}
+
+return $True

--- a/WS2012R2/lisa/xml/CoreTests.xml
+++ b/WS2012R2/lisa/xml/CoreTests.xml
@@ -54,6 +54,7 @@
             <suiteTest>FloppyDisk</suiteTest>
             <suiteTest>StressReloadModules_SMP</suiteTest>
             <suiteTest>Core_max_cpus</suiteTest>
+            <suiteTest>Core_Offline_CPU_SMP</suiteTest>
             <suiteTest>VCPU_verify_online</suiteTest>
             <suiteTest>VerifyIntegratedShutdownService</suiteTest>
             <suiteTest>RebootDifferentMemSettings</suiteTest>
@@ -175,6 +176,22 @@
          </testParams>
          <timeout>1600</timeout>
          <noReboot>False</noReboot>
+        </test>
+        <test>
+            <testName>Core_Offline_CPU_SMP</testName>
+            <setupScript>
+                <file>setupscripts\ChangeCPU.ps1</file>
+            </setupScript>
+            <testScript>setupscripts\Core_Offline_CPU_SMP.ps1</testScript>
+            <files>remote-scripts/ica/utils.sh,remote-scripts/ica/Core_Offline_CPU_SMP.sh</files>
+            <testParams>
+                <param>TC_COVERED=CORE-39</param>
+                <param>VCPU=8</param>
+                <param>NR_CPU=4</param>
+            </testParams>
+            <timeout>1000</timeout>
+            <onError>Continue</onError>
+            <noReboot>False</noReboot>
         </test>
         <test>
             <testName>VerifyIntegratedShutdownService</testName>


### PR DESCRIPTION
This case is about verifying CPU can be offline permanently by boot with nr_cpus=xx. (Bug 1396336, Bug 1396335)

Test step:
1. Set the vcpu number.
2. Add nr_cpus=xx in kernel parameter and reboot it.
3. Verify the exact CPUs number and try to offline the CPUs.

Verify results:
1. Exact CPUs number and nr_cpus should be equal.
2. CPUs with VMBus channels attached should not go offline.

Thank you.